### PR TITLE
fix(model): Remove north from Model properties

### DIFF
--- a/honeybee_energy/cli/translate.py
+++ b/honeybee_energy/cli/translate.py
@@ -131,7 +131,7 @@ def model_to_idf(model_json, sim_par_json, additional_str, log_file):
             sim_par = SimulationParameter()
             sim_par.output.add_zone_energy_use()
 
-        # re-serialze the Model to Python
+        # re-serialize the Model to Python
         with open(model_json) as json_file:
             data = json.load(json_file)
         model = Model.from_dict(data)
@@ -145,9 +145,7 @@ def model_to_idf(model_json, sim_par_json, additional_str, log_file):
         ver_str = energyplus_idf_version() if folders.energyplus_version \
             is not None else energyplus_idf_version((9, 2, 0))
         sim_par_str = sim_par.to_idf()
-        model_str = model.to.idf(
-            model, schedule_directory=sch_directory,
-            solar_distribution=sim_par.shadow_calculation.solar_distribution)
+        model_str = model.to.idf(model, schedule_directory=sch_directory)
         idf_str = '\n\n'.join([ver_str, sim_par_str, model_str, additional_str])
 
         # write out the IDF file

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -96,7 +96,7 @@ def aperture_to_idf(aperture):
     loop through the Aperture.shades, and call the to.idf method on each one.
 
     Args:
-        aperture: A honeyee Aperture for which an IDF representation will be returned.
+        aperture: A honeybee Aperture for which an IDF representation will be returned.
     """
     ap_bc_obj = aperture.boundary_condition.boundary_condition_object if \
         isinstance(aperture.boundary_condition, Surface) else ''
@@ -296,8 +296,7 @@ def room_to_idf(room):
     return '\n\n'.join(zone_str)
 
 
-def model_to_idf(model, schedule_directory=None,
-                 solar_distribution='FullExteriorWithReflections'):
+def model_to_idf(model, schedule_directory=None):
     r"""Generate an IDF string representation of a Model.
 
     The resulting string will include all geometry (Rooms, Faces, Shades, Apertures,
@@ -313,15 +312,6 @@ def model_to_idf(model, schedule_directory=None,
         schedule_directory: An optional file directory to which any file-based
             schedules should be written to. If None, it will be written to the
             user folder assuming the project is entitled 'unnamed'.
-        solar_distribution: Text desribing how EnergyPlus should treat beam solar
-            radiation reflected from surfaces. Default: FullExteriorWithReflections.
-            Choose from the following:
-
-            * MinimalShadowing
-            * FullExterior
-            * FullInteriorAndExterior
-            * FullExteriorWithReflections
-            * FullInteriorAndExteriorWithReflections
 
     Usage:
 
@@ -364,7 +354,6 @@ def model_to_idf(model, schedule_directory=None,
     model_str = ['!-   =======================================\n'
                  '!-   ================ MODEL ================\n'
                  '!-   =======================================\n']
-    model_str.append(model.properties.energy.building_idf(solar_distribution))
 
     # write all of the schedules and type limits
     sched_strs = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core==1.28.1
+honeybee-core==1.28.3

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -279,7 +279,6 @@ def test_to_from_dict():
     tree_canopy.properties.energy.transmittance_schedule = tree_trans
 
     model = Model('TinyHouse', [room], orphaned_shades=[tree_canopy])
-    model.north_angle = 15
     model_dict = model.to_dict()
     new_model = Model.from_dict(model_dict)
     assert model_dict == new_model.to_dict()
@@ -293,7 +292,6 @@ def test_to_from_dict():
     assert new_model.rooms[0][1].apertures[0].properties.energy.construction == triple_pane
     assert new_model.rooms[0][1].apertures[0].is_operable
     assert len(new_model.orphaned_shades) == 1
-    assert new_model.north_angle == 15
 
     assert new_model.rooms[0][0].type == face_types.floor
     assert new_model.rooms[0][1].type == face_types.wall
@@ -354,7 +352,6 @@ def test_to_dict_single_zone():
     room.add_indoor_shade(table)
 
     model = Model('TinyHouse', [room], orphaned_shades=[tree_canopy])
-    model.north_angle = 15
 
     model_dict = model.to_dict()
 
@@ -432,7 +429,6 @@ def test_to_dict_single_zone_schedule_fixed_interval():
     tree_canopy.properties.energy.transmittance_schedule = trans_sched
 
     model = Model('TinyHouse', [room], orphaned_shades=[tree_canopy])
-    model.north_angle = 15
 
     model_dict = model.to_dict()
 
@@ -724,9 +720,6 @@ def test_writer_to_idf():
     room.add_indoor_shade(table)
 
     model = Model('TinyHouse', [room], orphaned_shades=[tree_canopy])
-    model.north_angle = 15
 
     assert hasattr(model.to, 'idf')
     idf_string = model.to.idf(model, schedule_directory='./tests/idf/')
-    assert 'TinyHouse,' in idf_string
-    assert 'Building,' in idf_string

--- a/tests/simulation_parameter_test.py
+++ b/tests/simulation_parameter_test.py
@@ -7,6 +7,7 @@ from honeybee_energy.simulation.control import SimulationControl
 from honeybee_energy.simulation.shadowcalculation import ShadowCalculation
 from honeybee_energy.simulation.sizing import SizingParameter
 
+from ladybug_geometry.geometry2d.pointvector import Vector2D
 from ladybug.dt import Date
 
 import pytest
@@ -23,6 +24,9 @@ def test_simulation_parameter_init():
     assert sim_par.simulation_control == SimulationControl()
     assert sim_par.shadow_calculation == ShadowCalculation()
     assert sim_par.sizing_parameter == SizingParameter()
+    assert sim_par.north_angle == 0
+    assert sim_par.north_vector == Vector2D(0, 1)
+    assert sim_par.terrain_type == 'City'
 
 
 def test_simulation_parameter_setability():
@@ -50,6 +54,10 @@ def test_simulation_parameter_setability():
     sizing_alt.add_from_ddy(relative_path)
     sim_par.sizing_parameter = sizing_alt
     assert sim_par.sizing_parameter == sizing_alt
+    sim_par.north_angle = 20
+    assert sim_par.north_angle == 20
+    sim_par.terrain_type = 'Ocean'
+    assert sim_par.terrain_type == 'Ocean'
 
 
 def test_simulation_parameter_equality():


### PR DESCRIPTION
After some discussions with @mostaphaRoudsari , we have decided that the north should not be a property of the Model for the same reason why we don't have the location as a part of the model. The north direction is a property of the simulation assets like the skies used in Radiance or the simulation parameters used in our EnergyPlus.