### PR TITLE
feat(simulation): Add objects for EnergyPlus simulation settings

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "bash deploy.sh ${nextRelease.version}"
+                "publishCmd": "bash deploy.sh"
             }
         ]
     ]

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,11 @@ jobs:
     - git config --global user.email "releases@ladybug.tools"
     - git config --global user.name "ladybugbot"
     - npx semantic-release
+  - stage: docs
+    if: branch = master AND (NOT type IN (pull_request))
+    script:
+    - sphinx-apidoc -f -e -d 4 -o ./docs ./honeybee_energy
+    - sphinx-build -b html ./docs ./docs/_build/docs
     deploy:
       provider: pages
       skip_cleanup: true

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,26 +1,6 @@
 #!/bin/sh
 
-deploy_to_pypi() {
-  echo "Building distribution"
-  python setup.py sdist bdist_wheel
-  echo "Pushing new version to PyPi"
-  twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
-}
-
-build_docs() {
-  echo "Building documentation files"
-  sphinx-apidoc -f -e -d 4 -o ./docs ./honeybee_energy
-  sphinx-build -b html ./docs ./docs/_build/docs -D release=$1 -D version=$1
-}
-
-
-if [ -n "$1" ]
-then
-  NEXT_RELEASE_VERSION=$1
-else
-  echo "A release version must be supplied"
-  exit 1
-fi
-
-deploy_to_pypi
-build_docs $NEXT_RELEASE_VERSION
+echo "Building distribution"
+python setup.py sdist bdist_wheel
+echo "Pushing new version to PyPi"
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD

--- a/honeybee_energy/idealair.py
+++ b/honeybee_energy/idealair.py
@@ -138,7 +138,7 @@ class IdealAirSystem(object):
 
     @property
     def sensible_heat_recovery(self):
-        """Get or set a a number for the effectiveness of sensible heat recovery."""
+        """Get or set a number for the effectiveness of sensible heat recovery."""
         return self._sensible_heat_recovery
 
     @sensible_heat_recovery.setter
@@ -148,7 +148,7 @@ class IdealAirSystem(object):
 
     @property
     def latent_heat_recovery(self):
-        """Get or set a a number for the effectiveness of latent heat recovery."""
+        """Get or set a number for the effectiveness of latent heat recovery."""
         return self._latent_heat_recovery
 
     @latent_heat_recovery.setter
