### PR TITLE
feat(lib): Add methods to automatically load extensions

### DIFF
--- a/honeybee_energy/config.json
+++ b/honeybee_energy/config.json
@@ -3,5 +3,6 @@
     "energyplus_path": "",
     "openstudio_path": "",
     "energy_model_measure_path": "",
-    "standards_data_folder": ""
+    "standards_data_folder": "",
+    "standards_extension_folders": []
 }

--- a/honeybee_energy/construction/dictutil.py
+++ b/honeybee_energy/construction/dictutil.py
@@ -42,7 +42,7 @@ def dict_to_construction(constr_dict, raise_exception=True):
 
 def dict_abridged_to_construction(constr_dict, materials, schedules,
                                   raise_exception=True):
-    """Get a Python object of any Construction from a dictionary.
+    """Get a Python object of any Construction from an abridged dictionary.
 
     Args:
         constr_dict: An abridged dictionary of any Honeybee energy construction.

--- a/honeybee_energy/lib/_loadconstructions.py
+++ b/honeybee_energy/lib/_loadconstructions.py
@@ -59,3 +59,24 @@ for f in os.listdir(folders.construction_lib):
                             _shade_constructions[constr_name] = constr
                 except KeyError:
                     pass  # not a Honeybee JSON file with Constructions
+
+
+# empty dictionaries to hold extension data
+_opaque_constr_standards_dict = {}
+_window_constr_standards_dict = {}
+_shade_constr_standards_dict = {}
+
+for ext_folder in folders.standards_extension_folders:
+    _data_dir = os.path.join(ext_folder, 'constructions')
+    _opaque_dir = os.path.join(_data_dir, 'opaque_construction.json')
+    if os.path.isfile(_opaque_dir):
+        with open(_opaque_dir, 'r') as f:
+            _opaque_constr_standards_dict.update(json.load(f))
+    _window_dir = os.path.join(_data_dir, 'window_construction.json')
+    if os.path.isfile(_window_dir):
+        with open(_window_dir, 'r') as f:
+            _window_constr_standards_dict.update(json.load(f))
+    _shade_dir = os.path.join(_data_dir, 'shade_construction.json')
+    if os.path.isfile(_shade_dir):
+        with open(_shade_dir, 'r') as f:
+            _shade_constr_standards_dict.update(json.load(f))

--- a/honeybee_energy/lib/_loadconstructionsets.py
+++ b/honeybee_energy/lib/_loadconstructionsets.py
@@ -31,3 +31,15 @@ for f in os.listdir(folders.constructionset_lib):
                 _construction_sets[constructionset.name] = constructionset
             except ValueError:
                 pass  # failed to find the construction in the construction library
+
+
+# empty dictionaries to hold extension data
+_construction_set_standards_dict = {}
+
+for ext_folder in folders.standards_extension_folders:
+    _data_dir = os.path.join(ext_folder, 'constructionsets')
+    for _c_set_json in os.listdir(_data_dir):
+        if _c_set_json.endswith('.json'):
+            _c_set_dir = os.path.join(_data_dir, _c_set_json)
+            with open(_c_set_dir, 'r') as f:
+                _construction_set_standards_dict.update(json.load(f))

--- a/honeybee_energy/lib/_loadmaterials.py
+++ b/honeybee_energy/lib/_loadmaterials.py
@@ -27,3 +27,19 @@ for f in os.listdir(folders.construction_lib):
                         _opaque_materials[mat_name] = mat_obj
             except KeyError:
                 pass  # not a Honeybee JSON file with Materials
+
+
+# empty dictionaries to hold extension data
+_opaque_mat_standards_dict = {}
+_window_mat_standards_dict = {}
+
+for ext_folder in folders.standards_extension_folders:
+    _data_dir = os.path.join(ext_folder, 'constructions')
+    _opaque_dir = os.path.join(_data_dir, 'opaque_material.json')
+    if os.path.isfile(_opaque_dir):
+        with open(_opaque_dir, 'r') as f:
+            _opaque_mat_standards_dict.update(json.load(f))
+    _window_dir = os.path.join(_data_dir, 'window_material.json')
+    if os.path.isfile(_window_dir):
+        with open(_window_dir, 'r') as f:
+            _window_mat_standards_dict.update(json.load(f))

--- a/honeybee_energy/lib/_loadprogramtypes.py
+++ b/honeybee_energy/lib/_loadprogramtypes.py
@@ -25,3 +25,15 @@ for f in os.listdir(folders.programtype_lib):
                 _program_types[program.name] = program
             except ValueError:
                 pass  # failed to find schedule in the library; not a valid program
