### PR TITLE
fix(run): Simulate pre-preprocess.idf output from OpenStudio CLI

### DIFF
--- a/honeybee_energy/result/colorroom.py
+++ b/honeybee_energy/result/colorroom.py
@@ -30,8 +30,8 @@ class ColorRoom(object):
             should all have headers with metadata dictionaries with 'Zone' or
             'System' keys. These keys will be used to match the data in the collections
             to the input rooms.
-        rooms: An array of honeybee Rooms, which will be matched to the data_collections
-            and. The length of these Rooms does not have to match the data_collections
+        rooms: An array of honeybee Rooms, which will be matched to the data_collections.
+            The length of these Rooms does not have to match the data_collections
             and this object will only create visualizations for rooms that are
             found to be matching.
         legend_parameters: An optional LegendParameter object to change the display
@@ -40,14 +40,13 @@ class ColorRoom(object):
             a specific step of the data collections for which result values will be
             generated. If None, the geometry will be colored with the total of
             resutls in the data_collections if the data type is cumulative or with
-            the average of results if the data type is not cumulative. Default: False.
+            the average of results if the data type is not cumulative. Default: None.
         normalize_by_floor: Boolean to note whether results should be normalized
             by the floor area of the Room if the data type of the data_colections
-            is cumulative. If False and the data type is cumulative, values will
-            be generated using sum total of the data collection values. Note that
-            this input has no effect if the data type of the data_collections is
-            not cumulative since data collection values will always be averaged
-            for this case. Default: True.
+            supports it. If False, values will be generated using sum total of
+            the data collection values. Note that this input has no effect if
+            the data type of the data_collections is not cumulative since data
+            collection values will always be averaged for this case. Default: True.
         geo_unit: Optional text to note the units that the Room geometry is in.
             This will be used to ensure the legend units display correctly when
             data is floor-normalized. Examples include 'm', 'mm', 'ft'.

--- a/honeybee_energy/run.py
+++ b/honeybee_energy/run.py
@@ -354,13 +354,19 @@ def _output_openstudio_files(directory):
         -   idf -- Path to a .idf file containing properties of the model, including
             the size of HVAC objects. Will be None if no file exists.
     """
-    # generate paths to the OSM and IDF files
+    # generate and check paths to the OSM and IDF files
     osm_file = os.path.join(directory, 'run', 'in.osm')
-    idf_file = os.path.join(directory, 'run', 'in.idf')
-
-    # check that the OSM and IDF files exist
     osm = osm_file if os.path.isfile(osm_file) else None
-    idf = idf_file if os.path.isfile(idf_file) else None
+
+    # check the pre-process idf and replace the other in.idf with it
+    idf_file_right = os.path.join(directory, 'run', 'pre-preprocess.idf')
+    idf_file_wrong = os.path.join(directory, 'run', 'in.idf')
+    if os.path.isfile(idf_file_right) and os.path.isfile(idf_file_wrong):
+        os.remove(idf_file_wrong)
+        os.rename(idf_file_right, idf_file_wrong)
+        idf = idf_file_wrong
+    else:
+        idf = None
 
     return osm, idf
 


### PR DESCRIPTION
I realized that the in.idf spit out by OpenStudio CLI contains a lot of extra stuff that interferes with honeybee and the pre-preprocess.idf is just the pure output from running the measures. So this changes the honeybee run commands to use the pre-preprocess.idf.