### PR TITLE
fix(ruleset): Bug fix to ScheduleRuleset.extract_all_from_idf_file

### DIFF
--- a/tests/idf/cross_referenced_schedule_day.idf
+++ b/tests/idf/cross_referenced_schedule_day.idf
@@ -1,0 +1,64 @@
+ScheduleTypeLimits,
+  avail_limit,                 !- Name
+  0,                                      !- Lower Limit Value {BasedOnField A3}
+  1,                                      !- Upper Limit Value {BasedOnField A3}
+  Discrete,                               !- Numeric Type
+  availability;                           !- Unit Type
+
+Schedule:Day:Interval,
+  off,                                   !- Name
+  avail_limit,                 !- Schedule Type Limits Name
+  No,                                     !- Interpolate to Timestep
+  24:00,                                  !- Time 1 {hh:mm}
+  0;                                      !- Value Until Time 1
+
+Schedule:Day:Interval,
+  on,                                   !- Name
+  avail_limit,                 !- Schedule Type Limits Name
+  No,                                     !- Interpolate to Timestep
+  24:00,                                  !- Time 1 {hh:mm}
+  1;                                      !- Value Until Time 1
+
+Schedule:Week:Daily, 
+Weeks_always_off,                       !- Name
+off,                                    !- Sunday Schedule:Day Name
+off,                                    !- Monday Schedule:Day Name
+off,                                    !- Tuesday Schedule:Day Name
+off,                                    !- Wednesday Schedule:Day Name
+off,                                    !- Thursday Schedule:Day Name
+off,                                    !- Friday Schedule:Day Name
+off,                                    !- Saturday Schedule:Day Name
+off,                                    !- Holiday Schedule:Day Name
+off,                                    !- SummerDesignDay Schedule:Day Name
+off,                                    !- WinterDesignDay Schedule:Day Name
+off,                                    !- CustomDay1 Schedule:Day Name
+off;                                    !- CustomDay2 Schedule:Day Name
+
+Schedule:Week:Daily,
+Week_cooling_switch_on,                        !- Name
+off,                                     !- Sunday Schedule:Day Name
+off,                                     !- Monday Schedule:Day Name
+on,                                    !- Tuesday Schedule:Day Name
+on,                                    !- Wednesday Schedule:Day Name
+on,                                    !- Thursday Schedule:Day Name
+on,                                    !- Friday Schedule:Day Name
+on,                                    !- Saturday Schedule:Day Name
+off,                                    !- Holiday Schedule:Day Name
+off,                                    !- SummerDesignDay Schedule:Day Name
+off,                                    !- WinterDesignDay Schedule:Day Name
+off,                                    !- CustomDay1 Schedule:Day Name
+off;                                    !- CustomDay2 Schedule:Day Name
+
+Schedule:Year,
+cooling_avail,                          !- Name
+avail_limit,                 !- Schedule Type Limits Name
+Weeks_always_off,   !- Schedule:Week Name 1
+1,                                      !- Start Month 1
+1,                                      !- Start Day 1
+4,                                      !- End Month 1
+2,                                      !- End Day 1
+Week_cooling_switch_on,   !- Schedule:Week Name 1
+4,                                      !- Start Month 1
+3,                                      !- Start Day 1
+12,                                      !- End Month 1
+31;                                     !- End Day 1

--- a/tests/schedule_ruleset_test.py
+++ b/tests/schedule_ruleset_test.py
@@ -274,9 +274,6 @@ def test_schedule_ruleset_from_idf_file_cross_referenced():
 
     cooling_avail = cooling_avail_schs[0]
     assert len(cooling_avail.schedule_rules) == 2
-    for sch_rule in cooling_avail.schedule_rules:
-        assert sch_rule.schedule_day != cooling_avail.default_day_schedule
-        assert sch_rule.schedule_day.name != cooling_avail.default_day_schedule.name
 
 
 def test_schedule_ruleset_to_from_idf():

--- a/tests/schedule_ruleset_test.py
+++ b/tests/schedule_ruleset_test.py
@@ -267,6 +267,18 @@ def test_schedule_ruleset_from_idf_file_compact():
     assert isinstance(office_occ.schedule_type_limit, ScheduleTypeLimit)
 
 
+def test_schedule_ruleset_from_idf_file_cross_referenced():
+    """Test ScheduleRuleset from_idf_file with cross-referenced ScheduleDay."""
+    cool_sched_idf = './tests/idf/cross_referenced_schedule_day.idf'
+    cooling_avail_schs = ScheduleRuleset.extract_all_from_idf_file(cool_sched_idf)
+
+    cooling_avail = cooling_avail_schs[0]
+    assert len(cooling_avail.schedule_rules) == 2
+    for sch_rule in cooling_avail.schedule_rules:
+        assert sch_rule.schedule_day != cooling_avail.default_day_schedule
+        assert sch_rule.schedule_day.name != cooling_avail.default_day_schedule.name
+
+
 def test_schedule_ruleset_to_from_idf():
     """Test the ScheduleRuleset to_idf and from_idf methods."""
     weekday_office = ScheduleDay('Weekday Office Occupancy', [0, 1, 0],

--- a/tests/simulationparameter_test.py
+++ b/tests/simulationparameter_test.py
@@ -102,7 +102,7 @@ def test_simulation_parameter_to_dict_simple():
 
     """
     f_dir = 'C:/Users/chris/Documents/GitHub/energy-model-schema/app/models/samples/json'
-    dest_file = f_dir + '/simple_simulatiion_par.json'
+    dest_file = f_dir + '/simple_simulation_par.json'
     with open(dest_file, 'w') as fp:
         json.dump(sim_par_dict, fp, indent=4)
     """
@@ -141,7 +141,7 @@ def test_simulation_parameter_to_dict_detailed():
 
     """
     f_dir = 'C:/Users/chris/Documents/GitHub/energy-model-schema/app/models/samples/json'
-    dest_file = f_dir + '/detailed_simulatiion_par.json'
+    dest_file = f_dir + '/detailed_simulation_par.json'
     with open(dest_file, 'w') as fp:
         json.dump(sim_par_dict, fp, indent=4)
     """


### PR DESCRIPTION
This fixes the bug found by @zha and reported in this issue: https://github.com/ladybug-tools/honeybee-energy/issues/56

Specifically, it addresses cases where the same ScheduleDay is referenced by multiple ScheduleWeeks in an IDF file.  This doesn't map as cleanly to the ScheduleRuleset schema or, rather, it creates cases where someone can edit the ScheduleDay of one ScheduleRule and this inadvertently edits the ScheduleDay of another ScheduleRule. I realize that this "inadvertent editing" situation happens in the IDF world and no one minds but we also know that the IDF world is mostly concerned with storing schedules for individual Models and really isn't meant to manage a library of schedules as honeybee is. This is apparent in the fact that IDF makes it difficult to view year schedules as self-contained units that can be called from a library when these IDF year schedules depend on week schedules and day schedules that might be referenced elsewhere in a Model. This "self-containment" of year schedules is something we have been able to achieve with the honeybee schema and I would rather not give it up just to address this case.

So, in this light, the best way to handle this case seems to be to duplicate the cross-referenced ScheduleDay and give it a new unique name so that it does not conflict with the other ScheduleDay.  This is what I have done in this PR.