### PR TITLE
feat(load): Add objects to specify infiltration and ventilation

### DIFF
--- a/honeybee_energy/lib/constructions.py
+++ b/honeybee_energy/lib/constructions.py
@@ -164,9 +164,6 @@ WINDOW_CONSTRUCTIONS = tuple(_idf_window_constructions.keys())
 SHADE_CONSTRUCTIONS = tuple(_idf_shade_constructions.keys())
 
 
-# methods to look up constructions from the library
-
-
 def opaque_construction_by_name(construction_name):
     """Get an opaque construction from the library given the construction name.
 

--- a/honeybee_energy/lib/materials.py
+++ b/honeybee_energy/lib/materials.py
@@ -172,9 +172,6 @@ OPAQUE_MATERIALS = tuple(_idf_opaque_materials.keys())
 WINDOW_MATERIALS = tuple(_idf_window_materials.keys())
 
 
-# methods to look up materials from the library
-
-
 def opaque_material_by_name(material_name):
     """Get an opaque material from the library given the material name.
 

--- a/honeybee_energy/lib/schedules.py
+++ b/honeybee_energy/lib/schedules.py
@@ -20,9 +20,6 @@ except KeyError:
 SCHEDULES = tuple(_idf_schedules.keys())
 
 
-# methods to look up schedule types from the library
-
-
 def schedule_by_name(schedule_name):
     """Get a schedule from the library given its name.
 

--- a/honeybee_energy/lib/scheduletypelimits.py
+++ b/honeybee_energy/lib/scheduletypelimits.py
@@ -72,9 +72,6 @@ except KeyError:
 SCHEDULE_TYPE_LIMITS = tuple(_idf_schedule_type_limits.keys())
 
 
-# methods to look up schedule types from the library
-
-
 def schedule_type_limit_by_name(schedule_type_limit_name):
     """Get a schedule type from the library given its name.
 

--- a/honeybee_energy/load/_base.py
+++ b/honeybee_energy/load/_base.py
@@ -6,7 +6,7 @@ from ..schedule.ruleset import ScheduleRuleset
 from ..schedule.fixedinterval import ScheduleFixedInterval
 
 from honeybee._lockable import lockable
-from honeybee.typing import valid_ep_string
+from honeybee.typing import valid_ep_string, tuple_with_length
 
 
 @lockable
@@ -47,6 +47,21 @@ class _LoadBase(object):
             assert schedule.schedule_type_limit.unit == 'fraction', '{} schedule ' \
                 'should be fractional [Dimensionless]. Got a schedule of unit_type ' \
                 '[{}].'.format(obj_name, schedule.schedule_type_limit.unit_type)
+
+    @staticmethod
+    def _check_avg_weights(load_objects, weights, obj_name):
+        """Check input weights of an average calculation and generate them if None."""
+        assert isinstance(load_objects, (list, tuple)), 'Expected a list of {0} objects' \
+            ' for {0}.average. Got {1}.'.format(obj_name, type(load_objects))
+        if weights is None:
+            weights = [1 / len(load_objects)] * len(load_objects) if \
+                len(load_objects) > 0 else []
+        else:
+            weights = tuple_with_length(weights, len(load_objects), float,
+                                        'average {} weights'.format(obj_name))
+        assert sum(weights) == 1, 'Average {} weights must sum to 1. ' \
+            'Got {}.'.format(obj_name, sum(weights))
+        return weights
 
     @staticmethod
     def _average_schedule(name, scheds, weights, timestep):

