### PR TITLE
feat(run): Add methods to run EnergyPlus/OpenStudio on Unix

### DIFF
--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -11,7 +11,7 @@ Usage:
 import honeybee.config as hb_config
 
 import os
-import sys
+import platform
 import json
 
 
@@ -119,6 +119,7 @@ class Folders(object):
         This folder must have the following sub-folders in order to be valid:
             * ladybug - ruby library with modules for model translation to OpenStudio.
             * measures - folder with the actual measures that run the translation.
+            * files - folder containing the openapi schemas
         """
         return self._energy_model_measure_path
     
@@ -281,7 +282,7 @@ class Folders(object):
             ep_folders = ['C:\\{}'.format(f) for f in os.listdir('C:\\')
                           if (f.lower().startswith('energyplus') and
                               os.path.isdir('C:\\{}'.format(f)))]
-        elif sys.platform == 'darwin':  # search the Applications folder on Mac
+        elif platform.system() == 'Darwin':  # search the Applications folder on Mac
             ep_folders = ['/Applications/{}'.format(f) for f in os.listdir('/Applications/')
                           if (f.lower().startswith('energyplus') and
                               os.path.isdir('/Applications/{}'.format(f)))]
@@ -317,7 +318,7 @@ class Folders(object):
             os_folders = ['C:\\{}'.format(f) for f in os.listdir('C:\\')
                           if (f.lower().startswith('openstudio') and
                               os.path.isdir('C:\\{}'.format(f)))]
-        elif sys.platform == 'darwin':  # search the Applications folder on Mac
+        elif platform.system() == 'Darwin':  # search the Applications folder on Mac
             os_folders = ['/Applications/{}'.format(f) for f in os.listdir('/Applications/')
                           if (f.lower().startswith('openstudio') and
                               os.path.isdir('/Applications/{}'.format(f)))]
@@ -343,7 +344,7 @@ class Folders(object):
         This is usually next to the Python pacakges when it's installed for a plugin.
         """
         measure_path = os.path.join(hb_config.folders.python_package_path,
-                                    'energy_model_measure')
+                                    'energy_model_measure', 'lib')
         if not os.path.isdir(measure_path):
             return  # No energy_model_measure is installed
         return measure_path

--- a/honeybee_energy/run.py
+++ b/honeybee_energy/run.py
@@ -8,95 +8,11 @@ from __future__ import division
 
 import os
 import json
+import subprocess
 
 from .config import folders
 