@@ -217,6 +217,7 @@ class IdealAirSystem(object):
         .. code-block:: json
 
             {
+            "type": "IdealAirSystem",
             "heating_limit": 'autosize',  // Max size of the heating system in Watts
             "cooling_limit": 'autosize',  // Max size of the cooling system in Watts
             "economizer_type": 'DifferentialDryBulb',  // Economizer type

--- a/honeybee_energy/load/infiltration.py
+++ b/honeybee_energy/load/infiltration.py
@@ -36,7 +36,8 @@ class Infiltration(_LoadBase):
                 Can include spaces but special characters will be stripped out.
             flow_per_exterior_area: A numerical value for the intensity of infiltration
                 in m3/s per square meter of exterior surface area. Typical values for
-                this property are as follows:
+                this property are as follows (note all values are at typical building
+                pressures of ~4 Pa):
                     * 0.0001 (m3/s per m2 facade) - Tight building
                     * 0.0003 (m3/s per m2 facade) - Average building
                     * 0.0006 (m3/s per m2 facade) - Leaky building

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -8,6 +8,7 @@ class ApertureEnergyProperties(object):
     """Energy Properties for Honeybee Aperture.
 
     Properties:
+        * host
         * construction
         * is_construction_set_by_user
     """

--- a/honeybee_energy/properties/door.py
+++ b/honeybee_energy/properties/door.py
@@ -9,6 +9,7 @@ class DoorEnergyProperties(object):
     """Energy Properties for Honeybee Door.
 
     Properties:
+        * host
         * construction
         * is_construction_set_by_user
     """

--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -8,6 +8,7 @@ class FaceEnergyProperties(object):
     """Energy Properties for Honeybee Face.
 
     Properties:
+        * host
         * construction
         * is_construction_set_by_user
     """

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -18,6 +18,7 @@ class RoomEnergyProperties(object):
     """Energy Properties for Honeybee Room.
 
     Properties:
+        * host
         * program_type
         * construction_set
         * hvac

--- a/honeybee_energy/properties/shade.py
+++ b/honeybee_energy/properties/shade.py
@@ -12,6 +12,7 @@ class ShadeEnergyProperties(object):
     """Energy Properties for Honeybee Shade.
 
     Properties:
+        * host
         * construction
         * transmittance_schedule
         * is_construction_set_by_user

--- a/honeybee_energy/simulation/__init__.py
+++ b/honeybee_energy/simulation/__init__.py
@@ -1,0 +1,1 @@
+"""honeybee-energy simulation settings."""

--- a/honeybee_energy/simulation/control.py
+++ b/honeybee_energy/simulation/control.py
@@ -1,0 +1,206 @@
+# coding=utf-8
+"""Simulation controls for which types of calculations to run."""
+from __future__ import division
+
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+
+class SimulationControl(object):
+    """Simulation controls for which types of calculations to run.
+
+    Properties:
+        * do_zone_sizing
+        * do_system_sizing
+        * do_plant_sizing
+        * run_for_sizing_periods
+        * run_for_run_periods
+    """
+    __slots__ = ('_do_zone_sizing', '_do_system_sizing', '_do_plant_sizing',
+                 '_run_for_sizing_periods', '_run_for_run_periods')
+
+    def __init__(self, do_zone_sizing=True, do_system_sizing=True,
+                 do_plant_sizing=True, run_for_sizing_periods=False,
+                 run_for_run_periods=True):
+        """Initialize SimulationControl.
+
+        Args:
+            do_zone_sizing: Boolean for whether the zone sizing calculation
+                should be run. Default: True.
+            do_system_sizing: Boolean for whether the system sizing calculation
+                should be run. Default: True.
+            do_plant_sizing: Boolean for whether the plant sizing calculation
+                should be run. Default: True.
+            run_for_sizing_periods: Boolean for whether the simulation should
+                be run for the sizing periods.
+            run_for_run_periods: Boolean for whether the simulation should
+                be run for the run periods.
+        """
+        self.do_zone_sizing = do_zone_sizing
+        self.do_system_sizing = do_system_sizing
+        self.do_plant_sizing = do_plant_sizing
+        self.run_for_sizing_periods = run_for_sizing_periods
+        self.run_for_run_periods = run_for_run_periods
+
+    @property
+    def do_zone_sizing(self):
+        """Get or set a boolean for whether the zone sizing calculation is run."""
+        return self._do_zone_sizing
+
+    @do_zone_sizing.setter
+    def do_zone_sizing(self, value):
+        self._do_zone_sizing = bool(value)
+
+    @property
+    def do_system_sizing(self):
+        """Get or set a boolean for whether the system sizing calculation is run."""
+        return self._do_system_sizing
+
+    @do_system_sizing.setter
+    def do_system_sizing(self, value):
+        self._do_system_sizing = bool(value)
+
+    @property
+    def do_plant_sizing(self):
+        """Get or set a boolean for whether the plant sizing calculation is run."""
+        return self._do_plant_sizing
+
+    @do_plant_sizing.setter
+    def do_plant_sizing(self, value):
+        self._do_plant_sizing = bool(value)
+
+    @property
+    def run_for_sizing_periods(self):
+        """Get or set a boolean for whether the simulation is run for sizing periods."""
+        return self._run_for_sizing_periods
+
+    @run_for_sizing_periods.setter
+    def run_for_sizing_periods(self, value):
+        self._run_for_sizing_periods = bool(value)
+
+    @property
+    def run_for_run_periods(self):
+        """Get or set a boolean for whether the simulation is run for run periods."""
+        return self._run_for_run_periods
+
+    @run_for_run_periods.setter
+    def run_for_run_periods(self, value):
+        self._run_for_run_periods = bool(value)
+
+    @classmethod
+    def from_idf(cls, idf_string):
+        """Create a SimulationControl object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                SimulationControl definition.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'SimulationControl,')
+
+        # extract the properties from the string
+        do_zone_sizing = False
+        do_system_sizing = False
+        do_plant_sizing = False
+        run_for_sizing_periods = True
+        run_for_run_periods = True
+        try:
+            do_zone_sizing = True if ep_strs[0].lower() == 'yes' else False
+            do_system_sizing = True if ep_strs[1].lower() == 'yes' else False
+            do_plant_sizing = True if ep_strs[2].lower() == 'yes' else False
+            run_for_sizing_periods = False if ep_strs[3].lower() == 'no' else True
+            run_for_run_periods = False if ep_strs[4].lower() == 'no' else True
+        except IndexError:
+            pass  # shorter SimulationControl definition
+
+        # return the object and the zone name for the object
+        return cls(do_zone_sizing, do_system_sizing, do_plant_sizing,
+                   run_for_sizing_periods, run_for_run_periods)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a SimulationControl object from a dictionary.
+
+        Args:
+            data: A SimulationControl dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "SimulationControl",
+            "do_zone_sizing": True,
+            "do_system_sizing": True,
+            "do_plant_sizing": True,
+            "run_for_sizing_periods": False,
+            "run_for_run_periods": True
+            }
+        """
+        assert data['type'] == 'SimulationControl', \
+            'Expected SimulationControl dictionary. Got {}.'.format(data['type'])
+        do_zone_sizing = data['do_zone_sizing'] if \
+            'do_zone_sizing' in data else True
+        do_system_sizing = data['do_system_sizing'] if \
+            'do_system_sizing' in data else True
+        do_plant_sizing = data['do_plant_sizing'] if \
+            'do_plant_sizing' in data else True
+        run_for_sizing_periods = data['run_for_sizing_periods'] if \
+            'run_for_sizing_periods' in data else False
+        run_for_run_periods = data['run_for_run_periods'] if \
+            'run_for_run_periods' in data else False
+        return cls(do_zone_sizing, do_system_sizing, do_plant_sizing,
+                   run_for_sizing_periods, run_for_run_periods)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the SimulationControl."""
+        do_zone_sizing = 'Yes' if self.do_zone_sizing else 'No'
+        do_system_sizing = 'Yes' if self.do_system_sizing else 'No'
+        do_plant_sizing = 'Yes' if self.do_plant_sizing else 'No'
+        run_for_sizing_periods = 'Yes' if self.run_for_sizing_periods else 'No'
+        run_for_run_periods = 'Yes' if self.run_for_run_periods else 'No'
+        values = (do_zone_sizing, do_system_sizing, do_plant_sizing,
+                  run_for_sizing_periods, run_for_run_periods)
+        comments = ('do zone sizing', 'do system sizing', 'do plant sizing',
+                    'run for sizing periods', 'run for run periods')
+        return generate_idf_string('SimulationControl', values, comments)
+
+    def to_dict(self):
+        """SimulationControl dictionary representation."""
+        return {
+            'type': 'SimulationControl',
+            'do_zone_sizing': self.do_zone_sizing,
+            'do_system_sizing': self.do_system_sizing,
+            'do_plant_sizing': self.do_plant_sizing,
+            'run_for_sizing_periods': self.run_for_sizing_periods,
+            'run_for_run_periods': self.run_for_run_periods
+        }
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __copy__(self):
+        return SimulationControl(
+            self.do_zone_sizing, self.do_system_sizing,
+            self.do_plant_sizing, self.run_for_sizing_periods,
+            self.run_for_run_periods)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.do_zone_sizing, self.do_system_sizing, self.do_plant_sizing,
+                self.run_for_sizing_periods, self.run_for_run_periods)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, SimulationControl) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()

--- a/honeybee_energy/simulation/daylightsaving.py
+++ b/honeybee_energy/simulation/daylightsaving.py
@@ -1,0 +1,178 @@
+# coding=utf-8
+"""EnergyPlus Daylight Saving Time Period."""
+from __future__ import division
+
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from ladybug.analysisperiod import AnalysisPeriod
+from ladybug.dt import Date
+
+
+class DaylightSavingTime(object):
+    """EnergyPlus Daylight Saving Time Period.
+
+    Properties:
+        * start_date
+        * end_date
+    """
+    __slots__ = ('_start_date', '_end_date')
+
+    def __init__(self, start_date=Date(3, 12), end_date=Date(11, 5)):
+        """Initialize DaylightSavingTime.
+
+        Args:
+            start_date: A ladybug Date object for the start of daylight saving time.
+                Must be before the end date and have a leap_year property matching the
+                end_date. Default: 12 Mar (daylight savings in the US in 2017)
+            end_date: A ladybug Date object for the end of daylight saving time.
+                Must be after the start date and have a leap_year property matching the
+                start_date. Default: 5 Nov (daylight savings in the US in 2017)
+        """
+        # process the dates
+        if start_date is not None:
+            self._check_date(start_date, 'start_date')
+            self._start_date = start_date
+        else:
+            self._start_date = Date(3, 12)
+        self.end_date = end_date
+
+    @property
+    def start_date(self):
+        """Get or set a ladybug Date object for the start of the period."""
+        return self._start_date
+
+    @start_date.setter
+    def start_date(self, value):
+        if value is not None:
+            self._check_date(value, 'start_date')
+            self._start_date = value
+        else:
+            self._start_date = Date(1, 1)
+        self._check_start_before_end()
+
+    @property
+    def end_date(self):
+        """Get or set a ladybug Date object for the end of the period."""
+        return self._end_date
+
+    @end_date.setter
+    def end_date(self, value):
+        if value is not None:
+            self._check_date(value, 'start_date')
+            self._end_date = value
+        else:
+            self._end_date = Date(12, 31)
+        self._check_start_before_end()
+
+    @classmethod
+    def from_analysis_period(cls, analysis_period=AnalysisPeriod(3, 12, 0, 11, 5, 23)):
+        """Initialize a DaylightSavingTime object from a ladybug AnalysisPeriod.
+
+        Args:
+            analysis_period: A ladybug AnalysisPeriod object that has the start
+                and end dates for daylight savings time.
+                Default: 12 Mar - 5 Nov (daylight savings in the US in 2017)
+        """
+        assert isinstance(analysis_period, AnalysisPeriod), 'Expected AnalysisPeriod ' \
+            'for DaylightSavingTime.from_analysis_period. Got {}.'.format(
+                type(analysis_period))
+        st_date = Date(analysis_period.st_month, analysis_period.st_date,
+                       analysis_period.is_leap_year)
+        end_date = Date(analysis_period.end_month, analysis_period.end_date,
+                        analysis_period.is_leap_year)
+        return cls(st_date, end_date)
+
+    @classmethod
+    def from_idf(cls, idf_string):
+        """Create a DaylightSavingTime object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                RunPeriodControl:DaylightSavingTime definition.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'RunPeriodControl:DaylightSavingTime,')
+        start_vals = ep_strs[0].split('/')
+        end_vals = ep_strs[1].split('/')
+        start_date = Date(int(start_vals[0]), int(start_vals[1]))
+        end_date = Date(int(end_vals[0]), int(end_vals[1]))
+        return cls(start_date, end_date)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a DaylightSavingTime object from a dictionary.
+
+        Args:
+            data: A DaylightSavingTime dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "DaylightSavingTime",
+            "start_date": {month: 1, day: 1},
+            "end_date": {month: 12, day: 31}
+            }
+        """
+        assert data['type'] == 'DaylightSavingTime', \
+            'Expected DaylightSavingTime dictionary. Got {}.'.format(data['type'])
+        start_date = Date.from_dict(data['start_date']) if \
+            'start_date' in data else Date(1, 1)
+        end_date = Date.from_dict(data['end_date']) if \
+            'end_date' in data else Date(12, 31)
+        return cls(start_date, end_date)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the DaylightSavingTime."""
+        values = ('{}/{}'.format(self.start_date.month, self.start_date.day),
+                  '{}/{}'.format(self.end_date.month, self.end_date.day))
+        comments = ('start date', 'end date')
+        return generate_idf_string('RunPeriodControl:DaylightSavingTime',
+                                   values, comments)
+
+    def to_dict(self):
+        """DaylightSavingTime dictionary representation."""
+        return {
+            'type': 'DaylightSavingTime',
+            'start_date': self.start_date.to_dict(),
+            'end_date': self.end_date.to_dict()
+        }
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def _check_start_before_end(self):
+        """Check that the start_date is before the end_date."""
+        assert self.start_date.leap_year is self.end_date.leap_year, \
+            'DaylightSavingTime start_date.leap_year must match the end_date.leap_year'
+        assert self._start_date < self._end_date, 'DaylightSavingTime start_date must ' \
+            'be before end_date. {} is after {}.'.format(self.start_date, self.end_date)
+
+    @staticmethod
+    def _check_date(date, date_name='date'):
+        assert isinstance(date, Date), 'Expected ladybug Date for ' \
+            'DaylightSavingTime {}. Got {}.'.format(date_name, type(date))
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __copy__(self):
+        return DaylightSavingTime(self.start_date, self.end_date)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.start_date), hash(self.end_date))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, DaylightSavingTime) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()

