### PR TITLE
fix(config): Update config to use new ladybug_tools install folder

### DIFF
--- a/honeybee_energy/run.py
+++ b/honeybee_energy/run.py
@@ -132,11 +132,11 @@ def run_osw(osw_json, measures_only=True):
     Returns:
         The following files output from the CLI run
 
-        -   osm -- Path to a .osm file containing all simulation results.
+        -   osm -- Path to a .osm file representing the output model.
             Will be None if no file exists.
 
-        -   idf -- Path to a .idf file containing properties of the model, including
-            the size of HVAC objects. Will be None if no file exists.
+        -   idf -- Path to a .idf file representing the model.
+            Will be None if no file exists.
     """
     # run the simulation
     if os.name == 'nt':  # we are on Windows


### PR DESCRIPTION
This commit adds code that prioritizes the searching of data and engines within the ladybug_tools installation folder. The code to find installations of OpenStudio and EnergyPlus in their default locations still exists but this code is only executed if no OpenStudio installations were found in the ladybug_tools folder.