### PR TITLE
feat(sizing): Add design_days to the SizingParameter object

### DIFF
--- a/honeybee_energy/load/ventilation.py
+++ b/honeybee_energy/load/ventilation.py
@@ -62,8 +62,8 @@ class Ventilation(_LoadBase):
             schedule: An optional ScheduleRuleset or ScheduleFixedInterval for the
                 ventilation over the course of the year. The type of this schedule
                 should be Fractional and the fractional values will get multiplied by
-                the total design flow rate (determined from the fields above and the
-                calculation_method) to yield a complete ventilation profile. Setting
+                the total design flow rate (determined from the sum of the other
+                4 fields) to yield a complete ventilation profile. Setting
                 this schedule to be the occupancy schedule of the zone will mimic demand
                 controlled ventilation. If None, the design level of ventilation will
                 be used throughout all timesteps of the simulation. Default: None.

--- a/honeybee_energy/schedule/fixedinterval.py
+++ b/honeybee_energy/schedule/fixedinterval.py
@@ -96,6 +96,7 @@ class ScheduleFixedInterval(object):
         assert self._timestep in self.VALIDTIMESTEPS, 'ScheduleFixedInterval timestep ' \
             '"{}" is invalid. Must be one of the following:\n{}'.format(
                 timestep, self.VALIDTIMESTEPS)
+        start_date = Date(1, 1) if start_date is None else start_date
         assert isinstance(start_date, Date), 'Expected ladybug Date for ' \
             'ScheduleFixedInterval start_date. Got {}.'.format(type(start_date))
         self._start_date = start_date

--- a/honeybee_energy/schedule/rule.py
+++ b/honeybee_energy/schedule/rule.py
@@ -12,7 +12,7 @@ from ladybug.dt import Date
 
 @lockable
 class ScheduleRule(object):
-    """Schedule rule including a DaySchedule and when it should be applied.
+    """Schedule rule including a ScheduleDay and when it should be applied.
 
     Note that a ScheduleRule cannot be assigned to Rooms, Shades, etc.  The
     ScheduleRule must be added to a ScheduleRuleset and then the ScheduleRuleset

--- a/honeybee_energy/simulation/shadowcalculation.py
+++ b/honeybee_energy/simulation/shadowcalculation.py
@@ -43,7 +43,7 @@ class ShadowCalculation(object):
                 Default: AverageOverDaysInFrequency. Choose from the following:
                     * AverageOverDaysInFrequency
                     * TimestepFrequency
-            calculation_frequency: Integer for the number of days in each period in
+            calculation_frequency: Integer for the number of days in each period for
                 which a unique shadow calculation will be performed. This field is only
                 used if the AverageOverDaysInFrequency method is used in the previous
                 field. Default: 30.

--- a/honeybee_energy/simulation/sizing.py
+++ b/honeybee_energy/simulation/sizing.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Global sizing parameters dictating scaling factors for all zone peak loads."""
+"""Parameters with criteria for sizing the heating and cooling system."""
 from __future__ import division
 
 from ..reader import parse_idf_string
@@ -7,20 +7,27 @@ from ..writer import generate_idf_string
 
 from honeybee.typing import float_positive
 
+from ladybug.ddy import DDY
+from ladybug.designday import DesignDay
+from ladybug.location import Location
+
 
 class SizingParameter(object):
-    """Global sizing parameters dictating scaling factors for all zone peak loads.
+    """Sizing parameters with criteria for sizing the heating and cooling system.
 
     Properties:
+        * design_days
         * heating_factor
         * cooling_factor
     """
-    __slots__ = ('_heating_factor', '_cooling_factor')
+    __slots__ = ('_design_days', '_heating_factor', '_cooling_factor')
 
-    def __init__(self, heating_factor=1.25, cooling_factor=1.15):
+    def __init__(self, design_days=None, heating_factor=1.25, cooling_factor=1.15):
         """Initialize SizingParameter.
 
         Args:
+            design_days: An array of Ladybug DesignDay objects that represent the
+                criteria for which the HVAC systems will be sized. Default: None.
             heating_factor: A number that will get multiplied by the peak heating load
                 for each zone in the model in order to size the heating system for
                 the model. Must be greater than 0. Default: 1.25.
@@ -28,8 +35,30 @@ class SizingParameter(object):
                 for each zone in the model in order to size the cooling system for
                 the model. Must be greater than 0. Default: 1.15.
         """
+        self.design_days = design_days
         self.heating_factor = heating_factor
         self.cooling_factor = cooling_factor
