### PR TITLE
Add dictionary format examples in from_dict()  docstrigs

### DIFF
--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -121,7 +121,7 @@ class Folders(object):
 
         This folder must have the following sub-folders in order to be valid:
 
-        * ladybug - ruby library with modules for model translation to OpenStudio.
+        * from_honeybee - ruby library with modules for model translation to OpenStudio.
         * measures - folder with the actual measures that run the translation.
         * files - folder containing the openapi schemas
         """

--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -111,10 +111,19 @@ class AirBoundaryConstruction(object):
         """Create a AirBoundaryConstruction from an abridged dictionary.
 
         Args:
-            data: A AirBoundaryConstructionAbridged dictionary.
+            data: A AirBoundaryConstructionAbridged dictionary with the format below.
             schedule_dict: A dictionary with schedule names as keys and
                 honeybee schedule objects as values. These will be used to
                 assign the schedule to the AirBoundaryConstruction object.
+
+        .. code-block:: python
+
+            {
+            "type": 'AirBoundaryConstructionAbridged',
+            "name": 'Generic Air Boundary Construction',
+            "air_mixing_per_area": 0.2,
+            "air_mixing_schedule": ""  # Name of a schedule
+            }
         """
         assert data['type'] == 'AirBoundaryConstructionAbridged', \
             'Expected AirBoundaryConstructionAbridged. Got {}.'.format(data['type'])

--- a/honeybee_energy/construction/opaque.py
+++ b/honeybee_energy/construction/opaque.py
@@ -177,7 +177,7 @@ class OpaqueConstruction(_ConstructionBase):
             {
             "type": 'OpaqueConstruction',
             "name": 'Generic Brick Wall',
-            "layers": [] # list of material names (from outside to inside)
+            "layers": [],  # list of material names (from outside to inside)
             "materials": []  # list of unique material objects
             }
         """
@@ -203,6 +203,14 @@ class OpaqueConstruction(_ConstructionBase):
             data: An OpaqueConstructionAbridged dictionary.
             materials: A dictionary with names of materials as keys and Python
                 material objects as values.
+
+        .. code-block:: python
+
+            {
+            "type": 'OpaqueConstructionAbridged',
+            "name": 'Generic Brick Wall',
+            "layers": [],  # list of material names (from outside to inside)
+            }
         """
         assert data['type'] == 'OpaqueConstructionAbridged', \
             'Expected OpaqueConstructionAbridged. Got {}.'.format(data['type'])

--- a/honeybee_energy/construction/window.py
+++ b/honeybee_energy/construction/window.py
@@ -59,7 +59,7 @@ class WindowConstruction(_ConstructionBase):
         * An exterior shade/screen/blind must be the first layer
         * An interior shade/blind must be the last layer
         * Shades/screens should always be adjacent to glass layers and should never
-          be adjacent to gas layers(honeybee takes care of adding the additional gas
+          be adjacent to gas layers (honeybee takes care of adding the additional gas
           gaps needed by EnergyPlus using the material's distance_to_shade property
           to set the gap thickness).
         * For triple glazing the between-glass shade/blind must be between the two

--- a/honeybee_energy/construction/window.py
+++ b/honeybee_energy/construction/window.py
@@ -58,18 +58,14 @@ class WindowConstruction(_ConstructionBase):
         * Only one shade/screen/blind layer is allowed
         * An exterior shade/screen/blind must be the first layer
         * An interior shade/blind must be the last layer
-        * An interior screen is not allowed
-        * For an exterior shade/screen/blind or interior shade/blind, there should
-          not be a gas layer between the shade/screen/blind and adjacent glass
-          (we take care of this for shade materials)
-        * A between-glass screen is not allowed
-        * A between-glass shade/blind is allowed only for double and triple glazing
-        * A between-glass shade/blind must have adjacent gas layers of the same type
-          and width (we take care of this so the user does not specify the gaps)
+        * Shades/screens should always be adjacent to glass layers and should never
+          be adjacent to gas layers(honeybee takes care of adding the additional gas
+          gaps needed by EnergyPlus using the material's distance_to_shade property
+          to set the gap thickness).
         * For triple glazing the between-glass shade/blind must be between the two
           inner glass layers. (currently no check)
-        * The slat width of a between-glass blind must be less than the sum of the
-          widths of the gas layers adjacent to the blind. (currently no check).
+        * The slat width of a between-glass blind must be less than 2 times the
+          blind's distance_to_glass.(currently no check).
         """
         try:
             if not isinstance(mats, tuple):
@@ -343,6 +339,7 @@ class WindowConstruction(_ConstructionBase):
             "type": 'WindowConstruction',
             "name": 'Generic Double Pane Window',
             "materials": []  # list of material objects