--- a/honeybee_energy/simulation/runperiod.py
+++ b/honeybee_energy/simulation/runperiod.py
@@ -1,0 +1,378 @@
+# coding=utf-8
+"""EnergyPlus Simulation Run Period."""
+from __future__ import division
+
+from .daylightsaving import DaylightSavingTime
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from honeybee.typing import valid_string
+
+from ladybug.analysisperiod import AnalysisPeriod
+from ladybug.dt import Date
+
+
+class RunPeriod(object):
+    """EnergyPlus Simulation Run Period.
+
+    Properties:
+        * start_date
+        * end_date
+        * start_day_of_week
+        * holidays
+        * daylight_saving_time
+        * is_leap_year
+    """
+    __slots__ = ('_start_date', '_end_date', '_start_day_of_week', '_holidays',
+                 '_daylight_saving_time')
+    DAYS_OF_THE_WEEK = (
+        'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday')
+
+    def __init__(self, start_date=Date(1, 1), end_date=Date(12, 31),
+                 start_day_of_week='Sunday', holidays=None, daylight_saving_time=None):
+        """Initialize RunPeriod.
+
+        Args:
+            start_date: A ladybug Date object for the start of the run period.
+                Must be before the end date and have a leap_year property matching the
+                end_date. Default: 1 Jan
+            end_date: A ladybug Date object for the end of the run period.
+                Must be after the start date and have a leap_year property matching the
+                start_date. Default: 31 Dec
+            start_day_of_week: Text for the day of the week on which the simulation
+                starts. Default: 'Sunday'. Choose from the following:
+                    * Sunday
+                    * Monday
+                    * Tuesday
+                    * Wednesday
+                    * Thursday
+                    * Friday
+                    * Saturday
+            holidays: A list of Ladybug Date objects for the holidays within the
+                simulation. If None, no folidays are applied. Default: None.
+            daylight_saving_time: A DaylightSavingTime object to dictate the start and
+                end dates of daylight saving time. If None, no daylight saving time is
+                applied to the simulation. Default: None.
+        """
+        # process the dates
+        if start_date is not None:
+            self._check_date(start_date, 'start_date')
+            self._start_date = start_date
+        else:
+            self._start_date = Date(1, 1)
+        self.end_date = end_date
+
+        self.start_day_of_week = start_day_of_week
+        self.holidays = holidays
+        self.daylight_saving_time = daylight_saving_time
+
+    @property
+    def start_date(self):
+        """Get or set a ladybug Date object for the start of the run period."""
+        return self._start_date
+
+    @start_date.setter
+    def start_date(self, value):
+        if value is not None:
+            self._check_date(value, 'start_date')
+            self._start_date = value
+        else:
+            self._start_date = Date(1, 1)
+        self._check_start_before_end()
+
+    @property
+    def end_date(self):
+        """Get or set a ladybug Date object for the end of the run period."""
+        return self._end_date
+
+    @end_date.setter
+    def end_date(self, value):
+        if value is not None:
+            self._check_date(value, 'start_date')
+            self._end_date = value
+        else:
+            self._end_date = Date(12, 31)
+        self._check_start_before_end()
+
+    @property
+    def start_day_of_week(self):
+        """Get or set text for the day of the week on which the simulation starts.
+
+        Choose from the following:
+            * Sunday
+            * Monday
+            * Tuesday
+            * Wednesday
+            * Thursday
+            * Friday
+            * Saturday
+        """
+        return self._start_day_of_week
+
+    @start_day_of_week.setter
+    def start_day_of_week(self, value):
+        clean_input = valid_string(value).lower()
+        for key in self.DAYS_OF_THE_WEEK:
+            if key.lower() == clean_input:
+                value = key
+                break
+        else:
+            raise ValueError(
+                'start_day_of_week {} is not recognized.\nChoose from the '
+                'following:\n{}'.format(value, self.DAYS_OF_THE_WEEK))
+        self._start_day_of_week = value
+
+    @property
+    def holidays(self):
+        """Get or set a list of ladybug Date objects for holidays."""
+        return self._holidays
+
+    @holidays.setter
+    def holidays(self, value):
+        if value is not None:
+            if not isinstance(value, tuple):
+                value = tuple(value)
+            for date in value:
+                assert isinstance(date, Date), 'Expected ladybug Date for ' \
+                    'RunPeriod holiday. Got {}.'.format(type(date))
+        self._holidays = value
+
+    @property
+    def daylight_saving_time(self):
+        """Get or set a DaylightSavingTime object for start and end of daylight savings.
+        """
+        return self._daylight_saving_time
+
+    @daylight_saving_time.setter
+    def daylight_saving_time(self, value):
+        if value is not None:
+            assert isinstance(value, DaylightSavingTime), 'Expected DaylightSavingTime' \
+                ' for RunPeriod run_period. Got {}.'.format(type(value))
+            if value.start_date.leap_year is not self.start_date.leap_year:
+                leap = self.start_date.leap_year
+                value._start_date = Date(value._start_date.month,
+                                         value._start_date.day, leap)
+                value._end_date = Date(value._end_date.month,
+                                       value._end_date.day, leap)
+        self._daylight_saving_time = value
+
+    @property
+    def is_leap_year(self):
+        """Get or set a boolean noting whether the RunPeriod is for a leap year simulation.
+        """
+        return self.start_date.leap_year
+
+    @is_leap_year.setter
+    def is_leap_year(self, value):
+        value = bool(value)
+        self._start_date = Date(self._start_date.month, self._start_date.day, value)
+        self._end_date = Date(self._end_date.month, self._end_date.day, value)
+        if self._daylight_saving_time is not None:
+            st_dt = self._daylight_saving_time._start_date
+            ed_dt = self._daylight_saving_time._end_date
+            self._daylight_saving_time._start_date = Date(st_dt.month, st_dt.day, value)
+            self._daylight_saving_time._end_date = Date(ed_dt.month, ed_dt.day, value)
+
+    @classmethod
+    def from_analysis_period(cls, analysis_period=None, start_day_of_week='Sunday',
+                             holidays=None, daylight_saving_time=None):
+        """Initialize a RunPeriod object from a ladybug AnalysisPeriod.
+
+        Note that the st_hour and end_hour properties of the AnalysisPeriod are
+        completely ignored when using this classmethod since EnergyPlus cannot start
+        or end a simulation at an interval less than a day.
+
+        Args:
+            analysis_period: A ladybug AnalysisPeriod object that has the start
+                and end dates for the simulation. Default: an AnalysisPeriod for the
+                whole year.
+            start_day_of_week: Text for the day of the week on which the simulation
+                starts. Default: 'Sunday'. Choose from the following:
+                    * Sunday
+                    * Monday
+                    * Tuesday
+                    * Wednesday
+                    * Thursday
+                    * Friday
+                    * Saturday
+            holidays: A list of Ladybug Date objects for the holidays within the
+                simulation. If None, no folidays are applied. Default: None.
+            daylight_saving_time: A DaylightSavingTime object to dictate the start and
+                end dates of daylight saving time. If None, no daylight saving time is
+                applied to the simulation. Default: None.
+        """
+        assert isinstance(analysis_period, AnalysisPeriod), 'Expected AnalysisPeriod ' \
+            'for RunPeriod.from_analysis_period. Got {}.'.format(type(analysis_period))
+        st_date = Date(analysis_period.st_month, analysis_period.st_date,
+                       analysis_period.is_leap_year)
+        end_date = Date(analysis_period.end_month, analysis_period.end_date,
+                        analysis_period.is_leap_year)
+        return cls(st_date, end_date, start_day_of_week, holidays, daylight_saving_time)
+
+    @classmethod
+    def from_idf(cls, idf_string, holiday_strings=None, daylight_saving_string=None):
+        """Create a RunPeriod object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus RunPeriod
+                definition.
+            holiday_strings: A list of IDF RunPeriodControl:SpecialDays strings
+                that represent the holidays applied to the simulation.
+            daylight_saving_string: An IDF RunPeriodControl:DaylightSavingTime string
+                that notes the start and ends dates of Daylight Savings time.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'RunPeriod,')
+
+        # extract the required properties
+        start_year = int(ep_strs[3]) if ep_strs[3] != '' else 2017
+        leap_year = True if start_year % 4 == 0 else False
+        start_date = Date(int(ep_strs[1]), int(ep_strs[2]), leap_year)
+        end_date = Date(int(ep_strs[4]), int(ep_strs[5]), leap_year)
+
+        # extract the optional properties
+        start_day_of_week = 'Sunday'
+        try:
+            start_day_of_week = ep_strs[7] if ep_strs[7] != '' else 'Sunday'
+        except IndexError:
+            pass  # shorter RunPeriod definition
+        holidays = None
+        if holiday_strings is not None:
+            holidays = []
+            for hol_str in holiday_strings:
+                ep_hol_str = parse_idf_string(hol_str, 'RunPeriodControl:SpecialDays,')
+                hol_vals = ep_hol_str[1].split('/')
+                holidays.append(Date(int(hol_vals[0]), int(hol_vals[1]), leap_year))
+        daylight_saving = DaylightSavingTime.from_idf(daylight_saving_string) if \
+            daylight_saving_string is not None else None
+
+        return cls(start_date, end_date, start_day_of_week, holidays, daylight_saving)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a RunPeriod object from a dictionary.
+
+        Args:
+            data: A RunPeriod dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "RunPeriod",
+            "start_date": {month: 1, day: 1},
+            "end_date": {month: 12, day: 31},
+            "start_day_of_week": 'Monday',
+            "holidays": [{month: 1, day: 1}, {month: 7, day: 4}],
+            "daylight_saving_time": {} // DaylightSavingTime dictionary representation
+            }
+        """
+        assert data['type'] == 'RunPeriod', \
+            'Expected RunPeriod dictionary. Got {}.'.format(data['type'])
+        start_date = Date.from_dict(data['start_date']) if \
+            'start_date' in data else Date(1, 1)
+        end_date = Date.from_dict(data['end_date']) if \
+            'end_date' in data else Date(12, 31)
+        start_day_of_week = data['start_day_of_week'] if \
+            'start_day_of_week' in data else 'Sunday'
+        holidays = None
+        if 'holidays' in data and data['holidays'] is not None:
+            holidays = tuple(Date.from_dict(hol) for hol in data['holidays'])
+        daylight_saving = None
+        if 'daylight_saving_time' in data and data['daylight_saving_time'] is not None:
+            daylight_saving = DaylightSavingTime.from_dict(data['daylight_saving_time'])
+        return cls(start_date, end_date, start_day_of_week, holidays, daylight_saving)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the RunPeriod.
+
+        Returns:
+            run_period: An IDF string representation of the RunPeriod object.
+            holidays: A list of IDF RunPeriodControl:SpecialDays strings that represent
+                the holidays applied to the simulation. Will be None if no holidays
+                are applied to this RunPeriod.
+            daylight_saving_time: An IDF RunPeriodControl:DaylightSavingTime string
+                that notes the start and ends dates of Daylight Savings time. Will be
+                None if no daylight_saving_time is applied to this RunPeriod.
+        """
+        year = 2016 if self.is_leap_year else 2017
+        values = ('CustomRunPeriod', self.start_date.month, self.start_date.day, year,
+                  self.end_date.month, self.end_date.day, year,
+                  self.start_day_of_week, 'Yes', 'Yes')
+        comments = ('name', 'start month', 'start day', 'start year',
+                    'end month', 'end day', 'end year', 'start day of week',
+                    'use weather file holidays', 'use weather file daylight savings')
+        run_period = generate_idf_string('RunPeriod', values, comments)
+
+        holidays = [self._holiday_to_idf(hol, i) for i, hol in
+                    enumerate(self.holidays)] if self.holidays is not None else None
+
+        daylight_saving_time = self.daylight_saving_time.to_idf() if \
+            self.daylight_saving_time is not None else None
+
+        return run_period, holidays, daylight_saving_time
+
+    def to_dict(self):
+        """RunPeriod dictionary representation."""
+        base = {
+            'type': 'RunPeriod',
+            'start_date': self.start_date.to_dict(),
+            'end_date': self.end_date.to_dict(),
+            'start_day_of_week': self.start_day_of_week
+        }
+        if self.holidays is not None:
+            base['holidays'] = [hol.to_dict() for hol in self.holidays]
+        if self.daylight_saving_time is not None:
+            base['daylight_saving_time'] = self.daylight_saving_time.to_dict()
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def _check_start_before_end(self):
+        """Check that the start_date is before the end_date."""
+        assert self.start_date.leap_year is self.end_date.leap_year, \
+            'RunPeriod start_date.leap_year must match the end_date.leap_year'
+        assert self._start_date < self._end_date, 'RunPeriod start_date must come ' \
+            'before end_date. {} comes after {}.'.format(self.start_date, self.end_date)
+
+    @staticmethod
+    def _check_date(date, date_name='date'):
+        assert isinstance(date, Date), 'Expected ladybug Date for ' \
+            'RunPeriod {}. Got {}.'.format(date_name, type(date))
+
+    @staticmethod
+    def _holiday_to_idf(date, count):
+        """Convert a ladybug Date object to an IDF holiday string."""
+        values = ('Holiday_{}'.format(count), '{}/{}'.format(date.month, date.day))
+        comments = ('name', 'date')
+        return generate_idf_string('RunPeriodControl:SpecialDays', values, comments)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __copy__(self):
+        dst = self.daylight_saving_time.duplicate() if self.daylight_saving_time \
+            is not None else None
+        return RunPeriod(self.start_date, self.end_date, self.start_day_of_week,
+                         self.holidays, dst)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        hol_tup = tuple(hash(hol) for hol in self.holidays) if \
+            self.holidays is not None else (None,)
+        return (hash(self.start_date), hash(self.end_date), self.start_day_of_week,
+                hash(self.daylight_saving_time)) + hol_tup
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, RunPeriod) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()[0]

--- a/honeybee_energy/simulation/shadowcalculation.py
+++ b/honeybee_energy/simulation/shadowcalculation.py
@@ -1,0 +1,230 @@
+# coding=utf-8
+"""Settings for the EnergyPlus Shadow Calculation."""
+from __future__ import division
+
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from honeybee.typing import valid_string, int_in_range
+
+
+class ShadowCalculation(object):
+    """Settings for the EnergyPlus Shadow Calculation.
+
+    Properties:
+        * solar_distribution
+        * calculation_method
+        * calculation_frequency
+        * maximum_figures
+    """
+    __slots__ = ('_solar_distribution', '_calculation_method', '_calculation_frequency',
+                 '_maximum_figures')
+    SOLAR_DISTRIBUTIONS = (
+        'MinimalShadowing', 'FullExterior', 'FullInteriorAndExterior',
+        'FullExteriorWithReflections', 'FullInteriorAndExteriorWithReflections')
+    CALCULATION_METHODS = ('AverageOverDaysInFrequency', 'TimestepFrequency')
+
+    def __init__(self, solar_distribution='FullInteriorAndExteriorWithReflections',
+                 calculation_method='AverageOverDaysInFrequency',
+                 calculation_frequency=30, maximum_figures=15000):
+        """Initialize ShadowCalculation.
+
+        Args:
+            solar_distribution: Text desribing how EnergyPlus should treat beam solar
+                radiation and reflectances from surfaces that strike the building surfaces.
+                Default: FullInteriorAndExteriorWithReflections. Choose from the following:
+                    * MinimalShadowing
+                    * FullExterior
+                    * FullInteriorAndExterior
+                    * FullExteriorWithReflections
+                    * FullInteriorAndExteriorWithReflections
+            calculation_method: Text describing how the solar and shading models are
+                calculated with respect to the time of calculations during the simulation.
+                Default: AverageOverDaysInFrequency. Choose from the following:
+                    * AverageOverDaysInFrequency
+                    * TimestepFrequency
+            calculation_frequency: Integer for the number of days in each period in
+                which a unique shadow calculation will be performed. This field is only
+                used if the AverageOverDaysInFrequency method is used in the previous
+                field. Default: 30.
+            maximum_figures: Integer for the number of figures used in shadow overlaps.
+                Default: 15000.
+        """
+        self.solar_distribution = solar_distribution
+        self.calculation_method = calculation_method
+        self.calculation_frequency = calculation_frequency
+        self.maximum_figures = maximum_figures
+
+    @property
+    def solar_distribution(self):
+        """Get or set text for how solar reflectances from surfaces should be treated.
+
+        Choose from the options below:
+            * MinimalShadowing
+            * FullExterior
+            * FullInteriorAndExterior
+            * FullExteriorWithReflections
+            * FullInteriorAndExteriorWithReflections
+        """
+        return self._solar_distribution
+
+    @solar_distribution.setter
+    def solar_distribution(self, value):
+        clean_input = valid_string(value).lower()
+        for key in self.SOLAR_DISTRIBUTIONS:
+            if key.lower() == clean_input:
+                value = key
+                break
+        else:
+            raise ValueError(
+                'solar_distribution {} is not recognized.\nChoose from the '
+                'following:\n{}'.format(value, self.SOLAR_DISTRIBUTIONS))
+        self._solar_distribution = value
+
+    @property
+    def calculation_method(self):
+        """Get or set text for how the shadows are calculated with respect to time.
+
+        Choose from the options below:
+            * AverageOverDaysInFrequency
+            * TimestepFrequency
+        """
+        return self._calculation_method
+
+    @calculation_method.setter
+    def calculation_method(self, value):
+        clean_input = valid_string(value).lower()
+        for key in self.CALCULATION_METHODS:
+            if key.lower() == clean_input:
+                value = key
+                break
+        else:
+            raise ValueError(
+                'calculation_method {} is not recognized.\nChoose from the '
+                'following:\n{}'.format(value, self.CALCULATION_METHODS))
+        self._calculation_method = value
+
+    @property
+    def calculation_frequency(self):
+        """Get or set a integer for the number of days with unique shadow calculations."""
+        return self._calculation_frequency
+
+    @calculation_frequency.setter
+    def calculation_frequency(self, value):
+        self._calculation_frequency = int_in_range(
+            value, 1, input_name='shadow calculation calculation frequency')
+
+    @property
+    def maximum_figures(self):
+        """Get or set a integer for the number of figures used in shadow overlaps."""
+        return self._maximum_figures
+
+    @maximum_figures.setter
+    def maximum_figures(self, value):
+        self._maximum_figures = int_in_range(
+            value, 200, input_name='shadow calculation maximum figures')
+
+    @classmethod
+    def from_idf(cls, idf_string,
+                 solar_distribution='FullInteriorAndExteriorWithReflections'):
+        """Create a ShadowCalculation object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                ShadowCalculation definition.
+            solar_distribution: Text desribing how EnergyPlus should treat beam solar
+                radiation and reflectances from surfaces that strike the building surfaces.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'ShadowCalculation,')
+
+        # extract the properties from the string
+        calculation_method = 'AverageOverDaysInFrequency'
+        calculation_frequency = 20
+        maximum_figures = 15000
+        try:
+            calculation_method = ep_strs[0] if ep_strs[0] != '' else calculation_method
+            calculation_frequency = ep_strs[1] if ep_strs[1] != '' else 20
+            maximum_figures = ep_strs[2] if ep_strs[2] != '' else 15000
+        except IndexError:
+            pass  # shorter ShadowCalculation definition
+
+        # return the object and the zone name for the object
+        return cls(solar_distribution, calculation_method, calculation_frequency,
+                   maximum_figures)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a ShadowCalculation object from a dictionary.
+
+        Args:
+            data: A ShadowCalculation dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "ShadowCalculation",
+            "solar_distribution": 'FullInteriorAndExteriorWithReflections',
+            "calculation_method": 'AverageOverDaysInFrequency',
+            "calculation_frequency": 30,
+            "maximum_figures": 15000
+            }
+        """
+        assert data['type'] == 'ShadowCalculation', \
+            'Expected ShadowCalculation dictionary. Got {}.'.format(data['type'])
+        solar_distribution = data['solar_distribution'] if \
+            'solar_distribution' in data else 'FullInteriorAndExteriorWithReflections'
+        calculation_method = data['calculation_method'] if \
+            'calculation_method' in data else 'AverageOverDaysInFrequency'
+        calculation_frequency = data['calculation_frequency'] if \
+            'calculation_frequency' in data else 30
+        maximum_figures = data['maximum_figures'] if \
+            'maximum_figures' in data else 15000
+        return cls(solar_distribution, calculation_method, calculation_frequency,
+                   maximum_figures)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the ShadowCalculation."""
+        values = (self.calculation_method, self.calculation_frequency,
+                  self.maximum_figures)
+        comments = ('calculation method', 'calculation frequency', 'maximum figures')
+        return generate_idf_string('ShadowCalculation', values, comments)
+
+    def to_dict(self):
+        """ShadowCalculation dictionary representation."""
+        return {
+            'type': 'ShadowCalculation',
+            'solar_distribution': self.solar_distribution,
+            'calculation_method': self.calculation_method,
+            'calculation_frequency': self.calculation_frequency,
+            'maximum_figures': self.maximum_figures
+        }
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __copy__(self):
+        return ShadowCalculation(self.solar_distribution, self.calculation_method,
+                                 self.calculation_frequency, self.maximum_figures)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.solar_distribution, self.calculation_method,
+                self.calculation_frequency, self.maximum_figures)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, ShadowCalculation) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()