+
+    @property
+    def design_days(self):
+        """Get or set an array of Ladybug DesignDay objects for sizing criteria."""
+        return tuple(self._design_days)
+
+    @design_days.setter
+    def design_days(self, value):
+        if value is not None:
+            try:
+                if not isinstance(value, list):
+                    value = list(value)
+            except TypeError:
+                raise TypeError('Expected list or tuple for SizingParameter '
+                                'design_days. Got {}'.format(type(value)))
+            for dday in value:
+                assert isinstance(dday, DesignDay), 'Expected ladybug DesignDay ' \
+                    'for SizingParameter. Got {}.'.format(type(dday))
+            self._design_days = value
+        else:
+            self._design_days = []
 
     @property
     def heating_factor(self):
@@ -50,64 +79,206 @@ class SizingParameter(object):
     def cooling_factor(self, value):
         self._cooling_factor = float_positive(value, 'sizing parameter cooling factor')
         assert self._cooling_factor != 0, 'SizingParameter cooling factor cannot be 0.'
+    
+    def add_design_day(self, design_day):
+        """Add a ladybug DesignDay to this object's design_days.
+        
+        Args:
+            design_day: A Ladybug DesignDay object to be added to this object.
+        """
+        assert isinstance(design_day, DesignDay), 'Expected ladybug DesignDay for' \
+            ' SizingParameter. Got {}.'.format(type(design_day))
+        self._design_days.append(design_day)
+    
+    def add_from_ddy(self, ddy_file):
+        """Add all design days within a .ddy file to this object.
+        
+        Args:
+            ddy_file: The full path to a .ddy file on this machine.
+        """
+        ddy_obj = DDY.from_ddy_file(ddy_file)
+        for dday in ddy_obj:
+            self._design_days.append(dday)
+
+    def add_from_ddy_996_004(self, ddy_file):
+        """Add the 99.6% and 0.4% design days within a .ddy file to this object.
+        
+        99.6% means that this percent of the hours of the year have outside heating
+        conditions warmer than this design day. 0.4% means that this percent of the
+        hours of the year have outside cooling conditions cooler than this design day.
+
+        Args:
+            ddy_file: The full path to a .ddy file on this machine.
+        """
+        ddy_obj = DDY.from_ddy_file(ddy_file)
+        for dday in ddy_obj:
+            if '99.6%' in dday.name or '.4%' in dday.name:
+                self._design_days.append(dday)
+
+    def add_from_ddy_990_010(self, ddy_file):
+        """Add the 99.0% and 1.0% design days within a .ddy file to this object.
+        
+        99.0% means that this percent of the hours of the year have outside heating
+        conditions warmer than this design day. 1.0% means that this percent of the
+        hours of the year have outside cooling conditions cooler than this design day.
+
+        Args:
+            ddy_file: The full path to a .ddy file on this machine.
+        """
+        ddy_obj = DDY.from_ddy_file(ddy_file)
+        for dday in ddy_obj:
+            if '99%' in dday.name or '1%' in dday.name:
+                self._design_days.append(dday)
+    
+    def add_from_ddy_keyword(self, ddy_file, keyword):
+        """Add DesignDays from a .ddy file using a keyword in the DesignDay name.
+
+        Args:
+            ddy_file: The full path to a .ddy file on this machine.
+            keywors: String for a keyword, which will be used to select DesignDays
+                from the .ddy file to add to this object.
+        """
+        ddy_obj = DDY.from_ddy_file(ddy_file)
+        for dday in ddy_obj:
+            if keyword in dday.name:
+                self._design_days.append(dday)
+    
+    def remove_design_day(self, design_day_index):
+        """Remove a single DesignDay from this object using an index.
+        
+        Args:
+            design_day_index: An interger for the index of the DesignDay to remove.
+        """
+        del self._design_days[design_day_index]
+    
+    def remove_design_day_keyword(self, keyword):
+        """Remove DesignDays from this object using a keyword in the DesignDay names.
+        
+        Args:
+            keyword: String for a keyword, which will be used to select DesignDays
+                for deletion from this object.
+        """
+        design_days = []
+        for dday in self._design_days:
+            if keyword not in dday.name:
+                design_days.append(dday)
+        self._design_days = design_days
+    
+    def remove_all_design_days(self):
+        """Remove all DesignDays from this object."""
+        self._design_days = []
+    
+    def apply_location(self, location):
+        """Apply a Ladybug Location object to all of the DesignDays in this object.
+        
+        This is particularly handy after re-serialization from an IDF since the
+        IDF does not store the location information in the DesignDay.
+        
+        Args:
+            location: A Ladybug Location object.
+        """
+        assert isinstance(location, Location), \
+            'Expected Ladybug Location. Got {}.'.format(type(Location))
+        for dday in self._design_days:
+            dday.location = location
 
     @classmethod
