### PR TITLE
refactor(init): Edit __init__.py to load honeybee_energy extensions

### DIFF
--- a/honeybee_energy/__init__.py
+++ b/honeybee_energy/__init__.py
@@ -1,5 +1,24 @@
 """honeybee-energy library."""
-__version__ = '0.0.1'
+import importlib
+import pkgutil
+from honeybee.logutil import get_logger
+
 
 # load all functions that extends honeybee core library
 import honeybee_energy._extend_honeybee
+
+
+logger = get_logger(__name__, filename='honeybee-energy.log')
+
+#  find and import honeybee_energy extensions
+#  this is a critical step to add additional functionalities to honeybee_energy library.
+extensions = {}
+for finder, name, ispkg in pkgutil.iter_modules():
+    if not name.startswith('honeybee_energy_') or name.count('_') > 2:
+        continue
+    try:
+        extensions[name] = importlib.import_module(name)
+    except Exception:
+        logger.exception('Failed to import {0}!'.format(name))
+    else:
+        logger.info('Successfully imported Honeybee-energy plugin: {}'.format(name))

--- a/honeybee_energy/programtype.py
+++ b/honeybee_energy/programtype.py
@@ -259,7 +259,7 @@ class ProgramType(object):
         ventilation = None
         setpoint = None
 
-        if data['occupancy_schedule'] is not None:
+        if 'occupancy_schedule' in data and data['occupancy_schedule'] is not None:
             occ_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['occupancy_schedule']])
             act_sched = ScheduleRuleset.from_standards_dict(
@@ -268,7 +268,7 @@ class ProgramType(object):
             people = People('{}_People'.format(pr_type_name), occ_density,
                             occ_sched, act_sched)
 
-        if data['lighting_schedule'] is not None:
+        if 'lighting_schedule' in data and data['lighting_schedule'] is not None:
             light_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['lighting_schedule']])
             lpd = data['lighting_per_area'] * 10.7639
@@ -277,7 +277,8 @@ class ProgramType(object):
                 data['lighting_fraction_to_return_air'],
                 data['lighting_fraction_radiant'], data['lighting_fraction_visible'])
 
-        if data['electric_equipment_schedule'] is not None:
+        if 'electric_equipment_schedule' in data and \
+                data['electric_equipment_schedule'] is not None:
             eequip_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['electric_equipment_schedule']])
             eepd = data['electric_equipment_per_area'] * 10.7639
@@ -287,7 +288,8 @@ class ProgramType(object):
                 data['electric_equipment_fraction_latent'],
                 data['electric_equipment_fraction_lost'])
 
-        if data['gas_equipment_schedule'] is not None:
+        if 'gas_equipment_schedule' in data and \
+                data['gas_equipment_schedule'] is not None:
             gequip_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['gas_equipment_schedule']])
             gepd = data['gas_equipment_per_area'] * 3.15459
@@ -297,14 +299,16 @@ class ProgramType(object):
                 data['gas_equipment_fraction_latent'],
                 data['gas_equipment_fraction_lost'])
 
-        if data['infiltration_schedule'] is not None:
+        if 'infiltration_schedule' in data and \
+                data['infiltration_schedule'] is not None:
             inf_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['infiltration_schedule']])
             inf = data['infiltration_per_exterior_area'] * 0.00508
             infiltration = Infiltration(
                 '{}_Infiltration'.format(pr_type_name), inf, inf_sched)
 
-        if data['ventilation_standard'] is not None:
+        if 'ventilation_standard' in data and \
+                data['ventilation_standard'] is not None:
             person = data['ventilation_per_person'] * 0.000471947 if \
                 data['ventilation_per_person'] is not None else 0
             area = data['ventilation_per_area'] * 0.00508 if \
@@ -314,7 +318,8 @@ class ProgramType(object):
             ventilation = Ventilation(
                 '{}_Ventilation'.format(pr_type_name), person, area, 0, ach)
 
-        if data['heating_setpoint_schedule'] is not None:
+        if 'heating_setpoint_schedule' in data and \
+                data['heating_setpoint_schedule'] is not None:
             heat_sched = ScheduleRuleset.from_standards_dict(
                 data_schedules[data['heating_setpoint_schedule']])
             cool_sched = ScheduleRuleset.from_standards_dict(

--- a/honeybee_energy/schedule/ruleset.py
+++ b/honeybee_energy/schedule/ruleset.py
@@ -1124,7 +1124,7 @@ class ScheduleRuleset(object):
         Example: "2014-01-01T00:00:00+00:00"
         """
         date_str = date_string.split('T')[0].split('-')
-        return Date(int(date_str[1]), int(date_str[2]))
+        return Date(int(date_str[-2]), int(date_str[-1]))
 
     @staticmethod
     def _type_from_standards_gem(units, category):


### PR DESCRIPTION
There are also a few edits here to the standards gem methods to get them to work with the cleaned data in `honeybee_energy_standards`.  The next PR that I send here will remove these methods, though, and I will have them code-injected form `honeybee_energy_standards`.