--- a/honeybee_energy/simulation/sizing.py
+++ b/honeybee_energy/simulation/sizing.py
@@ -1,0 +1,137 @@
+# coding=utf-8
+"""Global sizing parameters dictating scaling factors for all zone peak loads."""
+from __future__ import division
+
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
+
+from honeybee.typing import float_positive
+
+
+class SizingParameter(object):
+    """Global sizing parameters dictating scaling factors for all zone peak loads.
+
+    Properties:
+        * heating_factor
+        * cooling_factor
+    """
+    __slots__ = ('_heating_factor', '_cooling_factor')
+
+    def __init__(self, heating_factor=1.25, cooling_factor=1.15):
+        """Initialize SizingParameter.
+
+        Args:
+            heating_factor: A number that will get multiplied by the peak heating load
+                for each zone in the model in order to size the heating system for
+                the model. Must be greater than 0. Default: 1.25.
+            cooling_factor: A number that will get multiplied by the peak cooling load
+                for each zone in the model in order to size the cooling system for
+                the model. Must be greater than 0. Default: 1.15.
+        """
+        self.heating_factor = heating_factor
+        self.cooling_factor = cooling_factor
+
+    @property
+    def heating_factor(self):
+        """Get or set a number that will get multiplied by the peak heating loads."""
+        return self._heating_factor
+
+    @heating_factor.setter
+    def heating_factor(self, value):
+        self._heating_factor = float_positive(value, 'sizing parameter heating factor')
+        assert self._heating_factor != 0, 'SizingParameter heating factor cannot be 0.'
+
+    @property
+    def cooling_factor(self):
+        """Get or set a number that will get multiplied by the peak cooling loads."""
+        return self._cooling_factor
+
+    @cooling_factor.setter
+    def cooling_factor(self, value):
+        self._cooling_factor = float_positive(value, 'sizing parameter cooling factor')
+        assert self._cooling_factor != 0, 'SizingParameter cooling factor cannot be 0.'
+
+    @classmethod
+    def from_idf(cls, idf_string):
+        """Create a SizingParameter object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus
+                SizingParameters definition.
+        """
+        # check the inputs
+        ep_strs = parse_idf_string(idf_string, 'SizingParameters,')
+
+        # extract the properties from the string
+        heating_factor = 1.25
+        cooling_factor = 1.15
+        try:
+            heating_factor = ep_strs[0] if ep_strs[0] != '' else 1.25
+            cooling_factor = ep_strs[1] if ep_strs[1] != '' else 1.15
+        except IndexError:
+            pass  # shorter SizingParameters definition
+
+        # return the object and the zone name for the object
+        return cls(heating_factor, cooling_factor)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a SizingParameter object from a dictionary.
+
+        Args:
+            data: A SizingParameter dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "SizingParameter",
+            "heating_factor": 1.25,
+            "cooling_factor": 1.15
+            }
+        """
+        assert data['type'] == 'SizingParameter', \
+            'Expected SizingParameter dictionary. Got {}.'.format(data['type'])
+        heating_factor = data['heating_factor'] if 'heating_factor' in data else 1.25
+        cooling_factor = data['cooling_factor'] if 'cooling_factor' in data else 1.15
+        return cls(heating_factor, cooling_factor)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the SizingParameters."""
+        values = (self.heating_factor, self.cooling_factor)
+        comments = ('heating factor', 'cooling factor')
+        return generate_idf_string('SizingParameters', values, comments)
+
+    def to_dict(self):
+        """SizingParameter dictionary representation."""
+        return {
+            'type': 'SizingParameter',
+            'heating_factor': self.heating_factor,
+            'cooling_factor': self.cooling_factor
+        }
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __copy__(self):
+        return SizingParameter(self.heating_factor, self.cooling_factor)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.heating_factor, self.cooling_factor)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, SizingParameter) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()