-    def from_idf(cls, idf_string):
+    def from_idf(cls, design_days=None, sizing_parameter=None, location=None):
         """Create a SizingParameter object from an EnergyPlus IDF text string.
 
         Args:
-            idf_string: A text string fully describing an EnergyPlus
-                Sizing:Parameters definition.
+            design_days: An array of of IDF SizingPeriod:DesignDay strings that
+                represent the criteria for which the HVAC systems will be sized.
+                If None, no sizing criteria will be included. Default: None.
+            sizing_parameter: A text string for an EnergyPlus Sizing:Parameters
+                definition. If None, defaults of 1.25 anf 1.15 will be used.
+                Default: None.
+            location: An optional Ladybug Location object, which gets assinged
+                to the DesignDay objects in order to interpret their SkyConditions.
+                This object is not used in the export to IDF. If None, the
+                intersection of the equator with the prime meridian will be used.
+                Default: None.
         """
-        # check the inputs
-        ep_strs = parse_idf_string(idf_string, 'Sizing:Parameters,')
+        # process the input design_days
+        des_day_objs = None
+        if design_days is not None:
+            location = Location() if location is None else location
+            des_day_objs = [DesignDay.from_idf(dday, location) for dday in design_days]
 
-        # extract the properties from the string
+        # process the sizing_parameter
         heating_factor = 1.25
         cooling_factor = 1.15
-        try:
-            heating_factor = ep_strs[0] if ep_strs[0] != '' else 1.25
-            cooling_factor = ep_strs[1] if ep_strs[1] != '' else 1.15
-        except IndexError:
-            pass  # shorter SizingParameters definition
+        if sizing_parameter is not None:
+            try:
+                ep_strs = parse_idf_string(sizing_parameter, 'Sizing:Parameters,')
+                heating_factor = ep_strs[0] if ep_strs[0] != '' else 1.25
+                cooling_factor = ep_strs[1] if ep_strs[1] != '' else 1.15
+            except IndexError:
+                pass  # shorter SizingParameters definition
 
         # return the object and the zone name for the object
-        return cls(heating_factor, cooling_factor)
+        return cls(des_day_objs, heating_factor, cooling_factor)
 
     @classmethod
     def from_dict(cls, data):
         """Create a SizingParameter object from a dictionary.
 
         Args:
-            data: A SizingParameter dictionary in following the format below.
+            data: A SizingParameter dictionary in following the format.
 
         .. code-block:: python
 
             {
             "type": "SizingParameter",
+            "design_days": [],  # Array of Ladybug DesignDay dictionaries
             "heating_factor": 1.25,
             "cooling_factor": 1.15
             }
         """
         assert data['type'] == 'SizingParameter', \
             'Expected SizingParameter dictionary. Got {}.'.format(data['type'])
+        design_days = None
+        if 'design_days' in data and data['design_days'] is not None:
+            design_days = [DesignDay.from_dict(dday) for dday in data['design_days']]
         heating_factor = data['heating_factor'] if 'heating_factor' in data else 1.25
         cooling_factor = data['cooling_factor'] if 'cooling_factor' in data else 1.15
-        return cls(heating_factor, cooling_factor)
+        return cls(design_days, heating_factor, cooling_factor)
 
     def to_idf(self):
-        """Get an EnergyPlus string representation of the SizingParameters."""
+        """Get an EnergyPlus string representation of the SizingParameters.
+        
+        Returns:
+            design_days: An array of of IDF SizingPeriod:DesignDay strings.
+            sizing_parameter: A text string for an EnergyPlus Sizing:Parameters
+                definition.
+        """
+        # process the design_days
+        design_days = [dday.to_idf() for dday in self.design_days]
+        # process the Sizing:Parameters object
         values = (self.heating_factor, self.cooling_factor)
         comments = ('heating factor', 'cooling factor')
-        return generate_idf_string('Sizing:Parameters', values, comments)
+        sizing_parameter = generate_idf_string('Sizing:Parameters', values, comments)
+        return design_days, sizing_parameter
 
     def to_dict(self):
         """SizingParameter dictionary representation."""