--- a/honeybee_energy/load/infiltration.py
+++ b/honeybee_energy/load/infiltration.py
@@ -1,0 +1,335 @@
+# coding=utf-8
+"""Complete definition of infiltration in a simulation, including schedule and load."""
+from __future__ import division
+
+from ._base import _LoadBase
+from ..schedule.ruleset import ScheduleRuleset
+from ..schedule.fixedinterval import ScheduleFixedInterval
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from honeybee._lockable import lockable
+from honeybee.typing import float_positive
+
+
+@lockable
+class Infiltration(_LoadBase):
+    """A complete definition of infiltration, including schedules and load.
+
+    Properties:
+        * name
+        * flow_per_exterior_area
+        * schedule
+        * constant_coefficient
+        * temperature_coefficient
+        * velocity_coefficient
+    """
+    __slots__ = ('_flow_per_exterior_area', '_schedule', '_constant_coefficient',
+                 '_temperature_coefficient', '_velocity_coefficient')
+
+    def __init__(self, name, flow_per_exterior_area, schedule, constant_coefficient=1,
+                 temperature_coefficient=0, velocity_coefficient=0):
+        """Initialize Infiltration.
+
+        Args:
+            name: Text string for the infiltration name. Must be <= 100 characters.
+                Can include spaces but special characters will be stripped out.
+            flow_per_exterior_area: A numerical value for the intensity of infiltration
+                in m3/s per square meter of exterior surface area. Typical values for
+                this property are as follows:
+                    * 0.0001 (m3/s per m2 facade) - Tight building
+                    * 0.0003 (m3/s per m2 facade) - Average building
+                    * 0.0006 (m3/s per m2 facade) - Leaky building
+            schedule: A ScheduleRuleset or ScheduleFixedInterval for the infiltration
+                over the course of the year. The type of this schedule should be
+                Fractional and the fractional values will get multiplied by the
+                flow_per_exterior_area to yield a complete infiltration profile.
+            constant_coefficient: A number for the fraction of the infiltration that
+                remains constant in spite of exterior wind and the difference
+                between interior/exterior temperature. EnergyPlus uses 1 by default but
+                BLAST and DOE-2 (the EnergyPlus predecessors) used 0.606 and 0 for
+                this coefficient respectively. Default: 1.
+            temperature_coefficient: A number that will get multiplied by the difference
+                in interior/exterior temperature (in C) to yeild a coefficient that
+                gets mutiplied by the flow_per_exterior_area. EnergyPlus uses 0 by
+                default but BLAST and DOE-2 (the EnergyPlus predecessors) used 0.03636
+                and 0 for this coefficient respectively. Default: 0.
+            velocity_coefficient: A number that will get multiplied by the hourly
+                exterior wind velocity (in m/s) to yeild a coefficient that gets
+                mutiplied by the flow_per_exterior_area. EnergyPlus uses 0 by default
+                but BLAST and DOE-2 (the EnergyPlus predecessors) used 0.1177 and 0.224
+                for this coefficient respectively. Default: 0.
+        """
+        _LoadBase.__init__(self, name)
+        self.flow_per_exterior_area = flow_per_exterior_area
+        self.schedule = schedule
+        self.constant_coefficient = constant_coefficient
+        self.temperature_coefficient = temperature_coefficient
+        self.velocity_coefficient = velocity_coefficient
+
+    @property
+    def flow_per_exterior_area(self):
+        """Get or set the infiltration in m3/s per square meter of exterior surface area.
+
+        Typical values for this property are as follows:
+            * 0.0001 (m3/s per m2 facade) - Tight building
+            * 0.0003 (m3/s per m2 facade) - Average building
+            * 0.0006 (m3/s per m2 facade) - Leaky building
+        """
+        return self._flow_per_exterior_area
+
+    @flow_per_exterior_area.setter
+    def flow_per_exterior_area(self, value):
+        self._flow_per_exterior_area = float_positive(
+            value, 'infiltration flow per area')
+
+    @property
+    def schedule(self):
+        """Get or set a ScheduleRuleset or ScheduleFixedInterval for infiltration."""
+        return self._schedule
+
+    @schedule.setter
+    def schedule(self, value):
+        assert isinstance(value, (ScheduleRuleset, ScheduleFixedInterval)), \
+            'Expected ScheduleRuleset or ScheduleFixedInterval for Infiltration ' \
+            'schedule. Got {}.'.format(type(value))
+        self._check_fractional_schedule_type(value, 'Infiltration')
+        value.lock()   # lock editing in case schedule has multiple references
+        self._schedule = value
+
+    @property
+    def constant_coefficient(self):
+        """Get or set the fraction of infiltration remaining constant despite outdoors.
+        """
+        return self._constant_coefficient
+
+    @constant_coefficient.setter
+    def constant_coefficient(self, value):
+        self._constant_coefficient = float_positive(
+            value, 'infiltration constant coefficient')
+
+    @property
+    def temperature_coefficient(self):
+        """Get or set the coefficient for the interior/exterior temperature difference.
+        """
+        return self._temperature_coefficient
+
+    @temperature_coefficient.setter
+    def temperature_coefficient(self, value):
+        self._temperature_coefficient = float_positive(
+            value, 'infiltration temperature coefficient')
+
+    @property
+    def constant_coefficient(self):
+        """Get or set the infiltration fraction remaining constant despite the outdoors.
+        """
+        return self._constant_coefficient
+
+    @constant_coefficient.setter
+    def constant_coefficient(self, value):
+        self._constant_coefficient = float_positive(
+            value, 'infiltration constant coefficient')
+
+    @property
+    def temperature_coefficient(self):
+        """Get or set the coefficient for the interior/exterior temperature difference.
+        """
+        return self._temperature_coefficient
+
+    @temperature_coefficient.setter
+    def temperature_coefficient(self, value):
+        self._temperature_coefficient = float_positive(
+            value, 'infiltration temperature coefficient')
+
+    @property
+    def velocity_coefficient(self):
+        """Get or set the coefficient for the exterior wind speed."""
+        return self._velocity_coefficient
+
+    @velocity_coefficient.setter
+    def velocity_coefficient(self, value):
+        self._velocity_coefficient = float_positive(
+            value, 'infiltration velocity coefficient')
+
+    @classmethod
+    def from_idf(cls, idf_string, schedule_dict):
+        """Create an Infiltration object from an EnergyPlus IDF text string.
+
+        Note that the idf_string must use the 'flow per exterior surface area'
+        method in order to be successfully imported.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                ZoneInfiltration:DesignFlowRate definition.
+            schedule_dict: A dictionary with schedule names as keys and honeybee
+                schedule objects as values (either ScheduleRuleset or
+                ScheduleFixedInterval). These will be used to assign the schedules to
+                the Infiltration object.
+
+        Returns:
+            infiltration: An Infiltration object loaded from the idf_string.
+            zone_name: The name of the zone to which the Infiltration object should
+                be assigned.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'ZoneInfiltration:DesignFlowRate,')
+        assert ep_strs[3].lower() == 'flow/exteriorarea', \
+            'ZoneInfiltration:DesignFlowRate must use Flow/ExteriorArea method ' \
+            'to be loaded from IDF to honeybee.'
+
+        # extract the properties from the string
+        const = 1
+        temp = 0
+        vel = 0
+        try:
+            const = ep_strs[8] if ep_strs[8] != '' else 0
+            temp = ep_strs[9] if ep_strs[9] != '' else 0
+            vel = ep_strs[10] if ep_strs[10] != '' else 0
+        except IndexError:
+            pass  # shorter infiltration definition lacking coefficients
+
+        # extract the schedules from the string
+        try:
+            sched = schedule_dict[ep_strs[2]]
+        except KeyError as e:
+            raise ValueError('Failed to find {} in the schedule_dict.'.format(e))
+
+        # return the object and the zone name for the object
+        infiltration = cls(ep_strs[0], ep_strs[6], sched, const, temp, vel)
+        zone_name = ep_strs[1]
+        return infiltration, zone_name
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a Infiltration object from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this classmethod
+        to work.
+
+        Args:
+            data: A Infiltration dictionary in following the format below.
+
+        .. code-block:: json
+
+            {
+            "type": 'Infiltration',
+            "name": 'Residentail Infiltration',
+            "flow_per_exterior_area": 0.0003, // flow per square meter of exterior area
+            "schedule": {}, // ScheduleRuleset/ScheduleFixedInterval dictionary
+            "constant_coefficient": 1, // optional constant coefficient
+            "temperature_coefficient": 0, // optional temperature coefficient
+            "velocity_coefficient": 0 // optional velocity coefficient
+            }
+        """
+        assert data['type'] == 'Infiltration', \
+            'Expected Infiltration dictionary. Got {}.'.format(data['type'])
+        sched = cls._get_schedule_from_dict(data['schedule'])
+        const = data['constant_coefficient'] if 'constant_coefficient' in data else 1
+        tem = data['temperature_coefficient'] if 'temperature_coefficient' in data else 0
+        vel = data['velocity_coefficient'] if 'velocity_coefficient' in data else 0
+        return cls(data['name'], data['flow_per_exterior_area'], sched, const, tem, vel)
+
+    def to_idf(self, zone_name):
+        """IDF string representation of Infiltration object.
+
+        Note that this method only outputs a single string for the ZoneInfiltration:
+        DesignFlowRate object and, to write everything needed to describe the
+        object into an IDF, this object's schedule must also be written.
+
+        Args:
+            zone_name: Text for the zone name that the ZoneInfiltration:DesignFlowRate
+                object is assigned to.
+        """
+        values = (self.name, zone_name, self.schedule.name, 'Flow/ExteriorArea',
+                  '', '', self.flow_per_exterior_area, '', self.constant_coefficient,
+                  self.temperature_coefficient, self.velocity_coefficient, '')
+        comments = ('name', 'zone name', 'schedule name', 'flow rate method',
+                    'flow rate {m3/s}', 'flow per floor area {m3/s-m2}',
+                    'flow per exterior area {m3/s-m2}', 'air changes per hour {1/hr}',
+                    'constant term coefficient', 'temperature term coefficient',
+                    'velocity term coefficient', 'velocity squared term coefficient')
+        return generate_idf_string('ZoneInfiltration:DesignFlowRate', values, comments)
+
+    def to_dict(self, abridged=False):
+        """Infiltration dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True),
+                which only specifies the names of schedules. Default: False.
+        """
+        base = {'type': 'Infiltration'} if not abridged \
+            else {'type': 'InfiltrationAbridged'}
+        base['name'] = self.name
+        base['flow_per_exterior_area'] = self.flow_per_exterior_area
+        base['schedule'] = self.schedule.to_dict() if not \
+            abridged else self.schedule.name
+        if self.constant_coefficient != 1:
+            base['constant_coefficient'] = self.constant_coefficient
+        if self.temperature_coefficient != 0:
+            base['temperature_coefficient'] = self.temperature_coefficient
+        if self.velocity_coefficient != 0:
+            base['velocity_coefficient'] = self.velocity_coefficient
+        return base
+
+    @staticmethod
+    def average(name, infiltrations, weights=None, timestep_resolution=1):
+        """Get an Infiltration object that's an average between other Infiltrations.
+
+        Args:
+            name: A name for the new averaged Infiltration object.
+            infiltrations: A list of Infiltration objects that will be averaged
+                together to make a new Infiltration.
+            weights: An optional list of fractioanl numbers with the same length
+                as the input infiltrations that sum to 1. These will be used to weight
+                each of the Infiltration objects in the resulting average. If None, the
+                individual objects will be weighted equally. Default: None.
+            timestep_resolution: An optional integer for the timestep resolution
+                at which the schedules will be averaged. Any schedule details
+                smaller than this timestep will be lost in the averaging process.
+                Default: 1.
+        """
+        weights = Infiltration._check_avg_weights(infiltrations, weights, 'Infiltration')
+
+        # calculate the average values
+        fd = sum([inf.flow_per_exterior_area * w
+                  for inf, w in zip(infiltrations, weights)])
+        const = sum([inf.constant_coefficient * w
+                     for inf, w in zip(infiltrations, weights)])
+        temp = sum([inf.temperature_coefficient * w
+                    for inf, w in zip(infiltrations, weights)])
+        vel = sum([inf.velocity_coefficient * w
+                   for inf, w in zip(infiltrations, weights)])
+
+        # calculate the average schedules
+        sched = Infiltration._average_schedule(
+            '{} Schedule'.format(name), [inf.schedule for inf in infiltrations],
+            weights, timestep_resolution)
+
+        # return the averaged infiltration object
+        return Infiltration(name, fd, sched, const, temp, vel)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.name, self.flow_per_exterior_area, hash(self.schedule),
+                self.constant_coefficient, self.temperature_coefficient,
+                self.velocity_coefficient)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Infiltration) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __copy__(self):
+        return Infiltration(
+            self.name, self.flow_per_exterior_area, self.schedule,
+            self.constant_coefficient, self.temperature_coefficient,
+            self.velocity_coefficient)
+
+    def __repr__(self):
+        return 'Infiltration:\n name: {}\n flow per exterior area: {}\n schedule: ' \
+            '{}'.format(self.name, self.flow_per_exterior_area, self.schedule.name)