--- a/honeybee_energy/simulationparameter.py
+++ b/honeybee_energy/simulationparameter.py
@@ -1,0 +1,298 @@
+# coding=utf-8
+"""Complete set of EnergyPlus Simulation Settings."""
+from __future__ import division
+
+from .simulation.runperiod import RunPeriod
+from .simulation.control import SimulationControl
+from .simulation.shadowcalculation import ShadowCalculation
+from .simulation.sizing import SizingParameter
+from .reader import parse_idf_string
+from .writer import generate_idf_string
+
+from honeybee.typing import int_positive
+
+import re
+
+
+class SimulationParameter(object):
+    """Complete set of EnergyPlus Simulation Settings.
+
+    Properties:
+        * run_period
+        * timestep
+        * simulation_control
+        * shadow_calculation
+        * sizing_parameter
+    """
+    __slots__ = ('_run_period', '_timestep', '_simulation_control',
+                 '_shadow_calculation', '_sizing_parameter')
+    VALIDTIMESTEPS = (1, 2, 3, 4, 5, 6, 10, 12, 15, 20, 30, 60)
+
+    def __init__(self, run_period=None, timestep=6, simulation_control=None,
+                 shadow_calculation=None, sizing_parameter=None):
+        """Initialize SimulationParameter.
+
+        Args:
+            run_period: A RunPeriod object to describe the time period over which to
+                run the simulation. Default: Run for the whole year starting on Sunday.
+            timestep: An integer for the number of timesteps per hour at which the
+                calculation will be run. Default: 6.
+            simulation_control: A SimulationControl object that describes which types
+                of calculations to run. Default: perform a sizing calculation but only
+                run the simulation for the RunPeriod.
+            shadow_calculation: A ShadowCalculation object describing settings for
+                the EnergyPlus Shadow Calculation. Default: Average over 30 days with
+                FullInteriorAndExteriorWithReflections.
+            sizing_parameter: A SizingParameter object with factors that will get
+                multiplied by the peak heating and cooling loads. Default: 1.25 for
+                heating; 1.15 for cooling.
+        """
+        self.run_period = run_period
+        self.timestep = timestep
+        self.simulation_control = simulation_control
+        self.shadow_calculation = shadow_calculation
+        self.sizing_parameter = sizing_parameter
+
+    @property
+    def run_period(self):
+        """Get or set a RunPeriod object for the time period to run the simulation."""
+        return self._run_period
+
+    @run_period.setter
+    def run_period(self, value):
+        if value is not None:
+            assert isinstance(value, RunPeriod), 'Expected RunPeriod for ' \
+                'SimulationParameter run_period. Got {}.'.format(type(value))
+            self._run_period = value
+        else:
+            self._run_period = RunPeriod()
+
+    @property
+    def timestep(self):
+        """Get or set a integer for the number of days with unique shadow calculations.
+        """
+        return self._timestep
+
+    @timestep.setter
+    def timestep(self, value):
+        value = int_positive(value, 'simulation parameter timestep')
+        assert value in self.VALIDTIMESTEPS, 'SimulationParameter timestep "{}" is ' \
+            'invalid. Must be one of the following:{}'.format(value, self.VALIDTIMESTEPS)
+        self._timestep = value
+
+    @property
+    def simulation_control(self):
+        """Get or set a SimulationControl object for which types of calculations to run.
+        """
+        return self._simulation_control
+
+    @simulation_control.setter
+    def simulation_control(self, value):
+        if value is not None:
+            assert isinstance(value, SimulationControl), 'Expected SimulationControl ' \
+                'for SimulationParameter run_period. Got {}.'.format(type(value))
+            self._simulation_control = value
+        else:
+            self._simulation_control = SimulationControl()
+
+    @property
+    def shadow_calculation(self):
+        """Get or set a ShadowCalculation object with settings for the shadow calculation.
+        """
+        return self._shadow_calculation
+
+    @shadow_calculation.setter
+    def shadow_calculation(self, value):
+        if value is not None:
+            assert isinstance(value, ShadowCalculation), 'Expected ShadowCalculation ' \
+                'for SimulationParameter shadow_calculation. Got {}.'.format(type(value))
+            self._shadow_calculation = value
+        else:
+            self._shadow_calculation = ShadowCalculation()
+
+    @property
+    def sizing_parameter(self):
+        """Get or set a SizingParameter object with factors for the peak loads."""
+        return self._sizing_parameter
+
+    @sizing_parameter.setter
+    def sizing_parameter(self, value):
+        if value is not None:
+            assert isinstance(value, SizingParameter), 'Expected SizingParameter ' \
+                'for SimulationParameter sizing_parameter. Got {}.'.format(type(value))
+            self._sizing_parameter = value
+        else:
+            self._sizing_parameter = SizingParameter()
+
+    @classmethod
+    def from_idf(cls, idf_string):
+        """Create a SimulationParameter object from an EnergyPlus IDF text string.
+
+        Args:
+            idf_string: A text string with all IDF objects that should be included
+                in the resulting SimulationParameter object. Note that, unlike other
+                from_idf methods throughout honeybee_energy, this method can have
+                multiple IDF objects within the idf_string. Any object in the idf_string
+                that is not relevant to SimulationParameter will be ignored by this
+                method. So the input idf_string can simply be the entire file contents
+                of an IDF.
+        """
+        # Regex patterns for the varios objects comprising the SimulationParameter
+        runper_pattern = re.compile(r"(?i)(RunPeriod,[\s\S]*?;)")
+        holiday_pattern = re.compile(r"(?i)(RunPeriodControl:SpecialDays,[\s\S]*?;)")
+        dls_pattern = re.compile(r"(?i)(RunPeriodControl:DaylightSavingTime,[\s\S]*?;)")
+        timestep_pattern = re.compile(r"(?i)(Timestep,[\s\S]*?;)")
+        sh_calc_pattern = re.compile(r"(?i)(ShadowCalculation,[\s\S]*?;)")
+        bldg_pattern = re.compile(r"(?i)(Building,[\s\S]*?;)")
+        control_pattern = re.compile(r"(?i)(SimulationControl,[\s\S]*?;)")
+        sizing_pattern = re.compile(r"(?i)(SizingParameters,[\s\S]*?;)")
+
+        # process the RunPeriod within the idf_string
+        try:
+            run_period_str = runper_pattern.findall(idf_string)[0]
+        except IndexError:  # No RunPeriod in the file. Default to the whole year.
+            run_period_str = None
+            run_period = None
+        if run_period_str is not None:
+            holidays_str = holiday_pattern.findall(idf_string)
+            if len(holidays_str) == 0:
+                holidays_str = None
+            try:
+                dls_str = dls_pattern.findall(idf_string)[0]
+            except IndexError:  # No DalyightSavingTime in the file.
+                dls_str = None
+            run_period = RunPeriod.from_idf(run_period_str, holidays_str, dls_str)
+
+        # process the Timestep within the idf_string
+        try:
+            timestep_str = timestep_pattern.findall(idf_string)[0]
+            timestep = int(parse_idf_string(timestep_str)[0])
+        except IndexError:  # No Timestep in the file. Default to 6.
+            timestep = 6
+
+        # process the SimulationControl within the idf_string
+        try:
+            sim_control_str = control_pattern.findall(idf_string)[0]
+            sim_control = SimulationControl.from_idf(sim_control_str)
+        except IndexError:  # No SimulationControl in the file.
+            sim_control = None
+
+        # process the ShadowCalculation within the idf_string
+        try:
+            sh_calc_str = sh_calc_pattern.findall(idf_string)[0]
+        except IndexError:  # No ShadowCalculation in the file.
+            sh_calc_str = None
+            shadow_calc = None
+        if sh_calc_str is not None:
+            try:
+                bldg_str = bldg_pattern.findall(idf_string)[0]
+                solar_dist = bldg_str[5] if bldg_str[5] != '' else 'FullExterior'
+            except IndexError:  # No Building in the file. Use honeybee default.
+                solar_dist = 'FullInteriorAndExteriorWithReflections'
+            shadow_calc = ShadowCalculation.from_idf(sh_calc_str, solar_dist)
+
+        # process the SizingParameter within the idf_string
+        try:
+            sizing_str = sizing_pattern.findall(idf_string)[0]
+            sizing_par = SizingParameter.from_idf(sizing_str)
+        except IndexError:  # No SizingParameter in the file.
+            sizing_par = None
+
+        return cls(run_period, timestep, sim_control, shadow_calc, sizing_par)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a SimulationParameter object from a dictionary.
+
+        Args:
+            data: A SimulationParameter dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "SimulationParameter",
+            "run_period": {}, // Honeybee RunPeriod disctionary
+            "timestep": 6, // Integer for the simulation timestep
+            "simulation_control": {}, // Honeybee SimulationControl dictionary
+            "shadow_calculation": {}, // Honeybee ShadowCalculation dictionary
+            "sizing_parameter": {} // Honeybee SizingParameter dictionary
+            }
+        """
+        assert data['type'] == 'SimulationParameter', \
+            'Expected SimulationParameter dictionary. Got {}.'.format(data['type'])
+
+        timestep = data['timestep'] if 'timestep' in data else 6
+        run_period = None
+        if 'run_period' in data and data['run_period'] is not None:
+            run_period = RunPeriod.from_dict(data['run_period'])
+        simulation_control = None
+        if 'simulation_control' in data and data['simulation_control'] is not None:
+            simulation_control = SimulationControl.from_dict(data['simulation_control'])
+        shadow_calculation = None
+        if 'shadow_calculation' in data and data['shadow_calculation'] is not None:
+            shadow_calculation = ShadowCalculation.from_dict(data['shadow_calculation'])
+        sizing_parameter = None
+        if 'sizing_parameter' in data and data['sizing_parameter'] is not None:
+            sizing_parameter = SizingParameter.from_dict(data['sizing_parameter'])
+
+        return cls(run_period, timestep, simulation_control,
+                   shadow_calculation, sizing_parameter)
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the SimulationParameter.
+
+        Note that this string is a concatenation of the IDF strings for all of the
+        objects that make up the SimulationParameter (ie. RunPeriod, SimulationControl,
+        etc.),
+        """
+        header_str = '!-   ==============  SIMULATION PARAMETERS ==============\n'
+        run_period_str, holidays, daylight_saving = self.run_period.to_idf()
+        holiday_str = '/n/n'.join(holidays) if holidays is not None else ''
+        daylight_saving_time_str = daylight_saving if daylight_saving is not None else ''
+        timestep_str = generate_idf_string(
+            'Timestep', [self.timestep], ['timesteps per hour'])
+        sim_control_str = self.simulation_control.to_idf()
+        shadow_calc_str = self.shadow_calculation.to_idf()
+        sizing_par_str = self.sizing_parameter.to_idf()
+
+        return '/n/n'.join([header_str, sim_control_str, shadow_calc_str, timestep_str,
+                           run_period_str, holiday_str, daylight_saving_time_str,
+                           sizing_par_str])
+
+    def to_dict(self):
+        """SimulationParameter dictionary representation."""
+        return {
+            'type': 'SimulationParameter',
+            'run_period': self.run_period.to_dict(),
+            'timestep': self.timestep,
+            'simulation_control': self.simulation_control.to_dict(),
+            'shadow_calculation': self.shadow_calculation.to_dict(),
+            'sizing_parameter': self.sizing_parameter.to_dict()
+        }
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def __copy__(self):
+        return SimulationParameter(
+            self.run_period.duplicate(), self.timestep,
+            self.simulation_control.duplicate(), self.shadow_calculation.duplicate(),
+            self.sizing_parameter.duplicate())
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (hash(self.run_period), self.timestep, hash(self.simulation_control),
+                hash(self.shadow_calculation), hash(self.sizing_parameter))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, SimulationParameter) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return 'Energy SimulationParameter:'