-        return {
+        siz_par = {
             'type': 'SizingParameter',
             'heating_factor': self.heating_factor,
             'cooling_factor': self.cooling_factor
-        }
+            }
+        if len(self._design_days) != 0:
+            siz_par['design_days'] = [dday.to_dict(False) for dday in self.design_days]
+        return siz_par
+    
+    def to_ddy(self):
+        """Get this SizingParameter as a Ladybug DDY object.
+
+        This can be written to a .ddy file if so desired.
+        """
+        assert len(self._design_days) != 0, \
+            'There must be at least one design_day to use SizingParameter.to_ddy.'
+        return DDY(self._design_days[0].location, self._design_days)
 
     def duplicate(self):
         """Get a copy of this object."""
@@ -118,11 +289,13 @@ class SizingParameter(object):
         return self.__repr__()
 
     def __copy__(self):
-        return SizingParameter(self.heating_factor, self.cooling_factor)
+        return SizingParameter([dday.duplicate() for dday in self._design_days],
+                               self.heating_factor, self.cooling_factor)
 
     def __key(self):
         """A tuple based on the object properties, useful for hashing."""
-        return (self.heating_factor, self.cooling_factor)
+        return tuple(hash(dday) for dday in self._design_days) + \
+            (self.heating_factor, self.cooling_factor)
 
     def __hash__(self):
         return hash(self.__key())