--- a/honeybee_energy/load/lighting.py
+++ b/honeybee_energy/load/lighting.py
@@ -9,7 +9,7 @@ from ..reader import parse_idf_string
 from ..writer import generate_idf_string
 
 from honeybee._lockable import lockable
-from honeybee.typing import float_in_range, float_positive, tuple_with_length
+from honeybee.typing import float_in_range, float_positive
 
 
 @lockable
@@ -192,7 +192,7 @@ class Lighting(_LoadBase):
             }
         """
         assert data['type'] == 'Lighting', \
-            'Expected Lighting. Got {}.'.format(data['type'])
+            'Expected Lighting dictionary. Got {}.'.format(data['type'])
         sched = cls._get_schedule_from_dict(data['schedule'])
         ret_fract = data['return_air_fraction'] if 'return_air_fraction' in data else 0
         rad_fract = data['radiant_fraction'] if 'radiant_fraction' in data else 0.32
@@ -256,17 +256,7 @@ class Lighting(_LoadBase):
                 smaller than this timestep will be lost in the averaging process.
                 Default: 1.
         """
-        # check the inputs
-        assert isinstance(lightings, (list, tuple)), 'Expected a list of Lighting ' \
-            'objects for Lighting.average. Got {}.'.format(type(lightings))
-        if weights is None:
-            weight = 1 / len(lightings)
-            weights = [weight for i in lightings]
-        else:
-            weights = tuple_with_length(weights, len(lightings), float,
-                                        'average lighting weights')
-            assert sum(weights) == 1, 'Average lighting weights must sum to 1. ' \
-                'Got {}.'.format(sum(weights))
+        weights = Lighting._check_avg_weights(lightings, weights, 'Lighting')
 
         # calculate the average values
         lpd = sum([li.watts_per_area * w for li, w in zip(lightings, weights)])

--- a/honeybee_energy/load/people.py
+++ b/honeybee_energy/load/people.py
@@ -11,7 +11,7 @@ from ..writer import generate_idf_string
 import honeybee_energy.lib.schedules as _sched_lib
 
 from honeybee._lockable import lockable
-from honeybee.typing import float_in_range, float_positive, tuple_with_length
+from honeybee.typing import float_in_range, float_positive
 
 
 @lockable
@@ -210,7 +210,8 @@ class People(_LoadBase):
             "latent_fraction": 0.2 // fraction of total heat that is latent
             }
         """
-        assert data['type'] == 'People', 'Expected People. Got {}.'.format(data['type'])
+        assert data['type'] == 'People', \
+            'Expected People dictionary. Got {}.'.format(data['type'])
         occ_sched = cls._get_schedule_from_dict(data['occupancy_schedule'])
         act_sched = cls._get_schedule_from_dict(data['activity_schedule']) if \
             'activity_schedule' in data and data['activity_schedule'] is not None else None
@@ -281,17 +282,7 @@ class People(_LoadBase):
                 smaller than this timestep will be lost in the averaging process.
                 Default: 1.
         """
-        # check the inputs
-        assert isinstance(peoples, (list, tuple)), 'Expected a list of People ' \
-            'objects for People.average. Got {}.'.format(type(peoples))
-        if weights is None:
-            weight = 1 / len(peoples)
-            weights = [weight for i in peoples]
-        else:
-            weights = tuple_with_length(weights, len(peoples), float,
-                                        'average people weights')
-            assert sum(weights) == 1, 'Average people weights must sum to 1. ' \
-                'Got {}.'.format(sum(weights))
+        weights = People._check_avg_weights(peoples, weights, 'People')
 
         # calculate the average values
         ppl_area = sum([ppl.people_per_area * w for ppl, w in zip(peoples, weights)])