+            "layers": [],  # list of material names (from outside to inside)
             }
         """
         assert data['type'] == 'WindowConstruction', \
@@ -374,9 +371,17 @@ class WindowConstruction(_ConstructionBase):
         """Create a WindowConstruction from an abridged dictionary.
 
         Args:
-            data: An WindowConstructionAbridged dictionary.
+            data: An WindowConstructionAbridged dictionary with the format below.
             materials: A dictionary with names of materials as keys and Python
                 material objects as values.
+
+        .. code-block:: python
+
+            {
+            "type": 'WindowConstructionAbridged',
+            "name": 'Generic Double Pane Window',
+            "layers": [],  # list of material names (from outside to inside)
+            }
         """
         assert data['type'] == 'WindowConstructionAbridged', \
             'Expected WindowConstructionAbridged. Got {}.'.format(data['type'])

--- a/honeybee_energy/constructionset.py
+++ b/honeybee_energy/constructionset.py
@@ -333,8 +333,8 @@ class ConstructionSet(object):
             "roof_ceiling_set": {},  # A RoofCeilingSet dictionary
             "aperture_set": {},  # A ApertureSet dictionary
             "door_set": {},  # A DoorSet dictionary
-            "shade_construction": {},  # A ShadeConstruction dictionary
-            "air_boundary_construction": {},  # A AirBoundaryConstruction dictionary
+            "shade_construction": str,  # ShadeConstruction name
+            "air_boundary_construction": str,  # AirBoundaryConstruction name
             "materials": [],  # list of material dictionaries
             "constructions": []  # list of abridged construction dictionaries
             }
@@ -380,8 +380,8 @@ class ConstructionSet(object):
             "roof_ceiling_set": {},  # A RoofCeilingSet dictionary
             "aperture_set": {},  # A ApertureSet dictionary
             "door_set": {},  # A DoorSet dictionary
-            "shade_construction": {},  # A ShadeConstruction dictionary
-            "air_boundary_construction": {}  # A AirBoundaryConstruction dictionary
+            "shade_construction": str,  # ShadeConstruction name
+            "air_boundary_construction": str  # AirBoundaryConstruction name
             }
         """
         assert data['type'] == 'ConstructionSetAbridged', \

--- a/honeybee_energy/constructionset.py
+++ b/honeybee_energy/constructionset.py
@@ -320,7 +320,24 @@ class ConstructionSet(object):
         classmethod to work.
 
         Args:
-            data: Dictionary describing the ConstructionSet.
+            data: Dictionary describing the ConstructionSet with the
+                format below.
+
+        .. code-block:: python
+
+            {
+            "type": 'ConstructionSet',
+            "name": str,  # ConstructionSet name
+            "wall_set": {},  # A WallSet dictionary
+            "floor_set": {},  # A FloorSet dictionary
+            "roof_ceiling_set": {},  # A RoofCeilingSet dictionary
+            "aperture_set": {},  # A ApertureSet dictionary
+            "door_set": {},  # A DoorSet dictionary
+            "shade_construction": {},  # A ShadeConstruction dictionary
+            "air_boundary_construction": {},  # A AirBoundaryConstruction dictionary
+            "materials": [],  # list of material dictionaries
+            "constructions": []  # list of abridged construction dictionaries
+            }
         """
         assert data['type'] == 'ConstructionSet', \
             'Expected ConstructionSet. Got {}.'.format(data['type'])
@@ -352,6 +369,20 @@ class ConstructionSet(object):
             construction_dict: A dictionary with construction names as keys and
                 honeybee construction objects as values. These will be used to
                 assign the constructions to the ConstructionSet object.
+
+        .. code-block:: python
+
+            {
+            "type": 'ConstructionSetAbridged',
+            "name": str,  # ConstructionSet name
+            "wall_set": {},  # A WallSet dictionary
+            "floor_set": {},  # A FloorSet dictionary
+            "roof_ceiling_set": {},  # A RoofCeilingSet dictionary
+            "aperture_set": {},  # A ApertureSet dictionary
+            "door_set": {},  # A DoorSet dictionary
+            "shade_construction": {},  # A ShadeConstruction dictionary
+            "air_boundary_construction": {}  # A AirBoundaryConstruction dictionary
+            }
         """
         assert data['type'] == 'ConstructionSetAbridged', \
             'Expected ConstructionSetAbridged. Got {}.'.format(data['type'])

--- a/honeybee_energy/programtype.py
+++ b/honeybee_energy/programtype.py
@@ -203,7 +203,25 @@ class ProgramType(object):
         classmethod to work.
 
         Args:
-            data: Dictionary describing the ProgramType.
+            data: Dictionary describing the ProgramType with the format below.
+
+        .. code-block:: python
+
+            {
+            "type": 'ProgramType',
+            "name": str,  # ProgramType name
+            'people': {},  # A People dictionary
+            'lighting': {},  # A Lighting dictionary
+            'electric_equipment': {},  # A ElectricEquipment dictionary
+            'gas_equipment': {},  # A GasEquipment dictionary
+            'infiltration': {},  # A Infliltration dictionary
+            'ventilation': {},  # A Ventilation dictionary
+            'setpoint': {},  # A Setpoint dictionary
+            "schedule_type_limits": [],  # list of ScheduleTypeLimit dictionaries
+            "schedules": []  # list of ScheduleRuleset/ScheduleFixedInterval dictionaries
+            }
+
+
         """
         assert data['type'] == 'ProgramType', \
             'Expected ProgramType. Got {}.'.format(data['type'])
@@ -257,6 +275,20 @@ class ProgramType(object):
             schedule_dict: A dictionary with schedule names as keys and honeybee schedule
                 objects as values (either ScheduleRuleset or ScheduleFixedInterval).
                 These will be used to assign the schedules to the ProgramType object.
+
+        .. code-block:: python
+
+            {
+            "type": 'ProgramTypeAbridged',
+            "name": str,  # ProgramType name
+            'people': {},  # A People dictionary
+            'lighting': {},  # A Lighting dictionary
+            'electric_equipment': {},  # A ElectricEquipment dictionary
+            'gas_equipment': {},  # A GasEquipment dictionary
+            'infiltration': {},  # A Infliltration dictionary
+            'ventilation': {},  # A Ventilation dictionary
+            'setpoint': {}  # A Setpoint dictionary
+            }
         """
         assert data['type'] == 'ProgramTypeAbridged', \
             'Expected ProgramTypeAbridged dictionary. Got {}.'.format(data['type'])

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -98,6 +98,7 @@ class ApertureEnergyProperties(object):
             "construction": {
                 "type": 'WindowConstruction',
                 "name": 'Generic Double Pane Window',
+                "layers": [],  # list of material names (from outside to inside)
                 "materials": []  # list of material objects
                 }
             }

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -87,8 +87,20 @@ class ApertureEnergyProperties(object):
         classmethod to work.
 
         Args:
-            data: A dictionary representation of ApertureEnergyProperties.
+            data: A dictionary representation of ApertureEnergyProperties in the
+                format below.
             host: A Aperture object that hosts these properties.
+
+        .. code-block:: python
+
+            {
+            "type": 'ApertureEnergyProperties',
+            "construction": {
+                "type": 'WindowConstruction',
+                "name": 'Generic Double Pane Window',
+                "materials": []  # list of material objects
+                }
+            }
         """
         assert data['type'] == 'ApertureEnergyProperties', \
             'Expected ApertureEnergyProperties. Got {}.'.format(data['type'])

--- a/honeybee_energy/properties/door.py
+++ b/honeybee_energy/properties/door.py
@@ -94,8 +94,21 @@ class DoorEnergyProperties(object):
         classmethod to work.
 
         Args:
-            data: A dictionary representation of DoorEnergyProperties.
+            data: A dictionary representation of DoorEnergyProperties in the
+                format below.
             host: A Door object that hosts these properties.
+
+        .. code-block:: python
+
+            {
+            "type": 'DoorEnergyProperties',
+            "construction": {
+                "type": 'OpaqueConstruction',
+                "name": str,  # Construction name
+                "layers": [],  # list of material names (from outside to inside)
+                "materials": []  # list of unique material objects
+                }
+            }
         """
         assert data['type'] == 'DoorEnergyProperties', \
             'Expected DoorEnergyProperties. Got {}.'.format(data['type'])

--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -90,8 +90,21 @@ class FaceEnergyProperties(object):
         classmethod to work.
 
         Args:
-            data: A dictionary representation of FaceEnergyProperties.
+            data: A dictionary representation of FaceEnergyProperties with the
+                format below.
             host: A Face object that hosts these properties.
+
+        .. code-block:: python
+
+            {
+            "type": 'FaceEnergyProperties',
+            "construction": {
+                "type": 'OpaqueConstruction',
+                "name": str, "Construction name"
+                "layers": [], # list of material names (from outside to inside)
+                "materials": []  # list of unique material objects
+                }
+            }
         """
         assert data['type'] == 'FaceEnergyProperties', \
             'Expected FaceEnergyProperties. Got {}.'.format(data['type'])

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -304,8 +304,25 @@ class RoomEnergyProperties(object):
         classmethod to work.
 
         Args:
-            data: A dictionary representation of RoomEnergyProperties.
+            data: A dictionary representation of RoomEnergyProperties with the
+                format below.
             host: A Room object that hosts these properties.
+
+        .. code-block:: python
+
+            {
+            "type": 'RoomEnergyProperties',
+            "construction_set": {},  # A ConstructionSet dictionary
+            "program_type": {},  # A ProgramType dictionary
+            "hvac": {}, # A HVACSystem dictionary
+            "people":{},  # A People dictionary
+            "lighting": {},  # A Lighting dictionary
+            "electric_equipment": {},  # A ElectricEquipment dictionary
+            "gas_equipment": {},  # A GasEquipment dictionary
+            "infiltration": {},  # A Infiltration dictionary
+            "ventilation": {},  # A Ventilation dictionary
+            "setpoint": {}  # A Setpoint dictionary
+            }
         """
         assert data['type'] == 'RoomEnergyProperties', \
             'Expected RoomEnergyProperties. Got {}.'.format(data['type'])