@@ -132,6 +305,24 @@ class SizingParameter(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+    
+    def __len__(self):
+        return len(self._design_days)
+
+    def __getitem__(self, key):
+        return self._design_days[key]
+
+    def __setitem__(self, key, value):
+        assert isinstance(value, DesignDay), 'Expected' \
+                ' DesignDay type. Got {}'.format(type(value))
+        self._design_days[key] = value
+
+    def __iter__(self):
+        return iter(self._design_days)
+
+    def __contains__(self, item):
+        return item in self._design_days
 
     def __repr__(self):
-        return self.to_idf()
+        return 'SizingParameter:\n {} design days\n heating: {}\n cooling: ' \
+            '{}'.format(len(self._design_days), self.heating_factor, self.cooling_factor)

--- a/tests/ddy/chicago.ddy
+++ b/tests/ddy/chicago.ddy
@@ -1,0 +1,536 @@
+ ! The following Location and Design Day data are produced as possible from the indicated data source.
+ ! Wind Speeds follow the indicated design conditions rather than traditional values (6.7 m/s heating, 3.35 m/s cooling)
+ ! No special attempts at re-creating or determining missing data parts (e.g. Wind speed or direction)
+ ! are done.  Therefore, you should look at the data and fill in any incorrect values as you desire.
+  
+ Site:Location,
+  Chicago Ohare Intl Ap_IL_USA Design_Conditions,     !- Location Name
+      41.98,     !- Latitude {N+ S-}
+     -87.92,     !- Longitude {W- E+}
+      -6.00,     !- Time Zone Relative to GMT {GMT+/-}
+     201.00;     !- Elevation {m}
+ 
+ !  WMO=725300 Time Zone=NAC: (GMT-06:00) Central Time (US & Canada)
+ !  Data Source=ASHRAE 2009 Annual Design Conditions
+ RunPeriodControl:DaylightSavingTime,
+   2nd Sunday in March,    !- StartDate
+   2nd Sunday in November;    !- EndDate
+  
+ ! Using Design Conditions from "Climate Design Data 2009 ASHRAE Handbook"
+ ! Chicago Ohare Intl Ap_IL_USA Extreme Annual Wind Speeds, 1%=11.1m/s, 2.5%=9.4m/s, 5%=8.6m/s
+ ! Chicago Ohare Intl Ap_IL_USA Extreme Annual Temperatures, Max Drybulb=-23.7°C Min Drybulb=35.9°C
+  
+ ! Chicago Ohare Intl Ap_IL_USA Annual Heating Design Conditions Wind Speed=4.9m/s Wind Dir=270
+ ! Coldest Month=JAN
+ ! Chicago Ohare Intl Ap_IL_USA Annual Heating 99.6%, MaxDB=-20°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Htg 99.6% Condns DB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+        -20,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+        -20,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        4.9,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Heating 99%, MaxDB=-16.6°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Htg 99% Condns DB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+      -16.6,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+      -16.6,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        4.9,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Humidification 99.6% Design Conditions DP=>MCDB, DP=-25.7°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Hum_n 99.6% Condns DP=>MCDB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+      -19.2,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+      -25.7,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        4.9,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Humidification 99% Design Conditions DP=>MCDB, DP=-22.1°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Hum_n 99% Condns DP=>MCDB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+      -15.7,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+      -22.1,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        4.9,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Heating Wind 99.6% Design Conditions WS=>MCDB, WS=12.4m/s
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Htg Wind 99.6% Condns WS=>MCDB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       -3.5,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       -3.5,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+       12.4,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Heating Wind 99% Design Conditions WS=>MCDB, WS=11.4m/s
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Htg Wind 99% Condns WS=>MCDB,     !- Name
+          1,      !- Month
+         21,      !- Day of Month
+  WinterDesignDay,!- Day Type
+       -3.2,      !- Maximum Dry-Bulb Temperature {C}
+        0.0,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       -3.2,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+       11.4,      !- Wind Speed {m/s} design conditions vs. traditional 6.71 m/s (15 mph)
+        270,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+  ASHRAEClearSky, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+           ,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+           ,      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+       0.00;      !- Clearness {0.0 to 1.1}
+ 
+ ! Chicago Ohare Intl Ap Annual Cooling Design Conditions Wind Speed=5.2m/s Wind Dir=230
+ ! Hottest Month=JUL
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DB=>MWB) .4%, MaxDB=33.3°C MWB=23.7°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg .4% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       33.3,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       23.7,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DB=>MWB) 1%, MaxDB=31.6°C MWB=23°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 1% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       31.6,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+         23,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DB=>MWB) 2%, MaxDB=30.1°C MWB=22.1°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 2% Condns DB=>MWB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       30.1,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       22.1,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (WB=>MDB) .4%, MDB=31.2°C WB=25.5°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg .4% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       31.2,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       25.5,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (WB=>MDB) 1%, MDB=29.6°C WB=24.5°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 1% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       29.6,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       24.5,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (WB=>MDB) 2%, MDB=28.1°C WB=23.5°C
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 2% Condns WB=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       28.1,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Wetbulb,      !- Humidity Condition Type
+       23.5,      !- Wetbulb at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DP=>MDB) .4%, MDB=28.9°C DP=23.8°C HR=0.0192
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg .4% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       28.9,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       23.8,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DP=>MDB) 1%, MDB=27.7°C DP=22.9°C HR=0.0180
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 1% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       27.7,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       22.9,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (DP=>MDB) 2%, MDB=26.5°C DP=21.9°C HR=0.0170
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 2% Condns DP=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       26.5,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+    Dewpoint,     !- Humidity Condition Type
+       21.9,      !- Dewpoint at Maximum Dry-Bulb {C}
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+           ,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (Enthalpy=>MDB) .4%, MDB=31.4°C Enthalpy=79200.0J/kg
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg .4% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       31.4,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    79200.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (Enthalpy=>MDB) 1%, MDB=29.6°C Enthalpy=75100.0J/kg
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 1% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       29.6,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    75100.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 
+ ! Chicago Ohare Intl Ap_IL_USA Annual Cooling (Enthalpy=>MDB) 2%, MDB=28.2°C Enthalpy=70900.0J/kg
+ SizingPeriod:DesignDay,
+  Chicago Ohare Intl Ap Ann Clg 2% Condns Enth=>MDB,     !- Name
+          7,      !- Month
+         21,      !- Day of Month
+  SummerDesignDay,!- Day Type
+       28.2,      !- Maximum Dry-Bulb Temperature {C}
+       10.5,      !- Daily Dry-Bulb Temperature Range {C}
+ DefaultMultipliers, !- Dry-Bulb Temperature Range Modifier Type
+           ,      !- Dry-Bulb Temperature Range Modifier Schedule Name
+   Enthalpy,      !- Humidity Condition Type
+           ,      !- Wetbulb or Dewpoint at Maximum Dry-Bulb
+           ,      !- Humidity Indicating Day Schedule Name
+           ,      !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+    70900.0,      !- Enthalpy at Maximum Dry-Bulb {J/kg}
+           ,      !- Daily Wet-Bulb Temperature Range {deltaC}
+     98934.,      !- Barometric Pressure {Pa}
+        5.2,      !- Wind Speed {m/s} design conditions vs. traditional 3.35 m/s (7mph)
+        230,      !- Wind Direction {Degrees; N=0, S=180}
+         No,      !- Rain {Yes/No}
+         No,      !- Snow on ground {Yes/No}
+         No,      !- Daylight Savings Time Indicator
+       ASHRAETau, !- Solar Model Indicator
+           ,      !- Beam Solar Day Schedule Name
+           ,      !- Diffuse Solar Day Schedule Name
+      0.455,      !- ASHRAE Clear Sky Optical Depth for Beam Irradiance (taub)
+      2.050;      !- ASHRAE Clear Sky Optical Depth for Diffuse Irradiance (taud)
+ 