--- a/honeybee_energy/load/ventilation.py
+++ b/honeybee_energy/load/ventilation.py
@@ -1,0 +1,345 @@
+# coding=utf-8
+"""Complete definition of ventilation in a simulation, including schedule and load."""
+from __future__ import division
+
+from ._base import _LoadBase
+from ..schedule.ruleset import ScheduleRuleset
+from ..schedule.fixedinterval import ScheduleFixedInterval
+from ..schedule.typelimit import ScheduleTypeLimit
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from honeybee._lockable import lockable
+from honeybee.typing import float_positive
+
+
+@lockable
+class Ventilation(_LoadBase):
+    """A complete definition of ventilation, including schedules and load.
+
+    Note the the 4 ventilation types (flow_per_person, flow_per_area, flow_per_zone,
+    and air_changes_per_hour) are ultimately added together to yeild the ventilation
+    design flow rate used in the simulation.
+
+    Properties:
+        * name
+        * flow_per_person
+        * flow_per_area
+        * flow_per_zone
+        * air_changes_per_hour
+        * schedule
+    """
+    __slots__ = ('_flow_per_person', '_flow_per_area', '_flow_per_zone',
+                 '_air_changes_per_hour', '_schedule')
+    CALCULATION_METHODS = ('Sum', 'Maximum')
+
+    def __init__(self, name, flow_per_person=0, flow_per_area=0, flow_per_zone=0,
+                 air_changes_per_hour=0, schedule=None):
+        """Initialize Ventilation.
+
+        Args:
+            name: Text string for the ventilation name. Must be <= 100 characters.
+                Can include spaces but special characters will be stripped out.
+            flow_per_person: A numerical value for the intensity of ventilation
+                in m3/s per person. Note that setting this value here does not mean
+                that ventilation is varied based on real-time occupancy but rather
+                that the design level of ventilation is determined using this value
+                and the People object of the zone. To vary ventilation in real time,
+                the ventilation schedule should be used. Most ventilation standards
+                support that a value of 0.01 m3/s (10 L/s or ~20 cfm) per person is
+                sufficient to remove odors. Accordingly, setting this value to 0.01
+                and using 0 for the following ventilation terms will often be suitable
+                for many applications. Default: 0.
+            flow_per_area: A numerical value for the intensity of ventilation in m3/s
+                per square meter of floor area. Default: 0.
+            flow_per_zone: A numerical value for the design level of ventilation
+                in m3/s for the entire zone. Default: 0.
+            air_changes_per_hour: A numberical value for the design level of ventilation
+                in air changes per hour (ACH) for the entire zone. This is particularly
+                helpful for hospitals, where ventilation standards are often given
+                in ACH. Default: 0.
+            schedule: An optional ScheduleRuleset or ScheduleFixedInterval for the
+                ventilation over the course of the year. The type of this schedule
+                should be Fractional and the fractional values will get multiplied by
+                the total design flow rate (determined from the fields above and the
+                calculation_method) to yield a complete ventilation profile. Setting
+                this schedule to be the occupancy schedule of the zone will mimic demand
+                controlled ventilation. If None, the design level of ventilation will
+                be used throughout all timesteps of the simulation. Default: None.
+        """
+        _LoadBase.__init__(self, name)
+        self.flow_per_person = flow_per_person
+        self.flow_per_area = flow_per_area
+        self.flow_per_zone = flow_per_zone
+        self.air_changes_per_hour = air_changes_per_hour
+        self.schedule = schedule
+
+    @property
+    def flow_per_person(self):
+        """Get or set the intensity of ventilation in m3/s per person.
+
+        Note that setting this value here does not mean that ventilation is varied
+        based on real-time occupancy but rather that the design level of ventilation
+        is determined using this value and the People object of the zone. To vary
+        ventilation in real time, the ventilation schedule should be used or demand
+        controlled ventilation options should be set on the HVAC system.
+
+        Most ventilation standards support that a value of 0.01 m3/s (10 L/s or ~20 cfm)
+        per person is sufficient to remove odors. Accordingly, setting this value to
+        0.01 and using 0 for the following ventilation terms will often be suitable
+        for many applications.
+        """
+        return self._flow_per_person
+
+    @flow_per_person.setter
+    def flow_per_person(self, value):
+        self._flow_per_person = float_positive(value, 'ventilation flow per person')
+
+    @property
+    def flow_per_area(self):
+        """Get or set the ventilation in m3/s per square meter of zone floor area."""
+        return self._flow_per_area
+
+    @flow_per_area.setter
+    def flow_per_area(self, value):
+        self._flow_per_area = float_positive(value, 'ventilation flow per area')
+
+    @property
+    def flow_per_zone(self):
+        """Get or set the ventilation in m3/s per zone."""
+        return self._flow_per_zone
+
+    @flow_per_zone.setter
+    def flow_per_zone(self, value):
+        self._flow_per_zone = float_positive(value, 'ventilation flow per zone')
+
+    @property
+    def air_changes_per_hour(self):
+        """Get or set the ventilation in air changes per hour (ACH)."""
+        return self._air_changes_per_hour
+
+    @air_changes_per_hour.setter
+    def air_changes_per_hour(self, value):
+        self._air_changes_per_hour = float_positive(
+            value, 'ventilation air changes per hour')
+
+    @property
+    def schedule(self):
+        """Get or set a ScheduleRuleset or ScheduleFixedInterval for ventilation."""
+        return self._schedule
+
+    @schedule.setter
+    def schedule(self, value):
+        if value is not None:
+            assert isinstance(value, (ScheduleRuleset, ScheduleFixedInterval)), \
+                'Expected ScheduleRuleset or ScheduleFixedInterval for Ventilation ' \
+                'schedule. Got {}.'.format(type(value))
+            self._check_fractional_schedule_type(value, 'Ventilation')
+            value.lock()   # lock editing in case schedule has multiple references
+        self._schedule = value
+
+    @classmethod
+    def from_idf(cls, idf_string, schedule_dict):
+        """Create an Ventilation object from an EnergyPlus IDF text string.
+
+        Note that the idf_string must use the 'flow per exterior surface area'
+        method in order to be successfully imported.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                DesignSpecification:OutdoorAir definition.
+            schedule_dict: A dictionary with schedule names as keys and honeybee
+                schedule objects as values (either ScheduleRuleset or
+                ScheduleFixedInterval). These will be used to assign the schedules to
+                the Ventilation object.
+
+        Returns:
+            ventilation: An Ventilation object loaded from the idf_string.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'DesignSpecification:OutdoorAir,')
+
+        # extract the numerical properties from the string
+        person = 0.00944
+        area = 0
+        zone = 0
+        ach = 0
+        try:
+            person = ep_strs[2] if ep_strs[2] != '' else 0.00944
+            area = ep_strs[3] if ep_strs[3] != '' else 0
+            zone = ep_strs[4] if ep_strs[4] != '' else 0
+            ach = ep_strs[5] if ep_strs[5] != '' else 0
+        except IndexError:
+            pass  # shorter ventilation definition lacking values
+
+        # change the values to 0 if 'Sum' method is not used
+        try:
+            if ep_strs[1].lower() == 'sum':
+                pass
+            elif ep_strs[1].lower() == 'flow/person':
+                area, zone, ach = 0, 0, 0
+            elif ep_strs[1].lower() == 'flow/area':
+                person, zone, ach = 0, 0, 0
+            elif ep_strs[1].lower() == 'flow/zone':
+                person, area, ach = 0, 0, 0
+            elif ep_strs[1].lower() == 'airchanges/hour':
+                person, area, zone = 0, 0, 0
+            else:
+                raise ValueError('DesignSpecification:OutdoorAir {} method '
+                                 'is not supported by honeybee.'.format(ep_strs[1]))
+        except IndexError:  # EnergyPlus defaults to flow/person
+            area, zone, ach = 0, 0, 0
+
+        # extract the schedules from the string
+        try:
+            try:
+                sched = schedule_dict[ep_strs[6]] if ep_strs[6] != '' else None
+            except KeyError as e:
+                raise ValueError('Failed to find {} in the schedule_dict.'.format(e))
+        except IndexError:  # No schedule given
+            sched = None
+
+        # return the object and the zone name for the object
+        ventilation = cls(ep_strs[0], person, area, zone, ach, sched)
+        return ventilation
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a Ventilation object from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this classmethod
+        to work.
+
+        Args:
+            data: A Ventilation dictionary in following the format below.
+
+        .. code-block:: json
+
+            {
+            "type": 'Ventilation',
+            "name": 'Office Ventilation',
+            "flow_per_person": 0.01, // flow per person
+            "flow_per_area": 0.0005, // flow per square meter of floor area
+            "flow_per_zone": 0, // flow per zone
+            "air_changes_per_hour": 0, // air changes per hour
+            "schedule": {} // ScheduleRuleset/ScheduleFixedInterval dictionary
+            }
+        """
+        assert data['type'] == 'Ventilation', \
+            'Expected Ventilation dictionary. Got {}.'.format(data['type'])
+        person = data['flow_per_person'] if 'flow_per_person' in data else 0
+        area = data['flow_per_area'] if 'flow_per_area' in data else 0
+        zone = data['flow_per_zone'] if 'flow_per_zone' in data else 0
+        ach = data['air_changes_per_hour'] if 'air_changes_per_hour' in data else 0
+        sched = cls._get_schedule_from_dict(data['schedule']) if 'schedule' in data and \
+            data['schedule'] is not None else None
+        return cls(data['name'], person, area, zone, ach, sched)
+
+    def to_idf(self):
+        """IDF string representation of Ventilation object.
+
+        Note that this method only outputs a single string for the DesignSpecification:
+        OutdoorAir object and, to write everything needed to describe the object
+        into an IDF, this object's schedule must also be written.
+        """
+        sched = self.schedule.name if self.schedule is not None else ''
+        values = (self.name, 'Sum', self.flow_per_person, self.flow_per_area,
+                  self.flow_per_zone, self.air_changes_per_hour, sched)
+        comments = ('name', 'flow rate method', 'flow per person {m3/s-person}',
+                    'flow per floor area {m3/s-m2}', 'flow per zone {m3/s}',
+                    'air changes per hour {1/hr}', 'outdoor air schedule name')
+        return generate_idf_string('DesignSpecification:OutdoorAir', values, comments)
+
+    def to_dict(self, abridged=False):
+        """Ventilation dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True),
+                which only specifies the names of schedules. Default: False.
+        """
+        base = {'type': 'Ventilation'} if not abridged \
+            else {'type': 'VentilationAbridged'}
+        base['name'] = self.name
+        if self.flow_per_person != 0:
+            base['flow_per_person'] = self.flow_per_person
+        if self.flow_per_area != 0:
+            base['flow_per_area'] = self.flow_per_area
+        if self.flow_per_zone != 0:
+            base['flow_per_zone'] = self.flow_per_zone
+        if self.air_changes_per_hour != 0:
+            base['air_changes_per_hour'] = self.air_changes_per_hour
+        if self.schedule is not None:
+            base['schedule'] = self.schedule.to_dict() if not \
+                abridged else self.schedule.name
+        return base
+
+    @staticmethod
+    def average(name, ventilations, weights=None, timestep_resolution=1):
+        """Get an Ventilation object that's an average between other Ventilations.
+
+        Args:
+            name: A name for the new averaged Ventilation object.
+            ventilations: A list of Ventilation objects that will be averaged
+                together to make a new Ventilation.
+            weights: An optional list of fractioanl numbers with the same length
+                as the input ventilations that sum to 1. These will be used to weight
+                each of the Ventilation objects in the resulting average. If None, the
+                individual objects will be weighted equally. Default: None.
+            timestep_resolution: An optional integer for the timestep resolution
+                at which the schedules will be averaged. Any schedule details
+                smaller than this timestep will be lost in the averaging process.
+                Default: 1.
+        """
+        weights = Ventilation._check_avg_weights(ventilations, weights, 'Ventilation')
+
+        # calculate the average values
+        person = sum([vent.flow_per_person * w
+                      for vent, w in zip(ventilations, weights)])
+        area = sum([vent.flow_per_area * w
+                    for vent, w in zip(ventilations, weights)])
+        zone = sum([vent.flow_per_zone * w
+                    for vent, w in zip(ventilations, weights)])
+        ach = sum([vent.air_changes_per_hour * w
+                   for vent, w in zip(ventilations, weights)])
+
+        # calculate the average schedules
+        scheds = [vent.schedule for vent in ventilations]
+        if all(val is None for val in scheds):
+            sched = None
+        else:
+            fract = ScheduleTypeLimit('Fractional', 0, 1)
+            full_vent = ScheduleRuleset.from_constant_value('Full Ventilation', 1, fract)
+            for i, sch in enumerate(scheds):
+                if sch is None:
+                    scheds[i] = full_vent
+            sched = Ventilation._average_schedule(
+                '{} Schedule'.format(name), scheds, weights, timestep_resolution)
+
+        # return the averaged lighting object
+        return Ventilation(name, person, area, zone, ach, sched)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.name, self.flow_per_person, self.flow_per_area, self.flow_per_zone,
+                self.air_changes_per_hour, hash(self.schedule))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, Ventilation) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __copy__(self):
+        return Ventilation(
+            self.name, self.flow_per_person, self.flow_per_area, self.flow_per_zone,
+            self.air_changes_per_hour, self.schedule)
+
+    def __repr__(self):
+        return 'Ventilation:\n name: {}\n flow per person: {}\n flow per area: ' \
+            '{}\n flow per zone: {}\n ACH: {}'.format(
+                self.name, self.flow_per_person, self.flow_per_area, self.flow_per_zone,
+                self.air_changes_per_hour)