-from ladybug.futil import write_to_file_by_name, copy_files_to_folder, copy_file_tree
-
-
-def run_idf_windows(idf_file_path, epw_file_path):
-    """Run an IDF file through energyplus on a Windows-based operating system.
-
-    A batch file will be used to run the simulation.
-
-    Args:
-        idf_file_path: The full path to an IDF file.
-        epw_file_path: The full path to an EPW file.
-
-    Returns:
-        sql -- Path to a .sqlite file containing all simulation results.
-            Will be None if no file exists.
-        eio -- Path to a .eio file containing properties of the model, including
-            the size of HVAC objects. Will be None if no file exists.
-        rdd -- Path to a .rdd file containing all possible outputs that can be
-            requested from the simulation. Will be None if no file exists.
-        html -- Path to a .html file containing all summary reports.
-            Will be None if no file exists.
-    """
-    # check and prepare the input files
-    directory = prepare_idf_for_simulation(idf_file_path, epw_file_path)
-
-    # write a batch file
-    expand_path = os.path.join(folders.energyplus_path, 'ExpandObjects')
-    run_path = os.path.join(folders.energyplus_path, 'EnergyPlus')
-    working_drive = directory[:2]
-    batch = '{}\ncd {}\n{}\nif exist expanded.idf MOVE expanded.idf in.idf\n{}'.format(
-        working_drive, directory, expand_path, run_path)
-    write_to_file_by_name(directory, 'in.bat', batch, True)
-
-    # run the batch file
-    os.system(os.path.join(directory, 'in.bat'))
-
-    # output the simulation files
-    return _output_files_from_directory(directory)
-
-
-
-def run_osw_windows(osw_json, measures_only=True):
-    """Run a .osw file using the OpenStudio CLI.
-    
-    Args:
-        osw_json: File path to a OSW file to be run using OpenStudio CLI.
-        measures_only: Boolean to note whether only the measures should be applied
-            in the runnning of the OSW (True) or the resulting model shoudl be run
-            through EnergyPlus after the measures are aplied to it (False).
-            Default: True.
-    
-    Returns:
-        The following files output from the CLI run.
-        osm -- Path to a .osm file containing all simulation results.
-            Will be None if no file exists.
-        idf -- Path to a .idf file containing properties of the model, including
-            the size of HVAC objects. Will be None if no file exists.
-    """
-    # check the openstudio directory
-    if not folders.openstudio_path:
-        raise OSError('No OpenStudio installation was found on this machine.\n'
-                      'Install OpenStudio to run energy simulations.')
-
-    # check the input files
-    assert os.path.isfile(osw_json), 'No OSW file found at {}.'.format(osw_json)
-    directory = os.path.split(osw_json)[0]
-
-    # Write the batch file to apply the measures.
-    working_drive = directory[:2]
-    measure_str = '-m ' if measures_only else ''
-    batch = '{}\ncd {}\n"openstudio.exe" run {}-w {}'.format(
-        working_drive, folders.openstudio_path, measure_str, osw_json)
-    write_to_file_by_name(directory, 'run_workflow.bat', batch, True)
-    
-    # run the batch file
-    os.system(os.path.join(directory, 'run_workflow.bat'))
-    
-    # return the paths to the OSM and IDF
-    osm_file = os.path.join(directory, 'run', 'in.osm')
-    idf_file = os.path.join(directory, 'run', 'in.idf')
-
-    # check that the OSM and IDF files exist
-    osm = osm_file if os.path.isfile(osm_file) else None
-    idf = idf_file if os.path.isfile(idf_file) else None
-
-    return osm, idf
+from ladybug.futil import write_to_file, copy_files_to_folder, copy_file_tree
 
 
 def to_openstudio_osw(osw_directory, model_json_path, sim_par_json_path, epw_file=None):
@@ -116,24 +32,10 @@ def to_openstudio_osw(osw_directory, model_json_path, sim_par_json_path, epw_fil
     # check the energy_model_measure_path
     if not folders.energy_model_measure_path:
         raise OSError('The energy_model_measure that translates honeybee models'
-                      ' to OpenStudio was not found.')
+                      ' to OpenStudio was not found on this machine.')
 
