### PR TITLE
fix(config): Catch errors with auto-sorting of OpenStudio version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,7 +11,7 @@ sphinx-bootstrap-theme==0.7.1
 sphinxcontrib-fulltoc==1.2.0
 sphinxcontrib-websupport==1.1.2;python_version<'3.0'
 sphinxcontrib-websupport==1.2.1;python_version>='3.6'
-sphinx-click==2.3.1
+sphinx-click==2.3.2
 twine==1.13.0;python_version<'3.0'
 twine==3.1.1;python_version>='3.6'
 wheel==0.34.2

--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -370,8 +370,12 @@ class Folders(object):
         """
         def getversion(energyplus_path):
             """Get digits for the version of EnergyPlus."""
-            ver = ''.join(s for s in energyplus_path if (s.isdigit() or s == '-'))
-            return sum(int(d) * (10 ** i) for i, d in enumerate(reversed(ver.split('-'))))
+            try:
+                ver = ''.join(s for s in energyplus_path if (s.isdigit() or s == '-'))
+                return sum(int(d) * (10 ** i)
+                           for i, d in enumerate(reversed(ver.split('-'))))
+            except ValueError:  # folder starting with 'EnergyPlus' and no version
+                return 0
 
         # first check for the EnergyPlus that comes with OpenStudio
         ep_path = None
@@ -435,8 +439,12 @@ class Folders(object):
         """
         def getversion(openstudio_path):
             """Get digits for the version of OpenStudio."""
-            ver = ''.join(s for s in openstudio_path if (s.isdigit() or s == '.'))
-            return sum(int(d) * (10 ** i) for i, d in enumerate(reversed(ver.split('.'))))
+            try:
+                ver = ''.join(s for s in openstudio_path if (s.isdigit() or s == '.'))
+                return sum(int(d) * (10 ** i)
+                           for i, d in enumerate(reversed(ver.split('.'))))
+            except ValueError:  # folder starting with 'openstudio' and no version
+                return 0
 
         # first check if there's a version installed in the ladybug_tools folder
         lb_install = lb_config.folders.ladybug_tools_folder
@@ -485,9 +493,12 @@ class Folders(object):
         """
         if not os_path:
             return None
-        ver = ''.join(s for s in os_path if (s.isdigit() or s == '.'))
-        if ver:  # version was found in the file path name
-            return tuple(int(d) for d in ver.split('.'))
+        try:
+            ver = ''.join(s for s in os_path if (s.isdigit() or s == '.'))
+            if ver:  # version was found in the file path name
+                return tuple(int(d) for d in ver.split('.'))
+        except ValueError:
+            pass  # folder starting with 'openstudio' and no version
         return None
 
     @staticmethod


### PR DESCRIPTION
This error has come up twice now that I see people tend to create a lot of folders that start with openstudio. This commit allows honeybee to not crash when this happens or, if it does, it gives a much more useful error.