--- a/honeybee_energy/programtype.py
+++ b/honeybee_energy/programtype.py
@@ -8,25 +8,42 @@ class ProgramType(object):
     """Program Type object possessing all schedules and loads defining a program.
 
     Properties:
-        name
-        people
-        lighting
-        electric_equipment
-        gas_equipment
-        infiltration
-        ventilation
-        cooling_setpoint_schedule
-        heating_setpoint_schedule
+        * name
+        * people
+        * lighting
+        * electric_equipment
+        * gas_equipment
+        * infiltration
+        * ventilation
+        * setpoint
     """
 
     def __init__(self, name, people=None, lighting=None, electric_equipment=None,
-                 gas_equipment=None, infiltration=None, ventilation=None,
-                 cooling_setpoint_schedule=None, heating_setpoint_schedule=None):
-        """Initialize energy program type.
+                 gas_equipment=None, infiltration=None, ventilation=None, setpoint=None):
+        """Initialize ProgramType.
 
         Args:
-            name: Text string for construction program type. Must be <= 100 characters.
+            name: Text string for ProgramType. Must be <= 100 characters.
                 Can include spaces but special characters will be stripped out.
+            people: A People object to describe the occupancy of the program. If None,
+                no occupancy will be assumed for the program. Default: None.
+            lighting: A Lighting object to describe the lighting usage of the program.
+                If None, no lighting will be assumed for the program. Default: None.
+            electric_equipment: An ElectricEquipment object to describe the usage
+                of electric equipment within the program. If None, no electric equipment
+                will be assumed for the program. Default: None.
+            gas_equipment: A GasEquipment object to describe the usage of gas equipment
+                within the program. If None, no gas equipment will be assumed for
+                the program. Default: None.
+            infiltration: An Infiltration object to describe the outdoor air leakage of
+                the program. If None, no infiltration will be assumed for the program.
+                Default: None.
+            ventilation: A Ventilation object to describe the minimum outdoor air
+                requirement of the program. If None, no ventilation requirement will
+                be assumed for the program. Default: None
+            setpoint: A Setpoint object to describe the temperature and humidity
+                setpoints of the program.  If None, the ProgramType cannot be assigned
+                to a Room that is conditioned. Default: None.
         """
         self.name = name
         self.people = people
@@ -35,8 +52,7 @@ class ProgramType(object):
         self.gas_equipment = gas_equipment
         self.infiltration = infiltration
         self.ventilation = ventilation
-        self.heating_setpoint_schedule = heating_setpoint_schedule
-        self.heating_setpoint_schedule = heating_setpoint_schedule
+        self.setpoint = setpoint
 
     @property
     def name(self):

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -10,47 +10,53 @@ class RoomEnergyProperties(object):
     """Energy Properties for Honeybee Room.
 
     Properties:
