### PR TITLE
feat(config): Add a config module to handle folder locations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include honeybee/config.json
 include honeybee_energy/lib/library/constructions/*.idf
 include honeybee_energy/lib/library/schedules/*.idf
 include honeybee_energy/lib/library/constructionsets/*.json

--- a/honeybee_energy/config.json
+++ b/honeybee_energy/config.json
@@ -1,0 +1,7 @@
+{
+    "__comment__": "Add full paths to folders (eg. C:/EnergyPlusV9-0-1, /usr/local/energyplus).",
+    "energyplus_path": "",
+    "openstudio_path": "",
+    "energy_model_measure_path": "",
+    "template_library_folder": ""
+}

--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -1,0 +1,394 @@
+"""Honeybee_energy configurations.
+
+Import this into every module where access configurations are needed.
+
+Usage:
+    from honeybee_energy.config import folders
+    print(folders.energyplus_path)
+    print(folders.openstudio_path)
+    folders.energyplus_path = "C:/EnergyPlusV9-0-1"
+"""
+import honeybee.config as hb_config
+
+import os
+import sys
+import json
+
+
+class Folders(object):
+    """Honeybee_energy folders.
+
+    Args:
+        config_file: The path to the config.json file from which folders are loaded.
+            If None, the config.json module included in this package will be used.
+            Default: None.
+        mute: If False, the paths to the various folders will be printed as they
+            are found. If True, no printing will occur upon initialization of this
+            class. Default: True.
+
+    Properties:
+        * openstudio_path
+        * openstudio_exe
+        * energyplus_path
+        * energyplus_exe
+        * energy_model_measure_path
+        * template_library_folder
+        * construction_lib
+        * constructionset_lib
+        * schedule_lib
+        * programtype_lib
+        * config_file
+        * mute
+    """
+
+    def __init__(self, config_file=None, mute=True):
+        # set the mute value
+        self.mute = bool(mute)
+
+        # load paths from the config JSON file 
+        self.config_file  = config_file
+
+    @property
+    def openstudio_path(self):
+        """Get or set the path to OpenStudio installation folder.
+        
+        This is the "bin" directory for OpenStudio installation (the one that
+        contains the openstudio executable file).
+        """
+        return self._openstudio_path
+
+    @openstudio_path.setter
+    def openstudio_path(self, path):
+        exe_name = 'openstudio.exe' if os.name == 'nt' else 'openstudio'
+        if not path:  # check the PATH and then the default installation location
+            path, os_exe_file = self._which(exe_name)
+            if path is None:  # search within the default installation location
+                path, os_exe_file = self._find_openstudio_folder()
+        else:
+            os_exe_file = os.path.join(path, exe_name)
+
+        if path:  # check that the OpenStudio executable exists in the path
+            assert os.path.isfile(os_exe_file), \
+                '{} is not a valid path to an openstudio installation.'.format(path)
+
+        #set the openstudio_path
+        self._openstudio_path = path
+        self._openstudio_exe = os_exe_file
+        if path and not self.mute:
+            print("Path to OpenStudio is set to: %s" % path)
+    
+    @property
+    def openstudio_exe(self):
+        """Get the path to the executable openstudio file."""
+        return self._openstudio_exe
+
+    @property
+    def energyplus_path(self):
+        """Get or set the path to EnergyPlus installation folder."""
+        return self._energyplus_path
+    
+    @energyplus_path.setter
+    def energyplus_path(self, path):
+        exe_name = 'energyplus.exe' if os.name == 'nt' else 'energyplus'
+        if not path:  # check the PATH and then the default installation location
+            path, ep_exe_file = self._which(exe_name)
+            if path is None:  # search within the default installation location
+                path, ep_exe_file = self._find_energyplus_folder()
+        else:
+            ep_exe_file = os.path.join(path, exe_name)
+        
+        if path:  # check that the Energyplus executable exists in the installation
+            assert os.path.isfile(ep_exe_file), \
+                '{} is not a valid path to an energyplus installation.'.format(path)
+
+        # set the energyplus_path
+        self._energyplus_path = path
+        self._energyplus_exe = ep_exe_file
+        if path and not self.mute:
+            print("Path to EnergyPlus is set to: %s" % self._energyplus_path)
+
+    @property
+    def energyplus_exe(self):
+        """Get the path to the executable energyplus file."""
+        return self._energyplus_exe
+    
+    @property
+    def energy_model_measure_path(self):
+        """Get or set the path to the energy_model_measure translating to OpenStudio.
+        
+        This folder must have the following sub-folders in order to be valid:
+            * ladybug - ruby library with modules for model translation to OpenStudio.
+            * measures - folder with the actual measures that run the translation.
+        """
+        return self._energy_model_measure_path
+    
+    @energy_model_measure_path.setter
+    def energy_model_measure_path(self, path):
+        if not path:  # check the default locations of the energy_model_measure
+            path = self._find_energy_model_measure_path()
+
+        # check that the library's sub-folders exist
+        if path:
+            assert os.path.isdir(os.path.join(path, 'ladybug')), \
+                '{} lacks a "ladybug" folder for the translation ruby library.'.format(path)
+            assert os.path.isdir(os.path.join(path, 'measures')), \
+                '{} lacks a "measures" folder.'.format(path)
+
+        # set the energy_model_measure_path
+        self._energy_model_measure_path = path
+        if path and not self.mute:
+            print('Path to the energy_model_measure is set to: '
+                    '{}'.format(self._energy_model_measure_path))
+    
+    @property
+    def template_library_folder(self):
+        """Get or set the path to the library of templates loaded to honeybee_energy.lib.
+        
+        This folder must have the following sub-folders in order to be valid:
+            * constructions - folder with IDF files for materials + constructions.
+            * constructionsets - folder with JSON files of abridged ConstructionSets.
+            * schedules - folder with IDF files for schedules.
+            * programtypes - folder with JSON files of abridged ProgramTypes.
+        """
+        return self._template_library_folder
+    
+    @template_library_folder.setter
+    def template_library_folder(self, path):
+        if not path:  # check the default locations of the template library
+            path = self._find_template_library_folder()
+        
+        # gather all of the sub folders underneath the master folder
+        self._construction_lib = os.path.join(path, 'constructions') if path else None
+        self._constructionset_lib = os.path.join(path, 'constructionsets') if path else None
+        self._schedule_lib = os.path.join(path, 'schedules') if path else None
+        self._programtype_lib = os.path.join(path, 'programtypes') if path else None
+
+        # check that the library's sub-folders exist
+        if path:
+            assert os.path.isdir(self._construction_lib), \
+                '{} lacks a "constructions" folder.'.format(path)
+            assert os.path.isdir(self._constructionset_lib), \
+                '{} lacks a "constructionsets" folder.'.format(path)
+            assert os.path.isdir(self._schedule_lib), \
+                '{} lacks a "schedules" folder.'.format(path)
+            assert os.path.isdir(self._programtype_lib), \
+                '{} lacks a "programtypes" folder.'.format(path)
+
+        # set the template_library_folder
+        self._template_library_folder = path
+        if path and not self.mute:
+            print('Path to the template_library_folder is set to: '
+                    '{}'.format(self._template_library_folder))
+    
+    @property
+    def construction_lib(self):
+        """Get the path to the construction library in the template_library_folder."""
+        return self._construction_lib
+    
+    @property
+    def constructionset_lib(self):
+        """Get the path to the constructionset library in the template_library_folder."""
+        return self._constructionset_lib
+    
+    @property
+    def schedule_lib(self):
+        """Get the path to the schedule library in the template_library_folder."""
+        return self._schedule_lib
+    
+    @property
+    def programtype_lib(self):
+        """Get the path to the programtype library in the template_library_folder."""
+        return self._programtype_lib
+
+    @property 
+    def config_file(self):
+        """Get or set the path to the config.json file from which folders are loaded.
+        
+        Setting this to None will result in using the config.json module included
+        in this package.
+        """
+        return self._config_file
+
+    @config_file.setter
+    def config_file(self, cfg):
+        if cfg is None:
+            cfg = os.path.join(os.path.dirname(__file__), 'config.json')
+        self._load_from_file(cfg)
+        self._config_file = cfg
+
+    def _load_from_file(self, file_path):
+        """Set all of the the properties of this object from a config JSON file.
+        
+        Args:
+            file_path: Path to a JSON file containing the file paths. A sample of this
+                JSON is the config.json file within this package.
+        """
+        # check the default file path
+        assert os.path.isfile(str(file_path)), \
+            ValueError('No file found at {}'.format(file_path))
+
+        # set the default paths to be all blank
+        default_path = {
+            "energyplus_path": r'',
+            "openstudio_path": r'',
+            "energy_model_measure_path": r'',
+            "template_library_folder": r''
+        }
+
+        with open(file_path, 'r') as cfg:
+            try:
+                paths = json.load(cfg)
+            except Exception as e:
+                print('Failed to load paths from {}.\n{}'.format(file_path, e))
+            else:
+                for key, p in paths.items():
+                    if not key.startswith('__') and p.strip():
+                        default_path[key] = p.strip()
+
+        # set paths for energyplus and openstudio installations
+        self.openstudio_path = default_path["openstudio_path"]
+        self.energyplus_path = default_path["energyplus_path"]
+
+        # set the paths for the energy_model_measure
+        self.energy_model_measure_path = default_path["energy_model_measure_path"]
+
+        # set path for the template_library_folder
+        self.template_library_folder = default_path["template_library_folder"]
+
+    def _find_energyplus_folder(self):
+        """Find the most recent EnergyPlus installation in its default location.
+        
+        This method will first attempt to return the path of the EnergyPlus that
+        installs with OpenStudio and, if none are found, it will search for a
+        standalone installation of EnergyPlus.
+
+        Returns:
+            File directory and full path to executable in case of success.
+            None, None in case of failure.
+        """
+        def getversion(energyplus_path):
+            """Get digits for the version of EnergyPlus."""
+            ver = ''.join(s for s in energyplus_path if (s.isdigit() or s == '-'))
+            return sum(int(i) * d ** 10 for d, i in enumerate(reversed(ver.split('-'))))
+
+        # first check for the EnergyPlus that comes with OpenStudio
+        ep_path = None
+        if self.openstudio_path is not None and os.path.isdir(os.path.join(
+                os.path.split(self.openstudio_path)[0], 'EnergyPlus')):
+            ep_path = os.path.join(os.path.split(self.openstudio_path)[0], 'EnergyPlus')
+        # then check the default location where standalone EnergyPlus is installed
+        elif os.name == 'nt':  # search the C:/ drive on Windows
+            ep_folders = ['C:\\{}'.format(f) for f in os.listdir('C:\\')
+                          if (f.lower().startswith('energyplus') and
+                              os.path.isdir('C:\\{}'.format(f)))]
+        elif sys.platform == 'darwin':  # search the Applications folder on Mac
+            ep_folders = ['/Applications/{}'.format(f) for f in os.listdir('/Applications/')
+                          if (f.lower().startswith('energyplus') and
+                              os.path.isdir('/Applications/{}'.format(f)))]
+        else:  # unknown operating system
+            # TODO: Add code to search in the default installation folder on Linux
+            ep_folders = None
+        
+        if not ep_path and not ep_folders:  # No EnergyPlus installations were found
+            return None, None
+        elif not ep_path:
+            # get the most recent version of energyplus that was found
+            ep_path = sorted(ep_folders, key=getversion, reverse=True)[0]
+        
+        # return the path to the executable
+        exec_file = os.path.join(ep_path, 'energyplus.exe') if os.name == 'nt' \
+            else os.path.join(ep_path, 'energyplus')
+        return ep_path, exec_file
+
+    @staticmethod
+    def _find_openstudio_folder():
+        """Find the most recent OpenStudio installation in its default location.
+
+        Returns:
+            File directory and full path to executable in case of success.
+            None, None in case of failure.
+        """
+        def getversion(openstudio_path):
+            """Get digits for the version of OpenStudio."""
+            ver = ''.join(s for s in openstudio_path if (s.isdigit() or s == '.'))
+            return sum(int(i) * d ** 10 for d, i in enumerate(reversed(ver.split('.'))))
+
+        if os.name == 'nt':  # search the C:/ drive on Windows
+            os_folders = ['C:\\{}'.format(f) for f in os.listdir('C:\\')
+                          if (f.lower().startswith('openstudio') and
+                              os.path.isdir('C:\\{}'.format(f)))]
+        elif sys.platform == 'darwin':  # search the Applications folder on Mac
+            os_folders = ['/Applications/{}'.format(f) for f in os.listdir('/Applications/')
+                          if (f.lower().startswith('openstudio') and
+                              os.path.isdir('/Applications/{}'.format(f)))]
+        else:  # unknown operating system
+            # TODO: Add code to search in the default installation folder on Linux
+            os_folders = None
+        
+        if not os_folders:  # No Openstudio installations were found
+            return None, None
+        
+        # get the most recent version of OpenStudio that was found
+        os_path = sorted(os_folders, key=getversion, reverse=True)[0]
+        
+        # return the path to the executable
+        exec_file = os.path.join(os_path, 'bin', 'openstudio.exe') if os.name == 'nt' \
+            else os.path.join(os_path, 'bin', 'openstudio')
+        return os.path.join(os_path, 'bin'), exec_file
+
+    @staticmethod
+    def _find_energy_model_measure_path():
+        """Find the energy_model_measure_path in its default location.
+        
+        This is usually next to the Python pacakges when it's installed for a plugin.
+        """
+        measure_path = os.path.join(hb_config.folders.python_package_path,
+                                    'energy_model_measure')
+        if not os.path.isdir(measure_path):
+            return  # No energy_model_measure is installed
+        return measure_path
+    
+    @staticmethod
+    def _find_template_library_folder():
+        """Find the the user template library in its default location.
+        
+        The default_simulation_folder/energy_library/ folder will be checked first,
+        which can conatain libraries that are not overwritten with the update of the
+        honeybee_energy package. If no such folder is found, this method defaults to
+        the lib/library/ folder within this package.
+        """
+        # first check the default sim folder folder, where permanent libraries live
+        lib_folder = os.path.join(
+                hb_config.folders.default_simulation_folder, 'energy_library')
+        if os.path.isdir(lib_folder):
+            return lib_folder
+        else:  # default to the library folder that installs with this Python package
+            return os.path.join(os.path.dirname(__file__), 'lib', 'library')
+    
+    @staticmethod
+    def _which(program):
+        """Find an executable program in the PATH by name.
+
+        Args:
+            program: Full file name for the program (e.g. energyplus.exe)
+
+        Returns:
+            File directory and full path to program in case of success.
+            None, None in case of failure.
+        """
+        def is_exe(fpath):
+            # Return true if the file exists and is executable
+            return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+        # check for the file in all path in environment
+        for path in os.environ["PATH"].split(os.pathsep):
+            exe_file = os.path.join(path.strip('"'), program)  # strip "" in Windows
+            if is_exe(exe_file):
+                return path, exe_file
+
+        # couldn't find it in the PATH! return None :|
+        return None, None
+
+
+"""Object possesing all key folders within the configuration."""
+folders = Folders(mute=True)

--- a/honeybee_energy/lib/_loadconstructions.py
+++ b/honeybee_energy/lib/_loadconstructions.py
@@ -1,4 +1,5 @@
 """Load all materials and constructions from the IDF libraries."""
+from honeybee_energy.config import folders
 from honeybee_energy.construction.opaque import OpaqueConstruction
 from honeybee_energy.construction.window import WindowConstruction
 
@@ -13,10 +14,8 @@ _idf_window_constructions = {}
 
 
 # load materials and constructions from the default and user-supplied files
-cur_dir = os.path.dirname(__file__)
-construction_lib = os.path.join(cur_dir, 'library', 'constructions')
-for f in os.listdir(construction_lib):
-    f_path = os.path.join(construction_lib, f)
+for f in os.listdir(folders.construction_lib):
+    f_path = os.path.join(folders.construction_lib, f)
     if os.path.isfile(f_path) and f_path.endswith('.idf'):
         constructions, materials = OpaqueConstruction.extract_all_from_idf_file(f_path)
         for mat in materials:

--- a/honeybee_energy/lib/_loadconstructionsets.py
+++ b/honeybee_energy/lib/_loadconstructionsets.py
@@ -1,4 +1,5 @@
 """Load all construction sets from the JSON libraries."""
+from honeybee_energy.config import folders
 from honeybee_energy.constructionset import ConstructionSet
 
 from ._loadconstructions import _idf_opaque_constructions, _idf_window_constructions
@@ -15,14 +16,11 @@ _json_construction_sets = {}
 
 
 # load construction sets from the default and user-supplied files
-cur_dir = os.path.dirname(__file__)
-constr_lib = os.path.join(cur_dir, 'library', 'constructionsets')
-for f in os.listdir(constr_lib):
-    f_path = os.path.join(constr_lib, f)
+for f in os.listdir(folders.constructionset_lib):
+    f_path = os.path.join(folders.constructionset_lib, f)
     if os.path.isfile(f_path) and f_path.endswith('.json'):
         with open(f_path, 'r') as json_file:
-            file_contents = json_file.read()
-        c_dict = json.loads(file_contents)
+            c_dict = json.load(json_file)
         for c_name in c_dict:
             try:
                 constructionset = ConstructionSet.from_dict_abridged(

--- a/honeybee_energy/lib/_loadprogramtypes.py
+++ b/honeybee_energy/lib/_loadprogramtypes.py
@@ -1,4 +1,5 @@
 """Load all program types from the JSON libraries."""
+from honeybee_energy.config import folders
 from honeybee_energy.programtype import ProgramType
 
 from ._loadschedules import _idf_schedules
@@ -12,14 +13,11 @@ _json_program_types = {}
 
 
 # load program types from the default and user-supplied files
-cur_dir = os.path.dirname(__file__)
-program_lib = os.path.join(cur_dir, 'library', 'programtypes')
-for f in os.listdir(program_lib):
-    f_path = os.path.join(program_lib, f)
+for f in os.listdir(folders.programtype_lib):
+    f_path = os.path.join(folders.programtype_lib, f)
     if os.path.isfile(f_path) and f_path.endswith('.json'):
         with open(f_path, 'r') as json_file:
-            file_contents = json_file.read()
-        p_dict = json.loads(file_contents)
+            p_dict = json.load(json_file)
         for p_name in p_dict:
             try:
                 program = ProgramType.from_dict_abridged(p_dict[p_name], _idf_schedules)

--- a/honeybee_energy/lib/_loadschedules.py
+++ b/honeybee_energy/lib/_loadschedules.py
@@ -1,4 +1,5 @@
 """Load all schedules from the IDF libraries."""
+from honeybee_energy.config import folders
 from honeybee_energy.schedule.ruleset import ScheduleRuleset
 
 import os
@@ -9,10 +10,8 @@ _idf_schedules = {}
 
 
 # load schedules from the default and user-supplied files
-cur_dir = os.path.dirname(__file__)
-schedule_lib = os.path.join(cur_dir, 'library', 'schedules')
-for f in os.listdir(schedule_lib):
-    f_path = os.path.join(schedule_lib, f)
+for f in os.listdir(folders.schedule_lib):
+    f_path = os.path.join(folders.schedule_lib, f)
     if os.path.isfile(f_path) and f_path.endswith('.idf'):
         schedule_rulesets = ScheduleRuleset.extract_all_from_idf_file(f_path)
         for sch in schedule_rulesets:

--- a/honeybee_energy/lib/_loadtypelimits.py
+++ b/honeybee_energy/lib/_loadtypelimits.py
@@ -1,4 +1,5 @@
 """Load all schedule type limits from the IDF libraries."""
+from honeybee_energy.config import folders
 from honeybee_energy.schedule.typelimit import ScheduleTypeLimit
 
 import os
@@ -9,8 +10,7 @@ _idf_schedule_type_limits = {}
 
 
 # load schedule types from the default and user-supplied files
-cur_dir = os.path.dirname(__file__)
-schedule_lib = os.path.join(cur_dir, 'library', 'schedules')
+schedule_lib = os.path.join(folders.template_library_folder, 'schedules')
 for f in os.listdir(schedule_lib):
     f_path = os.path.join(schedule_lib, f)
     if os.path.isfile(f_path) and f_path.endswith('.idf'):

--- a/honeybee_energy/run.py
+++ b/honeybee_energy/run.py
@@ -8,10 +8,11 @@ from __future__ import division
 
 import os
 
+from .config import folders
 from ladybug.futil import write_to_file_by_name, copy_files_to_folder
 
 
-def run_idf(idf_file_path, epw_file_path, energyplus_directory):
+def run_idf(idf_file_path, epw_file_path, energyplus_directory=None):
     """Run an IDF file through energyplus.
 
     Args:
@@ -19,8 +20,8 @@ def run_idf(idf_file_path, epw_file_path, energyplus_directory):
         epw_file_path: The full path to an EPW file.
         energyplus_directory: The directory in which EnergyPlus is installed on
             the machine. Specifically, this should be the folder containing
-            energyplus.exe as well as the other supporting files.
-            (eg. 'C:/openstudio-2.8.0/EnergyPlus/')
+            energyplus.exe (eg. 'C:/openstudio-2.8.0/EnergyPlus/'). If None, the
+            energyplus_path in the config.folders will be used. Default: None.
 
     Returns:
         sql -- Path to a .sqlite file containing all simulation results.
@@ -32,6 +33,13 @@ def run_idf(idf_file_path, epw_file_path, energyplus_directory):
         html -- Path to a .html file containing all summary reports.
             Will be None if no file exists.
     """
+    # check the energyplus directory
+    if not energyplus_directory:
+        energyplus_directory = folders.energyplus_path
+        if not energyplus_directory:
+            raise OSError('No EnergyPlus installation was found on this machine.\n'
+                          'Install EnergyPlus to run energy simulations.')
+
     # check the input files
     assert os.path.isfile(idf_file_path), \
         'No IDF file found at {}.'.format(idf_file_path)

--- a/honeybee_energy/run.py
+++ b/honeybee_energy/run.py
@@ -7,21 +7,21 @@ the use of queenbee and workerbee.
 from __future__ import division
 
 import os
+import json
 
 from .config import folders
-from ladybug.futil import write_to_file_by_name, copy_files_to_folder
+
+from ladybug.futil import write_to_file_by_name, copy_files_to_folder, copy_file_tree
 
 
-def run_idf(idf_file_path, epw_file_path, energyplus_directory=None):
-    """Run an IDF file through energyplus.
+def run_idf_windows(idf_file_path, epw_file_path):
+    """Run an IDF file through energyplus on a Windows-based operating system.
+
+    A batch file will be used to run the simulation.
 
     Args:
         idf_file_path: The full path to an IDF file.
         epw_file_path: The full path to an EPW file.
-        energyplus_directory: The directory in which EnergyPlus is installed on
-            the machine. Specifically, this should be the folder containing
-            energyplus.exe (eg. 'C:/openstudio-2.8.0/EnergyPlus/'). If None, the
-            energyplus_path in the config.folders will be used. Default: None.
 
     Returns:
         sql -- Path to a .sqlite file containing all simulation results.
@@ -33,39 +33,12 @@ def run_idf(idf_file_path, epw_file_path, energyplus_directory=None):
         html -- Path to a .html file containing all summary reports.
             Will be None if no file exists.
     """
-    # check the energyplus directory
-    if not energyplus_directory:
-        energyplus_directory = folders.energyplus_path
-        if not energyplus_directory:
-            raise OSError('No EnergyPlus installation was found on this machine.\n'
-                          'Install EnergyPlus to run energy simulations.')
-
-    # check the input files
-    assert os.path.isfile(idf_file_path), \
-        'No IDF file found at {}.'.format(idf_file_path)
-    assert os.path.isfile(epw_file_path), \
-        'No EPW file found at {}.'.format(epw_file_path)
-    assert os.path.isdir(energyplus_directory), \
-        'No EnergyPlus installation was found at {}.'.format(energyplus_directory)
-
-    # copy all files needed for simulation to the folder
-    directory, idf_file_name = os.path.split(idf_file_path)
-    idd_path = os.path.join(energyplus_directory, 'Energy+.idd')
-    copy_files_to_folder([idd_path, epw_file_path], directory, True)
-
-    # rename the weather file to in.epw
-    folder, epw_file_name = os.path.split(epw_file_path)
-    old_file_name = os.path.join(directory, epw_file_name)
-    new_file_name = os.path.join(directory, 'in.epw')
-    try:
-        os.remove(new_file_name)
-    except Exception:
-        pass  # file does not yet exist
-    os.rename(old_file_name, new_file_name)
+    # check and prepare the input files
+    directory = prepare_idf_for_simulation(idf_file_path, epw_file_path)
 
     # write a batch file
-    expand_path = os.path.join(energyplus_directory, 'ExpandObjects')
-    run_path = os.path.join(energyplus_directory, 'EnergyPlus')
+    expand_path = os.path.join(folders.energyplus_path, 'ExpandObjects')
+    run_path = os.path.join(folders.energyplus_path, 'EnergyPlus')
     working_drive = directory[:2]
     batch = '{}\ncd {}\n{}\nif exist expanded.idf MOVE expanded.idf in.idf\n{}'.format(
         working_drive, directory, expand_path, run_path)
@@ -74,6 +47,190 @@ def run_idf(idf_file_path, epw_file_path, energyplus_directory=None):
     # run the batch file
     os.system(os.path.join(directory, 'in.bat'))
 
+    # output the simulation files
+    return _output_files_from_directory(directory)
+
+
+
+def run_osw_windows(osw_json, measures_only=True):
+    """Run a .osw file using the OpenStudio CLI.
+    
+    Args:
+        osw_json: File path to a OSW file to be run using OpenStudio CLI.
+        measures_only: Boolean to note whether only the measures should be applied
+            in the runnning of the OSW (True) or the resulting model shoudl be run
+            through EnergyPlus after the measures are aplied to it (False).
+            Default: True.
+    
+    Returns:
+        The following files output from the CLI run.
+        osm -- Path to a .osm file containing all simulation results.
+            Will be None if no file exists.
+        idf -- Path to a .idf file containing properties of the model, including
+            the size of HVAC objects. Will be None if no file exists.
+    """
+    # check the openstudio directory
+    if not folders.openstudio_path:
+        raise OSError('No OpenStudio installation was found on this machine.\n'
+                      'Install OpenStudio to run energy simulations.')
+
+    # check the input files
+    assert os.path.isfile(osw_json), 'No OSW file found at {}.'.format(osw_json)
+    directory = os.path.split(osw_json)[0]
+
+    # Write the batch file to apply the measures.
+    working_drive = directory[:2]
+    measure_str = '-m ' if measures_only else ''
+    batch = '{}\ncd {}\n"openstudio.exe" run {}-w {}'.format(
+        working_drive, folders.openstudio_path, measure_str, osw_json)
+    write_to_file_by_name(directory, 'run_workflow.bat', batch, True)
+    
+    # run the batch file
+    os.system(os.path.join(directory, 'run_workflow.bat'))
+    
+    # return the paths to the OSM and IDF
+    osm_file = os.path.join(directory, 'run', 'in.osm')
+    idf_file = os.path.join(directory, 'run', 'in.idf')
+
+    # check that the OSM and IDF files exist
+    osm = osm_file if os.path.isfile(osm_file) else None
+    idf = idf_file if os.path.isfile(idf_file) else None
+
+    return osm, idf
+
+
+def to_openstudio_osw(osw_directory, model_json_path, sim_par_json_path, epw_file=None):
+    """Create a .osw to translate honeybee JSONs to an .osm file.
+    
+    Args:
+        osw_directory: The directory into which the .osw should be written and the
+            .osm will eventually be written into.
+        model_json_path: File path to the Model JSON.
+        sim_par_json_path: File path to the SimulationParameter JSON.
+        epw_file: Optional file path to an EPW that should be associated with the
+            output energy model.
+    
+    Returns:
+        The file path to the .osw written out by this method.
+    """
+    # check the energy_model_measure_path
+    if not folders.energy_model_measure_path:
+        raise OSError('The energy_model_measure that translates honeybee models'
+                      ' to OpenStudio was not found.')
+
+    # copy the measures into the directory
+    measure_directory = os.path.join(folders.energy_model_measure_path, 'measures')
+    sim_measures_dir = os.path.join(osw_directory, 'measures')
+    copy_file_tree(measure_directory, sim_measures_dir)
+
+    # copy the ladybug ruby library to the directory
+    ladybug_ruby_directory = os.path.join(folders.energy_model_measure_path, 'ladybug')
+    sim_ladybug_ruby = os.path.join(osw_directory, 'ladybug')
+    copy_file_tree(ladybug_ruby_directory, sim_ladybug_ruby)
+
+    # copy the files to the directory
+    files_directory = os.path.join(folders.energy_model_measure_path, 'files')
+    sim_files = os.path.join(osw_directory, 'files')
+    copy_file_tree(files_directory, sim_files)
+
+    # create a dictionary representation of the .osw
+    model_measure_dict = {
+        'arguments' : {
+            'ladybug_json' : model_json_path
+            },
+         'measure_dir_name': 'ladybug_energy_model_measure'
+         }
+
+    sim_par_dict = {
+        'arguments' : {
+            'simulation_parameter_json' : sim_par_json_path
+            },
+         'measure_dir_name': 'ladybug_simulation_parameter_measure'
+         }
+
+    osw_dict = {'steps': [model_measure_dict, sim_par_dict]}
+
+    # assign the epw_file to the osw if it is input
+    if epw_file is not None:
+        osw_dict['weather_file'] = epw_file
+
+    # write the dictionary to a workflow.json
+    osw_json = os.path.join(osw_directory, 'workflow.osw')
+    with open(osw_json, 'w') as fp:
+        json.dump(osw_dict, fp, indent=4)
+
+    return osw_json
+
+
+def prepare_idf_for_simulation(idf_file_path, epw_file_path):
+    """Prepare an IDF file to be run through EnergyPlus.
+
+    This includes copying the Energy+.idd to the directory of the IDF, copying the EPW
+    file to the directory, renaming the EPW to in.epw and renaming the IDF to in.idf.
+
+    Args:
+        idf_file_path: The full path to an IDF file.
+        epw_file_path: The full path to an EPW file.
+    
+    Returns:
+        directory: The folder in which the IDF exists and out of which the EnergyPlus
+            simulation will be run.
+    """
+    # check the energyplus directory
+    if not folders.energyplus_path:
+        raise OSError('No EnergyPlus installation was found on this machine.\n'
+                        'Install EnergyPlus to run energy simulations.')
+
+    # check the input files
+    assert os.path.isfile(idf_file_path), \
+        'No IDF file found at {}.'.format(idf_file_path)
+    assert os.path.isfile(epw_file_path), \
+        'No EPW file found at {}.'.format(epw_file_path)
+
+    # copy all files needed for simulation to the folder
+    directory = os.path.split(idf_file_path)[0]
+    idd_path = os.path.join(folders.energyplus_path, 'Energy+.idd')
+    copy_files_to_folder([idd_path, epw_file_path], directory, True)
+
+    # rename the weather file to in.epw (what energyplus is expecting)
+    epw_file_name = os.path.split(epw_file_path)[-1]
+    if epw_file_name != 'in.epw':
+        old_file_name = os.path.join(directory, epw_file_name)
+        new_file_name = os.path.join(directory, 'in.epw')
+        # ensure that there isn't an in.epw file there already
+        if os.path.isfile(new_file_name):
+            os.remove(new_file_name)
+        os.rename(old_file_name, new_file_name)
+
+    # rename the idf file to in.idf if it isn't named that already
+    idf_file_name = os.path.split(idf_file_path)[-1]
+    if idf_file_name != 'in.idf':
+        old_file_name = os.path.join(directory, epw_file_name)
+        new_file_name = os.path.join(directory, 'in.idf')
+        # ensure that there isn't an in.idf file there already
+        if os.path.isfile(new_file_name):
+            os.remove(new_file_name)
+        os.rename(old_file_name, new_file_name)
+    
+    return directory
+
+
+def _output_files_from_directory(directory):
+    """Get the paths to the EnergyPlus simulation output files given the idf directory.
+
+    Args:
+        directory: The path to where the IDF was run.
+    
+    Returns:
+        sql -- Path to a .sqlite file containing all simulation results.
+            Will be None if no file exists.
+        eio -- Path to a .eio file containing properties of the model, including
+            the size of HVAC objects. Will be None if no file exists.
+        rdd -- Path to a .rdd file containing all possible outputs that can be
+            requested from the simulation. Will be None if no file exists.
+        html -- Path to a .html file containing all summary reports.
+            Will be None if no file exists.
+    """
     # output the simulation files
     sql_file = os.path.join(directory, 'eplusout.sql')
     eio_file = os.path.join(directory, 'eplusout.eio')

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -6,6 +6,7 @@ from honeybee.room import Room
 from honeybee.face import Face
 from honeybee.boundarycondition import Outdoors, Surface, Ground
 from honeybee.facetype import RoofCeiling, AirWall
+import honeybee.config as hb_config
 
 try:
     from itertools import izip as zip  # python 2
@@ -387,9 +388,11 @@ def model_to_idf(model, schedule_directory=None,
                 sched_strs.extend([year_schedule] + week_schedules + day_scheds)
         except AttributeError:  # ScheduleFixedInterval
             if sched_dir is None:
-                sched_dir = schedule_directory if schedule_directory is not None \
-                    else os.path.join(os.environ['USERPROFILE'], 'honeybee',
-                                      'unnamed', 'schedules')
+                if schedule_directory is None:
+                    sched_dir = os.path.join(hb_config.folders.default_simulation_folder,
+                                             'unnamed', 'schedules')
+                else:
+                    sched_dir = schedule_directory 
             sched_strs.append(sched.to_idf(sched_dir))
         t_lim = sched.schedule_type_limit
         if t_lim is not None and not _instance_in_array(t_lim, type_limits):

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ import sys
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
+
 setuptools.setup(
     name="honeybee-energy",
     use_scm_version=True,
@@ -17,7 +20,7 @@ setuptools.setup(
     url="https://github.com/ladybug-tools/honeybee-energy",
     packages=setuptools.find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["honeybee-core"],
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+from honeybee_energy.config import folders
+
+import pytest
+
+
+def test_config_init():
+    """Test the initialization of the config module and basic properties."""
+    assert hasattr(folders, 'energyplus_path')
+    assert folders.energyplus_path is None or isinstance(folders.energyplus_path, str)
+
+    assert hasattr(folders, 'openstudio_path')
+    assert folders.openstudio_path is None or isinstance(folders.openstudio_path, str)
+
+    assert hasattr(folders, 'energy_model_measure_path')
+    assert folders.energy_model_measure_path is None or \
+        isinstance(folders.energy_model_measure_path, str)
+
+    assert hasattr(folders, 'template_library_folder')
+    assert isinstance(folders.template_library_folder, str)
+    assert isinstance(folders.construction_lib, str)
+    assert isinstance(folders.constructionset_lib, str)
+    assert isinstance(folders.schedule_lib, str)
+    assert isinstance(folders.programtype_lib, str)
+
+    assert isinstance(folders.config_file, str)


### PR DESCRIPTION
The config file handles several commonly-accessed folders including the folders for openstudio/ energyplus installations, the user-defined library of templates (eg. constructions, schedules, etc.), the default simulation folder, and the location of the energy_model_measure.