+
+
+# empty dictionaries to hold extension data
+_program_types_standards_dict = {}
+
+for ext_folder in folders.standards_extension_folders:
+    _data_dir = os.path.join(ext_folder, 'programtypes')
+    for _p_type_json in os.listdir(_data_dir):
+        if _p_type_json.endswith('.json'):
+            _p_type_dir = os.path.join(_data_dir, _p_type_json)
+            with open(_p_type_dir, 'r') as f:
+                _program_types_standards_dict.update(json.load(f))

--- a/honeybee_energy/lib/_loadschedules.py
+++ b/honeybee_energy/lib/_loadschedules.py
@@ -34,3 +34,13 @@ for f in os.listdir(folders.schedule_lib):
                         _schedules[sch_name] = sch_obj
                 except KeyError:
                     pass  # not a Honeybee JSON file with Schedules
+
+
+# empty dictionaries to hold extension data
+_schedule_standards_dict = {}
+
+for ext_folder in folders.standards_extension_folders:
+    _data_dir = os.path.join(ext_folder, 'schedules', 'schedule.json')
+    if os.path.isfile(_data_dir):
+        with open(_data_dir, 'r') as f:
+            _schedule_standards_dict.update(json.load(f))

--- a/honeybee_energy/lib/constructionsets.py
+++ b/honeybee_energy/lib/constructionsets.py
@@ -1,7 +1,8 @@
 """Collection of construction sets."""
 from honeybee_energy.constructionset import ConstructionSet
+from ._loadconstructionsets import _construction_sets, _construction_set_standards_dict
 
-from ._loadconstructionsets import _construction_sets
+import honeybee_energy.lib.constructions as _c
 
 
 # establish variables for the default construction sets used across the library
@@ -15,7 +16,8 @@ except KeyError:
 
 
 # make lists of program types to look up items in the library
-CONSTRUCTION_SETS = tuple(_construction_sets.keys())
+CONSTRUCTION_SETS = tuple(_construction_sets.keys()) + \
+    tuple(_construction_set_standards_dict.keys())
 
 
 def construction_set_by_name(construction_set_name):
@@ -27,5 +29,32 @@ def construction_set_by_name(construction_set_name):
     try:
         return _construction_sets[construction_set_name]
     except KeyError:
-        raise ValueError('"{}" was not found in the construction set library.'.format(
-            construction_set_name))
+        try:  # search the extension data
+            con_set_dict = _construction_set_standards_dict[construction_set_name]
+            constrs = _constrs_from_set_dict(con_set_dict)
+            return ConstructionSet.from_dict_abridged(con_set_dict, constrs)
+        except KeyError:  # construction is nowhere to be found; raise an error
+            raise ValueError('"{}" was not found in the construction set library.'.format(
+                construction_set_name))
+
+
+def _constrs_from_set_dict(con_set_dict):
+    """Get a dictionary of constructions used in a ConstructionSetAbridged dictionary.
+    """
+    constrs = {}
+    for key in con_set_dict:
+        if isinstance(con_set_dict[key], dict):
+            sub_dict = con_set_dict[key]
+            for sub_key in sub_dict:
+                if sub_key != 'type':
+                    try:
+                        constrs[sub_dict[sub_key]] = \
+                            _c.opaque_construction_by_name(sub_dict[sub_key])
+                    except ValueError:
+                        constrs[sub_dict[sub_key]] = \
+                            _c.window_construction_by_name(sub_dict[sub_key])
+        elif key == 'shade_construction':
+            constrs[con_set_dict[key]] = _c.shade_construction_by_name(con_set_dict[key])
+        elif key == 'air_boundary_construction':
+            constrs[con_set_dict[key]] = _c.opaque_construction_by_name(con_set_dict[key])
+    return constrs

--- a/honeybee_energy/lib/materials.py
+++ b/honeybee_energy/lib/materials.py
@@ -2,8 +2,10 @@
 from honeybee_energy.material.opaque import EnergyMaterial
 from honeybee_energy.material.glazing import EnergyWindowMaterialGlazing
 from honeybee_energy.material.gas import EnergyWindowMaterialGas
+from honeybee_energy.material.dictutil import dict_to_material
 
 from ._loadconstructions import _opaque_materials, _window_materials
+from ._loadmaterials import _opaque_mat_standards_dict, _window_mat_standards_dict
 
 
 # properties of all default materials; used when they are not found in default.idf
@@ -159,8 +161,10 @@ except KeyError:
 
 
 # make lists of material names to look up items in the library