--- a/tests/ddy/chicago_monthly.ddy
+++ b/tests/ddy/chicago_monthly.ddy
@@ -1,0 +1,355 @@
+Site:Location,
+  Chicago Ohare Intl Ap,
+  41.96666666666667,      !Latitude
+  -87.91666666666667,     !Longitude
+  -6.0,     !Time Zone
+  201.0;       !Elevation
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Jan,                               !- Name
+  1,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  5.6,                                                         !- Max Dry-Bulb Temp {C}
+  9.0,                                                         !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  3.9,                                                         !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.9,                                                         !- Wind Speed {m/s}
+  270,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.302,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.364;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Feb,                               !- Name
+  2,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  7.8,                                                         !- Max Dry-Bulb Temp {C}
+  10.9,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  4.8,                                                         !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  5.1,                                                         !- Wind Speed {m/s}
+  225,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.343,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.149;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Mar,                               !- Name
+  3,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  15.8,                                                        !- Max Dry-Bulb Temp {C}
+  13.9,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  11.2,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  5.5,                                                         !- Wind Speed {m/s}
+  45,                                                          !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.39,                                                        !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.03;                                                        !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Apr,                               !- Name
+  4,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  21.6,                                                        !- Max Dry-Bulb Temp {C}
+  14.7,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  14.6,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.8,                                                         !- Wind Speed {m/s}
+  180,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.417,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  1.998;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for May,                               !- Name
+  5,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  26.5,                                                        !- Max Dry-Bulb Temp {C}
+  14.1,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  18.6,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  3.7,                                                         !- Wind Speed {m/s}
+  45,                                                          !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.438,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  1.999;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Jun,                               !- Name
+  6,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  30.4,                                                        !- Max Dry-Bulb Temp {C}
+  13.4,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  21.6,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.9,                                                         !- Wind Speed {m/s}
+  180,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.458,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.001;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Jul,                               !- Name
+  7,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  31.7,                                                        !- Max Dry-Bulb Temp {C}
+  12.2,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  23.6,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.2,                                                         !- Wind Speed {m/s}
+  180,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.455,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.05;                                                        !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Aug,                               !- Name
+  8,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  30.3,                                                        !- Max Dry-Bulb Temp {C}
+  11.7,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  23.1,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  3.8,                                                         !- Wind Speed {m/s}
+  225,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.452,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.048;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Sep,                               !- Name
+  9,                                                           !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  27.8,                                                        !- Max Dry-Bulb Temp {C}
+  12.7,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  20.2,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  3.4,                                                         !- Wind Speed {m/s}
+  270,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.412,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.146;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Oct,                               !- Name
+  10,                                                          !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  21.9,                                                        !- Max Dry-Bulb Temp {C}
+  13.6,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  15.8,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.8,                                                         !- Wind Speed {m/s}
+  180,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.365,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.259;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Nov,                               !- Name
+  11,                                                          !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  15.5,                                                        !- Max Dry-Bulb Temp {C}
+  10.9,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  12.6,                                                        !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  5.3,                                                         !- Wind Speed {m/s}
+  180,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.337,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.303;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+
+SizingPeriod:DesignDay,
+  5% Cooling Design Day for Dec,                               !- Name
+  12,                                                          !- Month
+  21,                                                          !- Day of Month
+  SummerDesignDay,                                             !- Day Type
+  8.7,                                                         !- Max Dry-Bulb Temp {C}
+  10.0,                                                        !- Daily Dry-Bulb Temp Range {C}
+  DefaultMultipliers,                                          !- Dry-Bulb Temp Range Modifier Type
+  ,                                                            !- Dry-Bulb Temp Range Modifier Schedule Name
+  Wetbulb,                                                     !- Humidity Condition Type
+  6.4,                                                         !- Wetbulb/Dewpoint at Max Dry-Bulb {C}
+  ,                                                            !- Humidity Indicating Day Schedule Name
+  ,                                                            !- Humidity Ratio at Maximum Dry-Bulb {kgWater/kgDryAir}
+  ,                                                            !- Enthalpy at Maximum Dry-Bulb {J/kg}
+  ,                                                            !- Daily Wet-Bulb Temperature Range {deltaC}
+  98934.0,                                                     !- Barometric Pressure {Pa}
+  4.3,                                                         !- Wind Speed {m/s}
+  270,                                                         !- Wind Direction {Degrees; N=0, S=180}
+  No,                                                          !- Rain {Yes/No}
+  No,                                                          !- Snow on ground {Yes/No}
+  No,                                                          !- Daylight Savings Time Indicator {Yes/No}
+  ASHRAETau,                                                   !- Solar Model Indicator
+  ,                                                            !- Beam Solar Day Schedule Name
+  ,                                                            !- Diffuse Solar Day Schedule Name
+  0.307,                                                       !- ASHRAE Clear Sky Beam Optical Depth (taub)
+  2.388;                                                       !- ASHRAE Clear Sky Diffuse Optical Depth (taud)
+
+
+

