### PR TITLE
fix(to_idf): Include room name in the name of thermostat and ventilation

### DIFF
--- a/honeybee_energy/idealair.py
+++ b/honeybee_energy/idealair.py
@@ -5,11 +5,9 @@ from __future__ import division
 from .reader import parse_idf_string
 from .writer import generate_idf_string
 
-from honeybee._lockable import lockable
 from honeybee.typing import valid_string, float_positive, float_in_range
 
 
-@lockable
 class IdealAirSystem(object):
     """Simple ideal air system object used to condition zones.
 
@@ -27,7 +25,7 @@ class IdealAirSystem(object):
     """
     __slots__ = ('_heating_limit', '_cooling_limit', '_economizer_type',
                  '_demand_controlled_ventilation', '_sensible_heat_recovery',
-                 '_latent_heat_recovery', '_parent', '_locked')
+                 '_latent_heat_recovery', '_parent')
     ECONOMIZER_TYPES = ('NoEconomizer', 'DifferentialDryBulb', 'DifferentialEnthalpy')
 
     def __init__(self, heating_limit='autosize', cooling_limit='autosize',
@@ -64,7 +62,6 @@ class IdealAirSystem(object):
             latent_heat_recovery: A number between 0 and 1 for the effectiveness
                 of latent heat recovery within the system. Default: 0.
         """
-        self._locked = False  # unlocked by default
         self._parent = None
         self.heating_limit = heating_limit
         self.cooling_limit = cooling_limit
@@ -281,7 +278,8 @@ class IdealAirSystem(object):
             dehumid_setpt = ''
         if self._parent.properties.energy.ventilation is not None:
             oa_method = 'DetailedSpecification'
-            oa_name = self._parent.properties.energy.ventilation.name
+            oa_name = '{}..{}'.format(self._parent.properties.energy.ventilation.name,
+                                      self._parent.name)
         else:
             oa_method = 'None'
             oa_name = ''
@@ -294,7 +292,9 @@ class IdealAirSystem(object):
             heat_recovery = 'Sensible'
 
         # return a full IDF string
-        values = (self._parent.name, self._parent.properties.energy.setpoint.name,
+        thermostat = '{}..{}'.format(self._parent.properties.energy.setpoint.name,
+                                     self._parent.name)
+        values = (self._parent.name, thermostat,
                   '', '', '', '', '', h_lim_type, '', heat_limit, c_lim_type,
                   air_limit, cool_limit, '', '', dehumid_type, '', dehumid_setpt,
                   humid_type, humid_setpt, oa_method, '', '', '', oa_name, dcv,

--- a/honeybee_energy/load/ventilation.py
+++ b/honeybee_energy/load/ventilation.py
@@ -268,15 +268,19 @@ class Ventilation(_LoadBase):
                 raise ValueError('Failed to find {} in the schedule_dict.'.format(e))
         return cls(data['name'], person, area, zone, ach, sched)
 
-    def to_idf(self):
+    def to_idf(self, zone_name):
         """IDF string representation of Ventilation object.
 
         Note that this method only outputs a single string for the DesignSpecification:
         OutdoorAir object and, to write everything needed to describe the object
         into an IDF, this object's schedule must also be written.
+
+        Args:
+            zone_name: Text for the zone name that the Ventilation object is assigned to.
         """
         sched = self.schedule.name if self.schedule is not None else ''
-        values = (self.name, 'Sum', self.flow_per_person, self.flow_per_area,
+        vent_obj_name = '{}..{}'.format(self.name, zone_name)
+        values = (vent_obj_name, 'Sum', self.flow_per_person, self.flow_per_area,
                   self.flow_per_zone, self.air_changes_per_hour, sched)
         comments = ('name', 'flow rate method', 'flow per person {m3/s-person}',
                     'flow per floor area {m3/s-m2}', 'flow per zone {m3/s}',

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -131,7 +131,6 @@ class RoomEnergyProperties(object):
                     'and then assigning it to this Room.'.format(
                         self.host.name, value._parent.name))
             value._parent = self.host
-            value.lock()   # lock because we don't duplicate the system
         self._hvac = value
 
     @property
@@ -391,8 +390,9 @@ class RoomEnergyProperties(object):
             If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
+        hvac = self.hvac.duplicate() if self.is_conditioned else None
         new_room = RoomEnergyProperties(
-            _host, self._program_type, self._construction_set, self.hvac)
+            _host, self._program_type, self._construction_set, hvac)
         new_room._people = self._people
         new_room._lighting = self._lighting
         new_room._electric_equipment = self._electric_equipment

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -284,10 +284,10 @@ def room_to_idf(room):
 
     # write the ventilation, thermostat, and ideal air system
     if ventilation is not None:
-        zone_str.append(ventilation.to_idf())
+        zone_str.append(ventilation.to_idf(room.name))
     if room.properties.energy.is_conditioned:
         zone_str.append(room.properties.energy.hvac.to_idf())
-        zone_str.append(room.properties.energy.setpoint.to_idf())
+        zone_str.append(room.properties.energy.setpoint.to_idf(room.name))
         humidistat = room.properties.energy.setpoint.to_idf_humidistat(room.name)
         if humidistat is not None:
             zone_str.append(humidistat)

--- a/tests/idealair_test.py
+++ b/tests/idealair_test.py
@@ -54,18 +54,6 @@ def test_ideal_air_system_equality():
     assert ideal_air != ideal_air_alt
 
 
-def test_ideal_air_lockability():
-    """Test the lockability of IdealAirSystem objects."""
-    ideal_air = IdealAirSystem()
-
-    ideal_air.sensible_heat_recovery = 0.6
-    ideal_air.lock()
-    with pytest.raises(AttributeError):
-        ideal_air.sensible_heat_recovery = 0.75
-    ideal_air.unlock()
-    ideal_air.sensible_heat_recovery = 0.75
-
-
 def test_ideal_air_init_from_idf():
     """Test the initialization of IdealAirSystem from_idf."""
     ideal_air = IdealAirSystem()

--- a/tests/load_setpoint_test.py
+++ b/tests/load_setpoint_test.py
@@ -161,7 +161,7 @@ def test_setpoint_init_from_idf():
     setpoint = Setpoint('Office Setpoint', heat_setpt, cool_setpt)
     sched_dict = {heat_setpt.name: heat_setpt, cool_setpt.name: cool_setpt}
 
-    idf_str = setpoint.to_idf()
+    idf_str = setpoint.to_idf('Test Zone')
     rebuilt_setpoint = Setpoint.from_idf(idf_str, sched_dict)
     assert setpoint == rebuilt_setpoint
 
@@ -186,7 +186,7 @@ def test_setpoint_init_from_idf_humidity():
                   humid_setpt.name: humid_setpt, dehumid_setpt.name: dehumid_setpt}
 
     zone_name = 'Test Zone'
-    idf_str = setpoint.to_idf()
+    idf_str = setpoint.to_idf(zone_name)
     humid_idf_str = setpoint.to_idf_humidistat(zone_name)
     rebuilt_setpoint = Setpoint.from_idf(idf_str, sched_dict)
     rebuilt_setpoint.add_humidity_from_idf(humid_idf_str, sched_dict)

--- a/tests/load_ventilation_test.py
+++ b/tests/load_ventilation_test.py
@@ -106,7 +106,7 @@ def test_ventilation_init_from_idf():
     ventilation.schedule = schedule
     sched_dict = {schedule.name: schedule}
 
-    idf_str = ventilation.to_idf()
+    idf_str = ventilation.to_idf('Test Zone')
     rebuilt_ventilation = Ventilation.from_idf(idf_str, sched_dict)
     assert ventilation == rebuilt_ventilation
 


### PR DESCRIPTION
Without including the room name, we ultimately end up with duplicate thermostats and ventilation objects in the IDF when we have more than one Room.