-OPAQUE_MATERIALS = tuple(_opaque_materials.keys())
-WINDOW_MATERIALS = tuple(_window_materials.keys())
+OPAQUE_MATERIALS = tuple(_opaque_materials.keys()) + \
+    tuple(_opaque_mat_standards_dict.keys())
+WINDOW_MATERIALS = tuple(_window_materials.keys()) + \
+    tuple(_window_mat_standards_dict.keys())
 
 
 def opaque_material_by_name(material_name):
@@ -169,12 +173,16 @@ def opaque_material_by_name(material_name):
     Args:
         material_name: A text string for the name of the material.
     """
-    try:
+    try:  # first check the default data
         return _opaque_materials[material_name]
     except KeyError:
-        raise ValueError(
-            '"{}" was not found in the opaque energy material library.'.format(
-                material_name))
+        try:  # search the extension data
+            _mat_dict = _opaque_mat_standards_dict[material_name]
+            return dict_to_material(_mat_dict)
+        except KeyError:  # material is nowhere to be found; raise an error
+            raise ValueError(
+                '"{}" was not found in the opaque energy material library.'.format(
+                    material_name))
 
 
 def window_material_by_name(material_name):
@@ -183,9 +191,13 @@ def window_material_by_name(material_name):
     Args:
         material_name: A text string for the name of the material.
     """
-    try:
+    try:  # first check the default data
         return _window_materials[material_name]
     except KeyError:
-        raise ValueError(
-            '"{}" was not found in the window energy material library.'.format(
-                material_name))
+        try:  # search the extension data
+            _mat_dict = _window_mat_standards_dict[material_name]
+            return dict_to_material(_mat_dict)
+        except KeyError:  # material is nowhere to be found; raise an error
+            raise ValueError(
+                '"{}" was not found in the window energy material library.'.format(
+                    material_name))

--- a/honeybee_energy/lib/schedules.py
+++ b/honeybee_energy/lib/schedules.py
@@ -1,8 +1,9 @@
 """Establish the default schedule types within the honeybee_energy library."""
 from honeybee_energy.schedule.ruleset import ScheduleRuleset
+from honeybee_energy.schedule.dictutil import dict_abridged_to_schedule
+from ._loadschedules import _schedules, _schedule_standards_dict
 
-from ._loadschedules import _schedules
-from .scheduletypelimits import activity_level, fractional
+import honeybee_energy.lib.scheduletypelimits as _stl
 
 
 # establish variables for the default schedules used across the library
@@ -11,14 +12,14 @@ try:
     seated_activity = _schedules['Seated Adult Activity']
 except KeyError:
     seated_activity = ScheduleRuleset.from_constant_value(
-        'Seated Adult Activity', 120, activity_level)
+        'Seated Adult Activity', 120, _stl.activity_level)
     seated_activity.lock()
     _schedules['Seated Adult Activity'] = seated_activity
 
 try:
     always_on = _schedules['Always On']
 except KeyError:
-    always_on = ScheduleRuleset.from_constant_value('Always On', 1, fractional)
+    always_on = ScheduleRuleset.from_constant_value('Always On', 1, _stl.fractional)
     always_on.lock()
     _schedules['Always On'] = always_on
 
@@ -41,7 +42,7 @@ except KeyError:  # the office program isn't critical for the rest of the librar
 
 
 # make lists of schedules to look up items in the library
-SCHEDULES = tuple(_schedules.keys())
+SCHEDULES = tuple(_schedules.keys()) + tuple(_schedule_standards_dict.keys())
 
 
 def schedule_by_name(schedule_name):
@@ -50,8 +51,16 @@ def schedule_by_name(schedule_name):
     Args:
         schedule_name: A text string for the name of the schedule.
     """
-    try:
+    try:  # first check the default data
         return _schedules[schedule_name]
     except KeyError:
-        raise ValueError('"{}" was not found in the schedule library.'.format(
-            schedule_name))
+        try:  # search the extension data
+            _sch_dict = _schedule_standards_dict[schedule_name]
+            try:
+                _tl = _stl.schedule_type_limit_by_name(_sch_dict['schedule_type_limit'])
+            except KeyError:
+                _tl = _stl.fractional
+            return dict_abridged_to_schedule(_sch_dict, {_tl.name: _tl})
+        except KeyError:  # schedule is nowhere to be found; raise an error
+            raise ValueError('"{}" was not found in the schedule library.'.format(
+                schedule_name))


### PR DESCRIPTION
This commit shifts the burden of loading data that extends the standards to honeybee_energy. This way, the only thing that standards extensions need to worry about is providing the data and not any of the code that does the extending.

This also makes it possible to put the honeybee_energy_standards data in a more central location (away from the Python packages) so that it can be used by other plugins.