--- a/honeybee_energy/properties/shade.py
+++ b/honeybee_energy/properties/shade.py
@@ -110,8 +110,17 @@ class ShadeEnergyProperties(object):
         classmethod to work.
 
         Args:
-            data: A dictionary representation of ShadeEnergyProperties.
+            data: A dictionary representation of ShadeEnergyProperties with the
+                format below.
             host: A Shade object that hosts these properties.
+
+        .. code-block:: python
+
+            {
+            "type": 'ShadeEnergyProperties',
+            "construction": {},  # A ShadeConstruction dictionary
+            "transmittance_schedule": {}  # A transmittance schedule dictionary
+            }
         """
         assert data['type'] == 'ShadeEnergyProperties', \
             'Expected ShadeEnergyProperties. Got {}.'.format(data['type'])

--- a/honeybee_energy/schedule/fixedinterval.py
+++ b/honeybee_energy/schedule/fixedinterval.py
@@ -411,9 +411,22 @@ class ScheduleFixedInterval(object):
         """Create a ScheduleFixedInterval from an abridged dictionary.
 
         Args:
-            data: ScheduleFixedIntervalAbridged dictionary.
+            data: ScheduleFixedIntervalAbridged dictionary with format below.
             schedule_type_limits: A dictionary with names of schedule type limits
                 as keys and Python schedule type limit objects as values.
+
+        .. code-block:: python
+
+            {
+            "type": 'ScheduleFixedIntervalAbridged',
+            "name": 'Automated Awning Transmittance',
+            "values": [], # list of numbers for the values of the schedule
+            "schedule_type_limit": "", # ScheduleTypeLimit name
+            "timestep": 1, # Integer for the timestep of the schedule
+            "start_date": (1, 1), # Date dictionary representation
+            "placeholder_value": 0, # Number for the values out of range
+            "interpolate": False # Boolean noting whether to interpolate between values
+            }
         """
         assert data['type'] == 'ScheduleFixedIntervalAbridged', \
             'Expected ScheduleFixedIntervalAbridged. Got {}.'.format(data['type'])

--- a/honeybee_energy/schedule/ruleset.py
+++ b/honeybee_energy/schedule/ruleset.py
@@ -55,7 +55,7 @@ class ScheduleRuleset(object):
         * is_single_week
     """
     __slots__ = ('_name', '_default_day_schedule', '_schedule_rules', '_holiday_schedule',
-                 '_summer_designday_schedule', '_winter_designday_schedule',  
+                 '_summer_designday_schedule', '_winter_designday_schedule',
                  '_schedule_type_limit', '_locked')
     _dow_text_to_int = {'sunday': 1, 'monday': 2, 'tuesday': 3, 'wednesday': 4,
                         'thursday': 2, 'friday': 3, 'saturday': 7}
@@ -627,6 +627,20 @@ class ScheduleRuleset(object):
             data: ScheduleRulesetAbridged dictionary.
             schedule_type_limits: A dictionary with names of schedule type limits
                 as keys and Python schedule type limit objects as values.
+
+        .. code-block:: python
+
+            {
+            "type": 'ScheduleRulesetAbridged',
+            "name": 'Office Occupancy',
+            "day_schedules": [], # Array of ScheduleDay dictionary representations
+            "default_day_schedule": str, # ScheduleDay name
+            "schedule_rules": [], # list of ScheduleRuleAbridged dictionaries
+            "schedule_type_limit": str, # ScheduleTypeLimit name
+            "holiday_schedule": str, # ScheduleDay name
+            "summer_designday_schedule": str, # ScheduleDay name
+            "winter_designday_schedule": str # ScheduleDay name
+            }
         """
         assert data['type'] == 'ScheduleRulesetAbridged', \
             'Expected ScheduleRulesetAbridged. Got {}.'.format(data['type'])


### PR DESCRIPTION
Hi @chriswmackey 
I hope I got these right, I did my best to figure out the keys and differences between from_dict and from_dict_abridged but I feel pretty good.

One minor comment I think the 'layers' key was missing from the WindowConstruction.from_dict() example. I added it, hope that's okay.

Please let me know if I got these right, Note also in same cases I specified 'str' in 'name' fields , you might have better options for some of these.