-        program_type
-        construction_set
-        people
-        lighting
-        electric_equipment
-        gas_equipment
-        infiltration
-        ventilation
+        * program_type
+        * construction_set
+        * hvac
+        * people
+        * lighting
+        * electric_equipment
+        * gas_equipment
+        * infiltration
+        * ventilation
+        * setpoint
+        * is_conditioned
     """
 
-    __slots__ = ('_host', '_program_type', '_construction_set',
-                 '_people', '_lighting', '_electric_equipment',
-                 '_gas_equipment', '_infiltration', '_ventilation')
+    __slots__ = ('_host', '_program_type', '_construction_set', '_hvac',
+                 '_people', '_lighting', '_electric_equipment', '_gas_equipment',
+                 '_infiltration', '_ventilation', '_setpoint')
 
-    def __init__(self, host, program_type=None, construction_set=None,
-                 people=None, lighting=None, electric_equipment=None,
-                 gas_equipment=None, infiltration=None, ventilation=None):
+    def __init__(self, host, program_type=None, construction_set=None, hvac=None):
         """Initialize Room energy properties.
 
         Args:
             host: A honeybee_core Room object that hosts these properties.
             program_type: A honeybee ProgramType object to specify all default
-                schedules and loads for the Room.
+                schedules and loads for the Room. If None, the Room will have a Plenum
+                program (with no loads or setpoints). Default: None.
             construction_set: A honeybee ConstructionSet object to specify all