--- a/tests/simulation_parameter_test.py
+++ b/tests/simulation_parameter_test.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from honeybee_energy.simulationparameter import SimulationParameter
+from honeybee_energy.simulation.parameter import SimulationParameter
 from honeybee_energy.simulation.output import SimulationOutput
 from honeybee_energy.simulation.runperiod import RunPeriod
 from honeybee_energy.simulation.daylightsaving import DaylightSavingTime
@@ -46,7 +46,9 @@ def test_simulation_parameter_setability():
     shadow_calc_alt = ShadowCalculation('FullExteriorWithReflections')
     sim_par.shadow_calculation = shadow_calc_alt
     assert sim_par.shadow_calculation == shadow_calc_alt
-    sizing_alt = SizingParameter(1, 1)
+    sizing_alt = SizingParameter(None, 1, 1)
+    relative_path = './tests/ddy/chicago_monthly.ddy'
+    sizing_alt.add_from_ddy(relative_path)
     sim_par.sizing_parameter = sizing_alt
     assert sim_par.sizing_parameter == sizing_alt
 
@@ -79,11 +81,14 @@ def test_simulation_parameter_init_from_idf():
     sim_par.simulation_control = sim_control_alt
     shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
     sim_par.shadow_calculation = shadow_calc_alt
-    sizing_alt = SizingParameter(1, 1)
+    sizing_alt = SizingParameter(None, 1, 1)
+    relative_path = './tests/ddy/chicago.ddy'
+    sizing_alt.add_from_ddy_996_004(relative_path)
     sim_par.sizing_parameter = sizing_alt
 
     idf_str = sim_par.to_idf()
     rebuilt_sim_par = SimulationParameter.from_idf(idf_str)
+    rebuilt_sim_par.sizing_parameter.apply_location(sizing_alt[0].location)
     assert sim_par == rebuilt_sim_par
     assert rebuilt_sim_par.to_idf() == idf_str
 
@@ -101,8 +106,8 @@ def test_simulation_parameter_to_dict_simple():
     assert 'sizing_parameter' in sim_par_dict
 
     """
-    f_dir = 'C:/Users/chris/Documents/GitHub/energy-model-schema/app/models/samples/json'
-    dest_file = f_dir + '/simple_simulation_par.json'
+    f_dir = 'C:/Users/chris/Documents/GitHub/honeybee-model-schema/honeybee_model_schema/samples'
+    dest_file = f_dir + '/simulation_par_simple.json'
     with open(dest_file, 'w') as fp:
         json.dump(sim_par_dict, fp, indent=4)
     """
@@ -130,7 +135,9 @@ def test_simulation_parameter_to_dict_detailed():
     sim_par.simulation_control = sim_control_alt
     shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
     sim_par.shadow_calculation = shadow_calc_alt
-    sizing_alt = SizingParameter(1, 1)
+    sizing_alt = SizingParameter(None, 1, 1)
+    relative_path = './tests/ddy/chicago.ddy'
+    sizing_alt.add_from_ddy_996_004(relative_path)
     sim_par.sizing_parameter = sizing_alt
 
     sim_par_dict = sim_par.to_dict()
@@ -138,10 +145,11 @@ def test_simulation_parameter_to_dict_detailed():
     assert 'outputs' in sim_par_dict['output']
     assert 'holidays' in sim_par_dict['run_period']
     assert 'daylight_saving_time' in sim_par_dict['run_period']
+    assert 'design_days' in sim_par_dict['sizing_parameter']
 
     """
-    f_dir = 'C:/Users/chris/Documents/GitHub/energy-model-schema/app/models/samples/json'
-    dest_file = f_dir + '/detailed_simulation_par.json'
+    f_dir = 'C:/Users/chris/Documents/GitHub/honeybee-model-schema/honeybee_model_schema/samples'
+    dest_file = f_dir + '/simulation_par_detailed.json'
     with open(dest_file, 'w') as fp:
         json.dump(sim_par_dict, fp, indent=4)
     """
@@ -161,10 +169,13 @@ def test_simulation_parameter_dict_methods():
     sim_par.simulation_control = sim_control_alt
     shadow_calc_alt = ShadowCalculation(calculation_frequency=20)
     sim_par.shadow_calculation = shadow_calc_alt
