### PR TITLE
docs(readme): Update README to current standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,50 @@
 [![Python 2.7](https://img.shields.io/badge/python-2.7-green.svg)](https://www.python.org/downloads/release/python-270/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![IronPython](https://img.shields.io/badge/ironpython-2.7-red.svg)](https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.8/)
 
 # honeybee-energy
-Honeybee plugin for energy simulation
+
+Honeybee extension for energy simulation.
+
+Honeybee-energy leverages the [EnergyPlus](https://github.com/NREL/EnergyPlus)
+simulation engine and the [OpenStudio](https://github.com/NREL/OpenStudio)
+SDK in order to add energy simulation properties and capabilities to
+[honeybee-core](https://github.com/ladybug-tools/honeybee-core).
+
+## Installation
+```console
+pip install honeybee-energy
+```
+
+## QuickStart
+```python
+import honeybee_energy
+
+```
+
+## [API Documentation](http://ladybug-tools.github.io/honeybee-energy/docs)
+
+## Local Development
+1. Clone this repo locally
+```console
+git clone git@github.com:ladybug-tools/honeybee-energy
+
+# or
+
+git clone https://github.com/ladybug-tools/honeybee-energy
+```
+2. Install dependencies:
+```console
+cd honeybee-energy
+pip install -r dev-requirements.txt
+pip install -r requirements.txt
+```
+
+3. Run Tests:
+```console
+python -m pytest tests/
+```
+
+4. Generate Documentation:
+```console
+sphinx-apidoc -f -e -d 4 -o ./docs ./honeybee_energy
+sphinx-build -b html ./docs ./docs/_build/docs
+```

--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -44,7 +44,7 @@ class FaceEnergyProperties(object):
         """
         if self._construction:  # set by user
             return self._construction
-        elif self._host.has_parent:  # set by parent zone
+        elif self._host.has_parent:  # set by parent room
             constr_set = self._host.parent.properties.energy.construction_set
             return constr_set.get_face_construction(
                 self._host.type.name, self._host.boundary_condition.name)

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -87,7 +87,7 @@ class RoomEnergyProperties(object):
     def program_type(self, value):
         if value is not None:
             assert isinstance(value, ProgramType), \
-                'Expected ProgramType for Room.program_type. Got {}'.format(type(value))
+                'Expected ProgramType for Room program_type. Got {}'.format(type(value))
             value.lock()   # lock in case program type has multiple references
         self._program_type = value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core
+honeybee-core>=1.10.0


### PR DESCRIPTION
The readme now includes all of the standard info about how to install and develop with the library. I also took the opportunity to fix a couple of typos in the module and add a minimum version number to the dependencies.