-                default constructions for the Faces of the Room.
-            people
-            lighting
-            electric_equipment
-            gas_equipment
-            infiltration
-            ventilation
+                default constructions for the Faces of the Room. If None, the Room
+                will use the honeybee default construction set, which is not
+                representative of a particular building code or climate zone.
+                Default: None.
+            hvac: A honeybee HVAC object (such as an IdealAirSystem) that specifies
+                how the Room is conditioned. If None, it will be assumed that the
+                space is not conditioned. Default: None.
         """
         self._host = host
         self.program_type = program_type
         self.construction_set = construction_set
-        self._people = people
-        self._lighting = lighting
-        self._electric_equipment = electric_equipment
-        self._gas_equipment = gas_equipment
-        self._infiltration = infiltration
-        self._ventilation = ventilation
+        self._hvac = hvac
+
+        # set the Room's overriding properties to None by default
+        self._people = None
+        self._lighting = None
+        self._electric_equipment = None
+        self._gas_equipment = None
+        self._infiltration = None
+        self._ventilation = None
+        self._setpoint = None
 
     @property
     def host(self):
@@ -130,7 +136,7 @@ class RoomEnergyProperties(object):
         # TODO: Add re-assigning of loads and program type once they are implemented
 
     def to_dict(self, abridged=False):
-        """Return energy properties as a dictionary.
+        """Return Room energy properties as a dictionary.
 
         Args:
             abridged: Boolean for whether the full dictionary of the Room should
@@ -140,17 +146,23 @@ class RoomEnergyProperties(object):
         base = {'energy': {}}
         base['energy']['type'] = 'RoomEnergyProperties' if not \
             abridged else 'RoomEnergyPropertiesAbridged'
+
+        # write the ProgramType into the dictionary
         if self._program_type is not None:
             base['energy']['program_type'] = \
                 self._program_type.name if abridged else self._program_type.to_dict()
         else:
             base['energy']['program_type'] = None
+
+        # write the ConstructionSet into the dictionary
         if self._construction_set is not None:
             base['energy']['construction_set'] = \
                 self._construction_set.name if abridged else \
                 self._construction_set.to_dict()
         else:
             base['energy']['construction_set'] = None
+
+        # write any room-specific overriding properties into the dictionary
         base['energy']['people'] = self._people.to_dict(abridged) if \
             self._people is not None else None
         base['energy']['lighting'] = self._lighting.to_dict(abridged) if \
@@ -164,6 +176,7 @@ class RoomEnergyProperties(object):
             self._infiltration is not None else None
         base['energy']['ventilation'] = self._ventilation.to_dict(abridged) if \
             self._ventilation is not None else None
+
         return base
 
     def duplicate(self, new_host=None):
@@ -173,10 +186,16 @@ class RoomEnergyProperties(object):
             If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
-        return RoomEnergyProperties(
-            _host, self._program_type, self._construction_set,
-            self._people, self._lighting, self._electric_equipment,
-            self._gas_equipment, self._infiltration, self._ventilation)
+        new_room = RoomEnergyProperties(_host, self._program_type,
+                                        self._construction_set, None)
+        new_room._people = self._people
+        new_room._lighting = self._lighting
+        new_room._electric_equipment = self._electric_equipment
+        new_room._gas_equipment = self._gas_equipment
+        new_room._infiltration = self._infiltration
+        new_room._ventilation = self._ventilation
+        new_room._setpoint = self._setpoint
+        return new_room
 
     def ToString(self):
         return self.__repr__()

--- a/honeybee_energy/properties/shade.py
+++ b/honeybee_energy/properties/shade.py
@@ -73,6 +73,10 @@ class ShadeEnergyProperties(object):
             assert isinstance(value, (ScheduleRuleset, ScheduleFixedInterval)), \
                 'Expected schedule for shade transmittance schedule. ' \
                 'Got {}.'.format(type(value))
+            if value.schedule_type_limit is not None:
+                assert value.schedule_type_limit.unit == 'fraction', 'Transmittance ' \
+                    'schedule should be fractional [Dimensionless]. Got a schedule ' \
+                    'of unit_type [{}].'.format(value.schedule_type_limit.unit_type)
             value.lock()  # lock editing in case schedule has multiple references
         self._transmittance_schedule = value
 

--- a/tests/load_infiltration_test.py
+++ b/tests/load_infiltration_test.py
@@ -1,0 +1,160 @@
+# coding=utf-8
+from honeybee_energy.load.infiltration import Infiltration
+from honeybee_energy.schedule.day import ScheduleDay
+from honeybee_energy.schedule.rule import ScheduleRule
+from honeybee_energy.schedule.ruleset import ScheduleRuleset
+
+import honeybee_energy.lib.scheduletypelimits as schedule_types
+
+from ladybug.dt import Time, Date
+
+import pytest
+
+
+def test_infiltration_init():
+    """Test the initialization of Infiltration and basic properties."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+    str(infiltration)  # test the string representation
+
+    assert infiltration.name == 'Lobby Infiltration'
+    assert infiltration.flow_per_exterior_area == 0.0003
+    assert infiltration.schedule.name == 'Lobby Infiltration Schedule'
+    assert infiltration.schedule.schedule_type_limit == schedule_types.fractional
+    assert infiltration.schedule == schedule
+    assert infiltration.constant_coefficient == 1
+    assert infiltration.temperature_coefficient == 0
+    assert infiltration.velocity_coefficient == 0
+
+
+def test_infiltration_setability():
+    """Test the setting of properties of Infiltration."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    constant = ScheduleRuleset.from_constant_value(
+        'Constant Infiltration', 1, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+
+    infiltration.name = 'Lobby Zone Infiltration'
+    assert infiltration.name == 'Lobby Zone Infiltration'
+    infiltration.flow_per_exterior_area = 0.0006
+    assert infiltration.flow_per_exterior_area == 0.0006
+    infiltration.schedule = constant
+    assert infiltration.schedule == constant
+    assert infiltration.schedule.values() == [1] * 8760
+    infiltration.constant_coefficient = 0.606
+    assert infiltration.constant_coefficient == 0.606
+    infiltration.temperature_coefficient = 0.03636
+    assert infiltration.temperature_coefficient == 0.03636
+    infiltration.velocity_coefficient = 0.1177
+    assert infiltration.velocity_coefficient == 0.1177
+
+
+def test_infiltration_equality():
+    """Test the equality of Infiltration objects."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    constant = ScheduleRuleset.from_constant_value(
+        'Constant Infiltration', 1, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+    infiltration_dup = infiltration.duplicate()
+    infiltration_alt = Infiltration(
+        'Lobby Infiltration', 0.0003, constant)
+
+    assert infiltration is infiltration
+    assert infiltration is not infiltration_dup
+    assert infiltration == infiltration_dup
+    infiltration_dup.flow_per_exterior_area = 0.0006
+    assert infiltration != infiltration_dup
+    assert infiltration != infiltration_alt
+
+
+def test_infiltration_lockability():
+    """Test the lockability of Infiltration objects."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+
+    infiltration.flow_per_exterior_area = 0.0006
+    infiltration.lock()
+    with pytest.raises(AttributeError):
+        infiltration.flow_per_exterior_area = 0.0008
+    with pytest.raises(AttributeError):
+        infiltration.schedule.default_day_schedule.remove_value_by_time(Time(17, 0))
+    infiltration.unlock()
+    infiltration.flow_per_exterior_area = 0.0008
+    with pytest.raises(AttributeError):
+        infiltration.schedule.default_day_schedule.remove_value_by_time(Time(17, 0))
+
+
+def test_infiltration_init_from_idf():
+    """Test the initialization of Infiltration from_idf."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+    sched_dict = {schedule.name: schedule}
+
+    zone_name = 'Test Zone'
+    idf_str = infiltration.to_idf(zone_name)
+    rebuilt_infiltration, rebuilt_zone_name = Infiltration.from_idf(idf_str, sched_dict)
+    assert infiltration == rebuilt_infiltration
+    assert zone_name == rebuilt_zone_name
+
+
+def test_infiltration_dict_methods():
+    """Test the to/from dict methods."""
+    simple_lobby = ScheduleDay('Simple Weekday', [0, 1, 0],
+                               [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Lobby Infiltration Schedule', simple_lobby,
+                               None, schedule_types.fractional)
+    infiltration = Infiltration('Lobby Infiltration', 0.0003, schedule)
+
+    inf_dict = infiltration.to_dict()
+    new_infiltration = Infiltration.from_dict(inf_dict)
+    assert new_infiltration == infiltration
+    assert inf_dict == new_infiltration.to_dict()
+
+
+def test_infiltration_average():
+    """Test the Infiltration.average method."""
+    weekday_office = ScheduleDay('Weekday Office Infiltration', [0, 1, 0.5, 0],
+                                 [Time(0, 0), Time(9, 0), Time(17, 0), Time(19, 0)])
+    weekday_lobby = ScheduleDay('Weekday Lobby Infiltration', [0.1, 1, 0.1],
+                                [Time(0, 0), Time(8, 0), Time(20, 0)])
+    weekend_office = ScheduleDay('Weekend Office Infiltration', [0])
+    weekend_lobby = ScheduleDay('Weekend Office Infiltration', [0.1])
+    wknd_office_rule = ScheduleRule(weekend_office, apply_saturday=True, apply_sunday=True)
+    wknd_lobby_rule = ScheduleRule(weekend_lobby, apply_saturday=True, apply_sunday=True)
+    office_schedule = ScheduleRuleset('Office Infiltration', weekday_office,
+                                      [wknd_office_rule], schedule_types.fractional)
+    lobby_schedule = ScheduleRuleset('Lobby Infiltration', weekday_lobby,
+                                     [wknd_lobby_rule], schedule_types.fractional)
+
+    office_inf = Infiltration('Office Infiltration', 0.0003, office_schedule, 1, 0, 0)
+    lobby_inf = Infiltration('Lobby Infiltration', 0.0006, lobby_schedule,
+                             0.6, 0.03, 0.1)
+
+    office_avg = Infiltration.average('Average Infiltration', [office_inf, lobby_inf])
+
+    assert office_avg.flow_per_exterior_area == pytest.approx(0.00045, rel=1e-3)
+    assert office_avg.constant_coefficient == pytest.approx(0.8, rel=1e-3)
+    assert office_avg.temperature_coefficient == pytest.approx(0.015, rel=1e-3)
+    assert office_avg.velocity_coefficient == pytest.approx(0.05, rel=1e-3)
+
+    week_vals = office_avg.schedule.values(end_date=Date(1, 7))
+    avg_vals = [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.5,
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75, 0.75,
+                0.5, 0.05, 0.05, 0.05, 0.05]
+    assert week_vals[:24] == [0.05] * 24
+    assert week_vals[24:48] == avg_vals

--- a/tests/load_ventilation_test.py
+++ b/tests/load_ventilation_test.py
@@ -1,0 +1,170 @@
+# coding=utf-8
+from honeybee_energy.load.ventilation import Ventilation
+from honeybee_energy.schedule.day import ScheduleDay
+from honeybee_energy.schedule.rule import ScheduleRule
+from honeybee_energy.schedule.ruleset import ScheduleRuleset
+
+import honeybee_energy.lib.scheduletypelimits as schedule_types
+
+from ladybug.dt import Time, Date
+
+import pytest
+
+
+def test_ventilation_init():
+    """Test the initialization of Ventilation and basic properties."""
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+    str(ventilation)  # test the string representation
+
+    assert ventilation.name == 'Office Ventilation'
+    assert ventilation.flow_per_person == 0.0025
+    assert ventilation.flow_per_area == 0.0006
+    assert ventilation.flow_per_zone == 0
+    assert ventilation.air_changes_per_hour == 0
+    assert ventilation.schedule is None
+
+
+def test_ventilation_init_schedule():
+    """Test the initialization of Ventilation with a schedule."""
+    simple_office = ScheduleDay('Simple Weekday', [0, 1, 0],
+                                [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Office Ventilation Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006, 0, 0, schedule)
+    str(ventilation)  # test the string representation
+
+    assert ventilation.name == 'Office Ventilation'
+    assert ventilation.flow_per_person == 0.0025
+    assert ventilation.flow_per_area == 0.0006
+    assert ventilation.flow_per_zone == 0
+    assert ventilation.air_changes_per_hour == 0
+    assert ventilation.schedule.name == 'Office Ventilation Schedule'
+    assert ventilation.schedule.schedule_type_limit == schedule_types.fractional
+    assert ventilation.schedule == schedule
+
+
+def test_ventilation_setability():
+    """Test the setting of properties of Ventilation."""
+    simple_office = ScheduleDay('Simple Weekday', [0, 1, 0],
+                                [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Office Ventilation Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+
+    ventilation.name = 'Office Zone Ventilation'
+    assert ventilation.name == 'Office Zone Ventilation'
+    ventilation.flow_per_person = 0.01
+    assert ventilation.flow_per_person == 0.01
+    ventilation.flow_per_area = 0
+    assert ventilation.flow_per_area == 0
+    ventilation.flow_per_zone = 1
+    assert ventilation.flow_per_zone == 1
+    ventilation.air_changes_per_hour = 2
+    assert ventilation.air_changes_per_hour == 2
+    ventilation.schedule = schedule
+    assert ventilation.schedule == schedule
+
+
+def test_ventilation_equality():
+    """Test the equality of Ventilation objects."""
+    simple_office = ScheduleDay('Simple Weekday', [0, 1, 0],
+                                [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Office Ventilation Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+    ventilation_dup = ventilation.duplicate()
+    ventilation_alt = Ventilation('Office Ventilation', 0.0025, 0.0006)
+    ventilation_alt.schedule = schedule
+
+    assert ventilation is ventilation
+    assert ventilation is not ventilation_dup
+    assert ventilation == ventilation_dup
+    ventilation_dup.flow_per_person = 0.01
+    assert ventilation != ventilation_dup
+    assert ventilation != ventilation_alt
+
+
+def test_ventilation_lockability():
+    """Test the lockability of Ventilation objects."""
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+
+    ventilation.flow_per_person = 0.01
+    ventilation.lock()
+    with pytest.raises(AttributeError):
+        ventilation.flow_per_person = 0.0025
+    ventilation.unlock()
+    ventilation.flow_per_person = 0.0025
+
+
+def test_ventilation_init_from_idf():
+    """Test the initialization of Ventilation from_idf."""
+    simple_office = ScheduleDay('Simple Weekday', [0, 1, 0],
+                                [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Office Ventilation Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+    ventilation.schedule = schedule
+    sched_dict = {schedule.name: schedule}
+
+    idf_str = ventilation.to_idf()
+    rebuilt_ventilation = Ventilation.from_idf(idf_str, sched_dict)
+    assert ventilation == rebuilt_ventilation
+
+
+def test_ventilation_dict_methods():
+    """Test the to/from dict methods."""
+    simple_office = ScheduleDay('Simple Weekday', [0, 1, 0],
+                                [Time(0, 0), Time(9, 0), Time(17, 0)])
+    schedule = ScheduleRuleset('Office Ventilation Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = Ventilation('Office Ventilation', 0.0025, 0.0006)
+
+    vent_dict = ventilation.to_dict()
+    new_ventilation = Ventilation.from_dict(vent_dict)
+    assert new_ventilation == ventilation
+    assert vent_dict == new_ventilation.to_dict()
+
+    ventilation.schedule = schedule
+    vent_dict = ventilation.to_dict()
+    new_ventilation = Ventilation.from_dict(vent_dict)
+    assert new_ventilation == ventilation
+    assert vent_dict == new_ventilation.to_dict()
+
+
+def test_ventilation_average():
+    """Test the Ventilation.average method."""
+    weekday_office = ScheduleDay('Weekday Office Ventilation', [0, 1, 0.5, 0],
+                                 [Time(0, 0), Time(9, 0), Time(17, 0), Time(19, 0)])
+    weekday_lobby = ScheduleDay('Weekday Lobby Ventilation', [0.1, 1, 0.1],
+                                [Time(0, 0), Time(8, 0), Time(20, 0)])
+    weekend_office = ScheduleDay('Weekend Office Ventilation', [0])
+    weekend_lobby = ScheduleDay('Weekend Office Ventilation', [0.1])
+    wknd_office_rule = ScheduleRule(weekend_office, apply_saturday=True, apply_sunday=True)
+    wknd_lobby_rule = ScheduleRule(weekend_lobby, apply_saturday=True, apply_sunday=True)
+    office_schedule = ScheduleRuleset('Office Ventilation', weekday_office,
+                                      [wknd_office_rule], schedule_types.fractional)
+    lobby_schedule = ScheduleRuleset('Lobby Ventilation', weekday_lobby,
+                                     [wknd_lobby_rule], schedule_types.fractional)
+
+    office_vent = Ventilation('Office Ventilation', 0.01, 0.0006, 0, 0, office_schedule)
+    lobby_vent = Ventilation('Lobby Ventilation', 0, 0, 0, 1, lobby_schedule)
+
+    office_avg = Ventilation.average('Average Ventilation', [office_vent, lobby_vent])
+
+    assert office_avg.flow_per_person == pytest.approx(0.005, rel=1e-3)
+    assert office_avg.flow_per_area == pytest.approx(0.0003, rel=1e-3)
+    assert office_avg.flow_per_zone == pytest.approx(0, rel=1e-3)
+    assert office_avg.air_changes_per_hour == pytest.approx(0.5, rel=1e-3)
+
+    week_vals = office_avg.schedule.values(end_date=Date(1, 7))
+    avg_vals = [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.5,
+                1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.75, 0.75,
+                0.5, 0.05, 0.05, 0.05, 0.05]
+    assert week_vals[:24] == [0.05] * 24
+    assert week_vals[24:48] == avg_vals
+
+    office_vent.schedule = None
+    lobby_vent.schedule = None
+    office_avg = Ventilation.average('Average Ventilation', [office_vent, lobby_vent])
+
+    assert office_avg.schedule is None


### PR DESCRIPTION
I also exposed the `fraction_lost` attribute on the equipment objects since I realized that certain space types in the standards gem make use of it.

@mostaphaRoudsari ,
If you are able to review this one quickly as you had done yesterday, that would be ideal.  Then, we can merge this one in and I can send a separate PR for `ProgramType` and the edits to the Room extension tomorrow.