-    sizing_alt = SizingParameter(1, 1)
+    sizing_alt = SizingParameter(None, 1, 1)
+    relative_path = './tests/ddy/chicago.ddy'
+    sizing_alt.add_from_ddy_996_004(relative_path)
     sim_par.sizing_parameter = sizing_alt
 
     sim_par_dict = sim_par.to_dict()
     new_sim_par = SimulationParameter.from_dict(sim_par_dict)
+    new_sim_par.sizing_parameter.apply_location(sizing_alt[0].location)
     assert new_sim_par == sim_par
     assert sim_par_dict == new_sim_par.to_dict()

--- a/tests/simulation_sizing_test.py
+++ b/tests/simulation_sizing_test.py
@@ -1,6 +1,9 @@
 # coding=utf-8
 from honeybee_energy.simulation.sizing import SizingParameter
 
+from ladybug.ddy import DDY
+from ladybug.designday import DesignDay
+
 import pytest
 
 
@@ -9,6 +12,8 @@ def test_sizing_parameter_init():
     sizing = SizingParameter()
     str(sizing)  # test the string representation
 
+    assert len(sizing.design_days) == 0
+    assert len(sizing) == 0
     assert sizing.heating_factor == 1.25
     assert sizing.cooling_factor == 1.15
 
@@ -17,6 +22,11 @@ def test_sizing_parameter_setability():
     """Test the setting of properties of SizingParameter."""
     sizing = SizingParameter()
 
+    relative_path = './tests/ddy/chicago_monthly.ddy'
+    sizing.add_from_ddy(relative_path)
+    assert len(sizing.design_days) == 12
+    assert len(sizing) == 12
+    assert isinstance(sizing[0], DesignDay)
     sizing.heating_factor = 1
     assert sizing.heating_factor == 1
     sizing.cooling_factor = 1
@@ -26,8 +36,10 @@ def test_sizing_parameter_setability():
 def test_sizing_parameter_equality():
     """Test the equality of SizingParameter objects."""
     sizing = SizingParameter()
+    relative_path = './tests/ddy/chicago_monthly.ddy'
+    sizing.add_from_ddy(relative_path)
     sizing_dup = sizing.duplicate()
-    sizing_alt = SizingParameter(1)
+    sizing_alt = SizingParameter(None, 1)
 
     assert sizing is sizing
     assert sizing is not sizing_dup
@@ -37,21 +49,39 @@ def test_sizing_parameter_equality():
     assert sizing != sizing_alt
 
 
-def test_simulation_control_init_from_idf():
+def test_sizing_parameter_init_from_idf():
     """Test the initialization of SimulationControl from_idf."""
-    sizing = SizingParameter(1)
+    sizing = SizingParameter(None, 1)
+    relative_path = './tests/ddy/chicago.ddy'
+    sizing.add_from_ddy_996_004(relative_path)
 
-    idf_str = sizing.to_idf()
-    rebuilt_sizing = SizingParameter.from_idf(idf_str)
+    des_days, idf_str = sizing.to_idf()
+    rebuilt_sizing = SizingParameter.from_idf(des_days, idf_str)
+    rebuilt_sizing.apply_location(sizing[0].location)
     assert sizing == rebuilt_sizing
-    assert rebuilt_sizing.to_idf() == idf_str
+    assert rebuilt_sizing.to_idf()[1] == idf_str
+    for dday1, dday2 in zip(des_days, rebuilt_sizing.to_idf()[0]):
+        assert dday1 == dday2
 
 
-def test_simulation_control_dict_methods():
+def test_sizing_parameter_dict_methods():
     """Test the to/from dict methods."""
-    sizing = SizingParameter(1)
+    sizing = SizingParameter(None, 1)
+    relative_path = './tests/ddy/chicago.ddy'
+    sizing.add_from_ddy_996_004(relative_path)
 
     sizing_dict = sizing.to_dict()
     new_sizing = SizingParameter.from_dict(sizing_dict)
+    new_sizing.apply_location(sizing[0].location)
     assert new_sizing == sizing
     assert sizing_dict == new_sizing.to_dict()
+
+
+def test_sizing_parameter_to_ddy():
+    """Test the setting of properties of SizingParameter."""
+    sizing = SizingParameter()
+    relative_path = './tests/ddy/chicago_monthly.ddy'
+    sizing.add_from_ddy(relative_path)
+    ddy_obj = DDY.from_ddy_file(relative_path)
+
+    assert sizing.to_ddy() == ddy_obj


### PR DESCRIPTION
Since these ultimately end up in the IDF and OSM, I think it makes sense to include them within the Python objects here rather than have users upload a .ddy file that might often have more design days than they actually need.