-    # copy the measures into the directory
-    measure_directory = os.path.join(folders.energy_model_measure_path, 'measures')
-    sim_measures_dir = os.path.join(osw_directory, 'measures')
-    copy_file_tree(measure_directory, sim_measures_dir)
-
-    # copy the ladybug ruby library to the directory
-    ladybug_ruby_directory = os.path.join(folders.energy_model_measure_path, 'ladybug')
-    sim_ladybug_ruby = os.path.join(osw_directory, 'ladybug')
-    copy_file_tree(ladybug_ruby_directory, sim_ladybug_ruby)
-
-    # copy the files to the directory
-    files_directory = os.path.join(folders.energy_model_measure_path, 'files')
-    sim_files = os.path.join(osw_directory, 'files')
-    copy_file_tree(files_directory, sim_files)
-
-    # create a dictionary representation of the .osw
+    # create a dictionary representation of the .osw with steps to run
+    # the model measure and the simulation parameter measure
     model_measure_dict = {
         'arguments' : {
             'ladybug_json' : model_json_path
@@ -150,6 +52,10 @@ def to_openstudio_osw(osw_directory, model_json_path, sim_par_json_path, epw_fil
 
     osw_dict = {'steps': [model_measure_dict, sim_par_dict]}
 
+    # assign the measure_paths to the osw_dict
+    measure_directory = os.path.join(folders.energy_model_measure_path, 'measures')
+    osw_dict['measure_paths'] = [measure_directory]
+
     # assign the epw_file to the osw if it is input
     if epw_file is not None:
         osw_dict['weather_file'] = epw_file
@@ -162,11 +68,42 @@ def to_openstudio_osw(osw_directory, model_json_path, sim_par_json_path, epw_fil
     return osw_json
 
 
+def run_osw(osw_json, measures_only=True):
+    """Run a .osw file using the OpenStudio CLI on any operating system.
+    
+    Args:
+        osw_json: File path to a OSW file to be run using OpenStudio CLI.
+        measures_only: Boolean to note whether only the measures should be applied
+            in the runnning of the OSW (True) or the resulting model shoudl be run
+            through EnergyPlus after the measures are aplied to it (False).
+            Default: True.
+    
+    Returns:
+        The following files output from the CLI run.
+        osm -- Path to a .osm file containing all simulation results.
+            Will be None if no file exists.
+        idf -- Path to a .idf file containing properties of the model, including
+            the size of HVAC objects. Will be None if no file exists.
+    """
+    # run the simulation
+    if os.name == 'nt':  # we are on Windows
+        directory = _run_osw_windows(osw_json, measures_only)
+    else:  # we are on Mac, Linux, or some other unix-based system
+        directory = _run_osw_unix(osw_json, measures_only)
+
+    # output the simulation files
+    return _output_openstudio_files(directory)
+
+
 def prepare_idf_for_simulation(idf_file_path, epw_file_path):
     """Prepare an IDF file to be run through EnergyPlus.
 
     This includes copying the Energy+.idd to the directory of the IDF, copying the EPW
-    file to the directory, renaming the EPW to in.epw and renaming the IDF to in.idf.
+    file to the directory, renaming the EPW to in.epw and renaming the IDF to in.idf
+    (if it is not already names so).
+
+    A check is also performed to be sure that a valid EnergyPlus installation
+    was found.
 
     Args:
         idf_file_path: The full path to an IDF file.
@@ -215,7 +152,243 @@ def prepare_idf_for_simulation(idf_file_path, epw_file_path):
     return directory
 
 
-def _output_files_from_directory(directory):
+def run_idf(idf_file_path, epw_file_path, expand_objects=True):
+    """Run an IDF file through energyplus on any operating system.
+
+    Args:
+        idf_file_path: The full path to an IDF file.
+        epw_file_path: The full path to an EPW file.
+        expand_objects: If True, the IDF run will include the expansion of any
+            HVAC Template objects in the file before beginning the simulation.
+            This is a necessary step whenever there are HVAC Template objets in
+            the IDF but it is unnecessary extra time when they are not present.
+            Default: True.
+
+    Returns:
+        A series of file paths to the simulation output files.
+        sql -- Path to a .sqlite file containing all simulation results.
+            Will be None if no file exists.
+        eio -- Path to a .eio file containing properties of the model, including
+            the size of HVAC objects. Will be None if no file exists.
+        rdd -- Path to a .rdd file containing all possible outputs that can be
+            requested from the simulation. Will be None if no file exists.
+        html -- Path to a .html file containing all summary reports.
+            Will be None if no file exists.
+        err -- Path to a .err file containing all errors and warnings from the
+            simulation. Will be None if no file exists.
+    """
+    # run the simulation
+    if os.name == 'nt':  # we are on Windows
+        directory = _run_idf_windows(idf_file_path, epw_file_path, expand_objects)
+    else:  # we are on Mac, Linux, or some other unix-based system
+        directory = _run_idf_unix(idf_file_path, epw_file_path, expand_objects)
+
+    # output the simulation files
+    return _output_energyplus_files(directory)
+
+
+def _check_osw(osw_json):
+    """Prepare an OSW file to be run through OpenStudio CLI.
+
+    This includes checking for a valid OpenStudio installation and ensuring the
+    OSW file exists.
+
+    Args:
+        osw_json: The full path to an OSW file.
+        epw_file_path: The full path to an EPW file.
+    
+    Returns:
+        The folder in which the OSW exists and out of which the OpenStudio CLI
+        will operate.
+    """
+    # check the openstudio directory
+    if not folders.openstudio_path:
+        raise OSError('No OpenStudio installation was found on this machine.\n'
+                      'Install OpenStudio to run energy simulations.')
+
+    # check the input files
+    assert os.path.isfile(osw_json), 'No OSW file found at {}.'.format(osw_json)
+    return os.path.split(osw_json)[0]
+
+
+def _run_osw_windows(osw_json, measures_only=True):
+    """Run a .osw file using the OpenStudio CLI on a Windows-based operating system.
+
+    A batch file will be used to run the simulation.
+    
+    Args:
+        osw_json: File path to a OSW file to be run using OpenStudio CLI.
+        measures_only: Boolean to note whether only the measures should be applied
+            in the runnning of the OSW (True) or the resulting model shoudl be run
+            through EnergyPlus after the measures are aplied to it (False).
+            Default: True.
+    
+    Returns:
+        Path to the folder out of which the OSW was run.
+    """
+    # check the input file
+    directory = _check_osw(osw_json)
+
+    # Write the batch file to call OpenStudio CLI
+    working_drive = directory[:2]
+    measure_str = '-m ' if measures_only else ''
+    batch = '{}\ncd {}\n"openstudio.exe" -I {} run {}-w {}'.format(
+        working_drive, folders.openstudio_path, folders.energy_model_measure_path,
+        measure_str, osw_json)
+    batch_file = os.path.join(directory, 'run_workflow.bat')
+    write_to_file(batch_file, batch, True)
+    
+    # run the batch file
+    os.system(batch_file)
+
+    return directory
+
+
+def _run_osw_unix(osw_json, measures_only=True):
+    """Run a .osw file using the OpenStudio CLI on a Unix-based operating system.
+
+    This includes both Mac OS and Linux since a shell will be used to run
+    the simulation.
+    
+    Args:
+        osw_json: File path to a OSW file to be run using OpenStudio CLI.
+        measures_only: Boolean to note whether only the measures should be applied
+            in the runnning of the OSW (True) or the resulting model shoudl be run
+            through EnergyPlus after the measures are aplied to it (False).
+            Default: True.
+    
+    Returns:
+        Path to the folder out of which the OSW was run.
+    """
+    # check the input file
+    directory = _check_osw(osw_json)
+
+    # Write the shell script to call OpenStudio CLI
+    measure_str = '-m ' if measures_only else ''
+    shell = '#!/usr/bin/env bash\n\ncd {}\n"openstudio" -I {} run {}-w {}'.format(
+        folders.openstudio_path, folders.energy_model_measure_path,
+        measure_str, osw_json)
+    shell_file = os.path.join(directory, 'run_workflow.sh')
+    write_to_file(shell_file, shell, True)
+
+    # make the shell script executable using subprocess.check_call
+    # this is more reliable than native Python chmod on Mac
+    subprocess.check_call(['chmod','u+x', shell_file])
+
+    # run the shell script
+    subprocess.call(shell_file)
+
+    return directory
+
+
+def _output_openstudio_files(directory):
+    """Get the paths to the OpenStudio simulation output files given the osw directory.
+
+    Args:
+        directory: The path to where the OSW was run.
+    
+    Returns:
+        osm -- Path to a .osm file containing all simulation results.
+            Will be None if no file exists.
+        idf -- Path to a .idf file containing properties of the model, including
+            the size of HVAC objects. Will be None if no file exists.
+    """
+    # generate paths to the OSM and IDF files
+    osm_file = os.path.join(directory, 'run', 'in.osm')
+    idf_file = os.path.join(directory, 'run', 'in.idf')
+
+    # check that the OSM and IDF files exist
+    osm = osm_file if os.path.isfile(osm_file) else None
+    idf = idf_file if os.path.isfile(idf_file) else None
+
+    return osm, idf
+
+
+def _run_idf_windows(idf_file_path, epw_file_path, expand_objects=True):
+    """Run an IDF file through energyplus on a Windows-based operating system.
+
+    A batch file will be used to run the simulation.
+
+    Args:
+        idf_file_path: The full path to an IDF file.
+        epw_file_path: The full path to an EPW file.
+        expand_objects: If True, the IDF run will include the expansion of any
+            HVAC Template objects in the file before beginning the simulation.
+            This is a necessary step whenever there are HVAC Template objets in
+            the IDF but it is unnecessary extra time when they are not present.
+            Default: True.
+
+    Returns:
+        Path to the folder out of which the simulation was run.
+    """
+    # check and prepare the input files
+    directory = prepare_idf_for_simulation(idf_file_path, epw_file_path)
+
+    # generate the object expansion string if requested
+    if expand_objects:
+        exp_path = os.path.join(folders.energyplus_path, 'ExpandObjects')
+        exp_str = '{}\nif exist expanded.idf MOVE expanded.idf in.idf\n'.format(exp_path)
+    else:
+        exp_str = ''
+
+    # write a batch file
+    run_path = os.path.join(folders.energyplus_path, 'EnergyPlus')
+    working_drive = directory[:2]
+    batch = '{}\ncd {}\n{}{}'.format(working_drive, directory, exp_str, run_path)
+    batch_file = os.path.join(directory, 'in.bat')
+    write_to_file(batch_file, batch, True)
+
+    # run the batch file
+    os.system(batch_file)
+
+    return directory
+
+
+def _run_idf_unix(idf_file_path, epw_file_path, expand_objects=True):
+    """Run an IDF file through energyplus on a Unix-based operating system.
+
+    This includes both Mac OS and Linux since a shell will be used to run
+    the simulation.
+
+    Args:
+        idf_file_path: The full path to an IDF file.
+        epw_file_path: The full path to an EPW file.
+        expand_objects: If True, the IDF run will include the expansion of any
+            HVAC Template objects in the file before beginning the simulation.
+            This is a necessary step whenever there are HVAC Template objets in
+            the IDF but it is unnecessary extra time when they are not present.
+            Default: True.
+
+    Returns:
+        Path to the folder out of which the simulation was run.
+    """
+    # check and prepare the input files
+    directory = prepare_idf_for_simulation(idf_file_path, epw_file_path)
+
+    # generate the object expansion string if requested
+    if expand_objects:
+        exp_path = os.path.join(folders.energyplus_path, 'ExpandObjects')
+        exp_str = '{}\ntest -f expanded.idf && mv expanded.idf in.idf\n'.format(exp_path)
+    else:
+        exp_str = ''
+
+    # write a shell file
+    run_path = os.path.join(folders.energyplus_path, 'EnergyPlus')
+    shell = '#!/usr/bin/env bash\n\ncd {}\n{}{}'.format(directory, exp_str, run_path)
+    shell_file = os.path.join(directory, 'in.sh')
+    write_to_file(shell_file, shell, True)
+
+    # make the shell script executable using subprocess.check_call
+    # this is more reliable than native Python chmod on Mac
+    subprocess.check_call(['chmod','u+x', shell_file])
+
+    # run the shell script
+    subprocess.call(shell_file)
+
+    return directory
+
+
+def _output_energyplus_files(directory):
     """Get the paths to the EnergyPlus simulation output files given the idf directory.
 
     Args:
@@ -230,16 +403,21 @@ def _output_files_from_directory(directory):
             requested from the simulation. Will be None if no file exists.
         html -- Path to a .html file containing all summary reports.
             Will be None if no file exists.
+        err -- Path to a .err file containing all errors and warnings from the
+            simulation. Will be None if no file exists.
     """
-    # output the simulation files
+    # generate paths to the simulation files
     sql_file = os.path.join(directory, 'eplusout.sql')
     eio_file = os.path.join(directory, 'eplusout.eio')
     rdd_file = os.path.join(directory, 'eplusout.rdd')
-    html_file = os.path.join(directory, 'eplustbl.htm')
+    html_file = os.path.join(directory, 'eplusout.html')
+    err_file = os.path.join(directory, 'eplusout.err')
 
+    # check that the simulation files exist
     sql = sql_file if os.path.isfile(sql_file) else None
     eio = eio_file if os.path.isfile(eio_file) else None
     rdd = rdd_file if os.path.isfile(rdd_file) else None
-    html = sql_file if os.path.isfile(html_file) else None
+    html = html_file if os.path.isfile(html_file) else None
+    err = err_file if os.path.isfile(err_file) else None
 
-    return sql, eio, rdd, html
+    return sql, eio, rdd, html, err


### PR DESCRIPTION
I got the chance to borrow Rosi's Macbook for a few hours and it was enough for me to develop and test some functions that could run EnergyPlus successfully on Mac. This commit also includes a bug fix to the previous code that I had implemented to find the EnergyPlus/OpenStudio installation on Mac.