--- a/tests/idealair_test.py
+++ b/tests/idealair_test.py
@@ -91,7 +91,7 @@ def test_ideal_air_init_from_idf():
     assert zone_name == rebuilt_zone_name
 
 
-def test_lighting_dict_methods():
+def test_ideal_air_dict_methods():
     """Test the to/from dict methods."""
     ideal_air = IdealAirSystem(sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
 

--- a/tests/simulation_control_test.py
+++ b/tests/simulation_control_test.py
@@ -1,0 +1,69 @@
+# coding=utf-8
+from honeybee_energy.simulation.control import SimulationControl
+
+import pytest
+
+
+def test_simulation_control_init():
+    """Test the initialization of SimulationControl and basic properties."""
+    sim_control = SimulationControl()
+    str(sim_control)  # test the string representation
+
+    assert sim_control.do_zone_sizing
+    assert sim_control.do_system_sizing
+    assert sim_control.do_plant_sizing
+    assert not sim_control.run_for_sizing_periods
+    assert sim_control.run_for_run_periods
+
+
+def test_simulation_control_setability():
+    """Test the setting of properties of SimulationControl."""
+    sim_control = SimulationControl()
+
+    sim_control.do_zone_sizing = False
+    assert not sim_control.do_zone_sizing
+    sim_control.do_system_sizing = False
+    assert not sim_control.do_system_sizing
+    sim_control.do_plant_sizing = False
+    assert not sim_control.do_plant_sizing
+    sim_control.run_for_sizing_periods = True
+    assert sim_control.run_for_sizing_periods
+    sim_control.run_for_run_periods = False
+    assert not sim_control.run_for_run_periods
+
+
+def test_simulation_control_equality():
+    """Test the equality of SimulationControl objects."""
+    sim_control = SimulationControl()
+    sim_control_dup = sim_control.duplicate()
+    sim_control_alt = SimulationControl(run_for_sizing_periods=True,
+                                        run_for_run_periods=False)
+
+    assert sim_control is sim_control
+    assert sim_control is not sim_control_dup
+    assert sim_control == sim_control_dup
+    sim_control_dup.run_for_sizing_periods = True
+    assert sim_control != sim_control_dup
+    assert sim_control != sim_control_alt
+
+
+def test_simulation_control_init_from_idf():
+    """Test the initialization of SimulationControl from_idf."""
+    sim_control = SimulationControl(run_for_sizing_periods=True,
+                                    run_for_run_periods=False)
+
+    idf_str = sim_control.to_idf()
+    rebuilt_sim_control = SimulationControl.from_idf(idf_str)
+    assert sim_control == rebuilt_sim_control
+    assert rebuilt_sim_control.to_idf() == idf_str
+
+
+def test_simulation_control_dict_methods():
+    """Test the to/from dict methods."""
+    sim_control = SimulationControl(run_for_sizing_periods=True,
+                                    run_for_run_periods=False)
+
+    cntrl_dict = sim_control.to_dict()
+    new_sim_control = SimulationControl.from_dict(cntrl_dict)
+    assert new_sim_control == sim_control
+    assert cntrl_dict == new_sim_control.to_dict()

--- a/tests/simulation_runperiod_test.py
+++ b/tests/simulation_runperiod_test.py
@@ -1,0 +1,144 @@
+# coding=utf-8
+from honeybee_energy.simulation.runperiod import RunPeriod
+from honeybee_energy.simulation.daylightsaving import DaylightSavingTime
+
+from ladybug.dt import Date
+
+import pytest
+
+
+def test_daylight_saving_time_init():
+    """Test the initialization of DaylightSavingTime and basic properties."""
+    daylight_save = DaylightSavingTime()
+    str(daylight_save)  # test the string representation
+
+    assert daylight_save.start_date == Date(3, 12)
+    assert daylight_save.end_date == Date(11, 5)
+
+
+def test_daylight_saving_time_setability():
+    """Test the setting of properties of DaylightSavingTime."""
+    daylight_save = DaylightSavingTime()
+
+    daylight_save.start_date = Date(3, 10)
+    assert daylight_save.start_date == Date(3, 10)
+    daylight_save.end_date = Date(11, 3)
+    assert daylight_save.end_date == Date(11, 3)
+
+    with pytest.raises(AssertionError):
+        daylight_save.start_date = Date(11, 10)
+    with pytest.raises(AssertionError):
+        daylight_save.start_date = Date(3, 10, True)
+
+
+def test_daylight_saving_time_equality():
+    """Test the equality of DaylightSavingTime objects."""
+    daylight_save = DaylightSavingTime()
+    daylight_save_dup = daylight_save.duplicate()
+    daylight_save_alt = DaylightSavingTime(Date(3, 10), Date(11, 3))
+
+    assert daylight_save is daylight_save
+    assert daylight_save is not daylight_save_dup
+    assert daylight_save == daylight_save_dup
+    daylight_save_dup.start_date = Date(3, 10)
+    assert daylight_save != daylight_save_dup
+    assert daylight_save != daylight_save_alt
+
+
+def test_simulation_control_init_from_idf():
+    """Test the initialization of SimulationControl from_idf."""
+    daylight_save = DaylightSavingTime(Date(3, 10), Date(11, 3))
+
+    idf_str = daylight_save.to_idf()
+    rebuilt_daylight_save = DaylightSavingTime.from_idf(idf_str)
+    assert daylight_save == rebuilt_daylight_save
+    assert rebuilt_daylight_save.to_idf() == idf_str
+
+
+def test_simulation_control_dict_methods():
+    """Test the to/from dict methods."""
+    daylight_save = DaylightSavingTime(Date(3, 10), Date(11, 3))
+
+    ds_dict = daylight_save.to_dict()
+    new_daylight_save = DaylightSavingTime.from_dict(ds_dict)
+    assert new_daylight_save == daylight_save
+    assert ds_dict == new_daylight_save.to_dict()
+
+
+def test_run_period_init():
+    """Test the initialization of RunPeriod and basic properties."""
+    run_period = RunPeriod()
+    str(run_period)  # test the string representation
+
+    assert run_period.start_date == Date(1, 1)
+    assert run_period.end_date == Date(12, 31)
+    assert run_period.start_day_of_week == 'Sunday'
+    assert run_period.holidays is None
+    assert run_period.daylight_saving_time is None
+    assert run_period.is_leap_year is False
+
+
+def test_run_period_setability():
+    """Test the setting of properties of RunPeriod."""
+    run_period = RunPeriod()
+
+    run_period.start_date = Date(1, 1)
+    assert run_period.start_date == Date(1, 1)
+    run_period.end_date = Date(6, 21)
+    assert run_period.end_date == Date(6, 21)
+    run_period.start_day_of_week = 'Monday'
+    assert run_period.start_day_of_week == 'Monday'
+    run_period.holidays = (Date(1, 1), Date(3, 17))
+    assert run_period.holidays == (Date(1, 1), Date(3, 17))
+    run_period.daylight_saving_time = DaylightSavingTime()
+    assert run_period.daylight_saving_time == DaylightSavingTime()
+    with pytest.raises(AssertionError):
+        run_period.start_date = Date(11, 10)
+    with pytest.raises(AssertionError):
+        run_period.start_date = Date(3, 10, True)
+    run_period.is_leap_year = True
+    assert run_period.is_leap_year
+
+
+def test_run_period_equality():
+    """Test the equality of RunPeriod objects."""
+    run_period = RunPeriod()
+    run_period_dup = run_period.duplicate()
+    run_period_alt = RunPeriod(end_date=Date(6, 21))
+
+    assert run_period is run_period
+    assert run_period is not run_period_dup
+    assert run_period == run_period_dup
+    run_period_dup.start_day_of_week = 'Monday'
+    assert run_period != run_period_dup
+    assert run_period != run_period_alt
+
+
+def test_run_period_init_from_idf():
+    """Test the initialization of RunPeriod from_idf."""
+    run_period = RunPeriod()
+    run_period.start_date = Date(1, 1)
+    run_period.end_date = Date(6, 21)
+    run_period.start_day_of_week = 'Monday'
+    run_period.holidays = (Date(1, 1), Date(3, 17))
+    run_period.daylight_saving_time = DaylightSavingTime()
+
+    rp_str, holidays, dst = run_period.to_idf()
+    rebuilt_run_period = RunPeriod.from_idf(rp_str, holidays, dst)
+    assert run_period == rebuilt_run_period
+    assert rebuilt_run_period.to_idf() == (rp_str, holidays, dst)
+
+
+def test_run_period_dict_methods():
+    """Test the to/from dict methods."""
+    run_period = RunPeriod()
+    run_period.start_date = Date(1, 1)
+    run_period.end_date = Date(6, 21)
+    run_period.start_day_of_week = 'Monday'
+    run_period.holidays = (Date(1, 1), Date(3, 17))
+    run_period.daylight_saving_time = DaylightSavingTime()
+
+    rp_dict = run_period.to_dict()
+    new_run_period = RunPeriod.from_dict(rp_dict)
+    assert new_run_period == run_period
+    assert rp_dict == new_run_period.to_dict()

--- a/tests/simulation_shadowcalculation_test.py
+++ b/tests/simulation_shadowcalculation_test.py
@@ -1,0 +1,63 @@
+# coding=utf-8
+from honeybee_energy.simulation.shadowcalculation import ShadowCalculation
+
+import pytest
+
+
+def test_shadow_calculation_init():
+    """Test the initialization of ShadowCalculation and basic properties."""
+    shadow_calc = ShadowCalculation()
+    str(shadow_calc)  # test the string representation
+
+    assert shadow_calc.solar_distribution == 'FullInteriorAndExteriorWithReflections'
+    assert shadow_calc.calculation_method == 'AverageOverDaysInFrequency'
+    assert shadow_calc.calculation_frequency == 30
+    assert shadow_calc.maximum_figures == 15000
+
+
+def test_shadow_calculation_setability():
+    """Test the setting of properties of ShadowCalculation."""
+    shadow_calc = ShadowCalculation()
+
+    shadow_calc.solar_distribution = 'fullexterior'
+    assert shadow_calc.solar_distribution == 'FullExterior'
+    shadow_calc.calculation_method = 'timestepfrequency'
+    assert shadow_calc.calculation_method == 'TimestepFrequency'
+    shadow_calc.calculation_frequency = 20
+    assert shadow_calc.calculation_frequency == 20
+    shadow_calc.maximum_figures = 5000
+    assert shadow_calc.maximum_figures == 5000
+
+
+def test_simulation_control_equality():
+    """Test the equality of SimulationControl objects."""
+    shadow_calc = ShadowCalculation()
+    shadow_calc_dup = shadow_calc.duplicate()
+    shadow_calc_alt = ShadowCalculation(solar_distribution='FullExteriorWithReflections')
+
+    assert shadow_calc is shadow_calc
+    assert shadow_calc is not shadow_calc_dup
+    assert shadow_calc == shadow_calc_dup
+    shadow_calc_dup.solar_distribution = 'FullExterior'
+    assert shadow_calc != shadow_calc_dup
+    assert shadow_calc != shadow_calc_alt
+
+
+def test_simulation_control_init_from_idf():
+    """Test the initialization of SimulationControl from_idf."""
+    shadow_calc = ShadowCalculation(calculation_frequency=20)
+
+    idf_str = shadow_calc.to_idf()
+    rebuilt_shadow_calc = ShadowCalculation.from_idf(idf_str)
+    assert shadow_calc == rebuilt_shadow_calc
+    assert rebuilt_shadow_calc.to_idf() == idf_str
+
+
+def test_simulation_control_dict_methods():
+    """Test the to/from dict methods."""
+    shadow_calc = ShadowCalculation(calculation_frequency=20)
+
+    shadow_dict = shadow_calc.to_dict()
+    new_shadow_calc = ShadowCalculation.from_dict(shadow_dict)
+    assert new_shadow_calc == shadow_calc
+    assert shadow_dict == new_shadow_calc.to_dict()

--- a/tests/simulation_sizing_test.py
+++ b/tests/simulation_sizing_test.py
@@ -1,0 +1,57 @@
+# coding=utf-8
+from honeybee_energy.simulation.sizing import SizingParameter
+
+import pytest
+
+
+def test_sizing_parameter_init():
+    """Test the initialization of SizingParameter and basic properties."""
+    sizing = SizingParameter()
+    str(sizing)  # test the string representation
+
+    assert sizing.heating_factor == 1.25
+    assert sizing.cooling_factor == 1.15
+
+
+def test_sizing_parameter_setability():
+    """Test the setting of properties of SizingParameter."""
+    sizing = SizingParameter()
+
+    sizing.heating_factor = 1
+    assert sizing.heating_factor == 1
+    sizing.cooling_factor = 1
+    assert sizing.cooling_factor == 1
+
+
+def test_sizing_parameter_equality():
+    """Test the equality of SizingParameter objects."""
+    sizing = SizingParameter()
+    sizing_dup = sizing.duplicate()
+    sizing_alt = SizingParameter(1)
+
+    assert sizing is sizing
+    assert sizing is not sizing_dup
+    assert sizing == sizing_dup
+    sizing_dup.cooling_factor = 1
+    assert sizing != sizing_dup
+    assert sizing != sizing_alt
+
+
+def test_simulation_control_init_from_idf():
+    """Test the initialization of SimulationControl from_idf."""
+    sizing = SizingParameter(1)
+
+    idf_str = sizing.to_idf()
+    rebuilt_sizing = SizingParameter.from_idf(idf_str)
+    assert sizing == rebuilt_sizing
+    assert rebuilt_sizing.to_idf() == idf_str
+
+
+def test_simulation_control_dict_methods():
+    """Test the to/from dict methods."""
+    sizing = SizingParameter(1)
+
+    sizing_dict = sizing.to_dict()
+    new_sizing = SizingParameter.from_dict(sizing_dict)
+    assert new_sizing == sizing
+    assert sizing_dict == new_sizing.to_dict()

--- a/tests/simulationparameter_test.py
+++ b/tests/simulationparameter_test.py
@@ -1,0 +1,97 @@
+# coding=utf-8
+from honeybee_energy.simulationparameter import SimulationParameter
+from honeybee_energy.simulation.runperiod import RunPeriod
+from honeybee_energy.simulation.control import SimulationControl
+from honeybee_energy.simulation.shadowcalculation import ShadowCalculation
+from honeybee_energy.simulation.sizing import SizingParameter
+
+from ladybug.dt import Date
+
+import pytest
+
+
+def test_simulation_parameter_init():
+    """Test the initialization of SimulationParameter and basic properties."""
+    sim_par = SimulationParameter()
+    str(sim_par)  # test the string representation
+
+    assert sim_par.run_period == RunPeriod()
+    assert sim_par.timestep == 6
+    assert sim_par.simulation_control == SimulationControl()
+    assert sim_par.shadow_calculation == ShadowCalculation()
+    assert sim_par.sizing_parameter == SizingParameter()
+
+
+def test_simulation_parameter_setability():
+    """Test the setting of properties of SimulationParameter."""
+    sim_par = SimulationParameter()
+
+    run_period = RunPeriod(Date(1, 1), Date(6, 21))
+    sim_par.run_period = run_period
+    assert sim_par.run_period == run_period
+    sim_par.timestep = 4
+    assert sim_par.timestep == 4
+    sim_control_alt = SimulationControl(run_for_sizing_periods=True,
+                                        run_for_run_periods=False)
+    sim_par.simulation_control = sim_control_alt
+    assert sim_par.simulation_control == sim_control_alt
+    shadow_calc_alt = ShadowCalculation('FullExteriorWithReflections')
+    sim_par.shadow_calculation = shadow_calc_alt
+    assert sim_par.shadow_calculation == shadow_calc_alt
+    sizing_alt = SizingParameter(1, 1)
+    sim_par.sizing_parameter = sizing_alt
+    assert sim_par.sizing_parameter == sizing_alt
+
+
+def test_simulation_parameter_equality():
+    """Test the equality of SimulationParameter objects."""
+    sim_par = SimulationParameter()
+    sim_par_dup = sim_par.duplicate()
+    sim_par_alt = SimulationParameter(timestep=4)
+
+    assert sim_par is sim_par
+    assert sim_par is not sim_par_dup
+    assert sim_par == sim_par_dup
+    sim_par_dup.timestep = 12
+    assert sim_par != sim_par_dup
+    assert sim_par != sim_par_alt
+
+
+def test_simulation_parameter_init_from_idf():
+    """Test the initialization of SimulationParameter from_idf."""
+    sim_par = SimulationParameter()
+    run_period = RunPeriod(Date(1, 1), Date(6, 21))
+    sim_par.run_period = run_period
+    sim_par.timestep = 4
+    sim_control_alt = SimulationControl(run_for_sizing_periods=True,
+                                        run_for_run_periods=False)
+    sim_par.simulation_control = sim_control_alt
+    shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
+    sim_par.shadow_calculation = shadow_calc_alt
+    sizing_alt = SizingParameter(1, 1)
+    sim_par.sizing_parameter = sizing_alt
+
+    idf_str = sim_par.to_idf()
+    rebuilt_sim_par = SimulationParameter.from_idf(idf_str)
+    assert sim_par == rebuilt_sim_par
+    assert rebuilt_sim_par.to_idf() == idf_str
+
+
+def test_simulation_parameter_dict_methods():
+    """Test the to/from dict methods."""
+    sim_par = SimulationParameter()
+    run_period = RunPeriod(Date(1, 1), Date(6, 21))
+    sim_par.run_period = run_period
+    sim_par.timestep = 4
+    sim_control_alt = SimulationControl(run_for_sizing_periods=True,
+                                        run_for_run_periods=False)
+    sim_par.simulation_control = sim_control_alt
+    shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
+    sim_par.shadow_calculation = shadow_calc_alt
+    sizing_alt = SizingParameter(1, 1)
+    sim_par.sizing_parameter = sizing_alt
+
+    sim_par_dict = sim_par.to_dict()
+    new_sim_par = SimulationParameter.from_dict(sim_par_dict)
+    assert new_sim_par == sim_par
+    assert sim_par_dict == new_sim_par.to_dict()


### PR DESCRIPTION
This commit adds all of the objects needed to describe basic parameters of the EnergyPlus simulation including:
* RunPeriod (including start day of week, holidays and daylight savings time)
* Timestep
* ShadowCalculation
* SimulationControl
* SizingParameter

@mostaphaRoudsari , all of the code here is ready for review but I still have to write tests for all of the objects (I will do this soon).

In addition to reviewing the code, I could use your thoughts on one structural decision that I know relates to how things will run on the cloud service.  Right now, the `SimulationParameter` schema (with all of the settings needed for the EnergyPlus simulation) is completely separate for the `Model` schema.  However, we know that at the end of the day, all of this info ends up in the same OSM and IDF. So we could just add `simulation_parameter` as a property for `Model.energy.properties` and then we would have a `Model` schema with a lot of the same info as an IDF. Here are the pros and cons I could think of for either structure:

**Reasons for putting SimulationParameter as a property of the Model**
- JSON files of `Model` objects would have a 1-to-1 relationship with the IDF or OSM
- Only one .json file needs to be parsed by the energy-model-measure to produce a simulate-able OSM (if the `SimulationParameters` are separate from the `Model`, we may need to pass two separate JSON files).

**Reasons for keeping SimulationParameter separate from Model**
- `SimulationParameters` really have more in common with the other assets (.epw, .ddy) than they have with the `Model`. They really aren't really a part of the design being simulated, which is how we have been thinking of the `Model` up to this point.
- In long iterative runs of design options (ie. different `Models`), the `SimulationParameters` aren't likely to change. So it would be useful to only upload them once and not have to upload them for each and every `Model`.
- If we end up making recipes for different types of Energy simulations (ie. a recipe for annual EUI calculation, a recipe for peak loads, a recipe for load balance graphics, a recipe for thermal comfort mapping), it will be useful to have these simulation parameters coordinated with these recipes and not have to edit all of the `Models` for each recipe that we want to use.