### PR TITLE
fix(colorobj): Handle cases of models in inches or mm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-honeybee-core==1.30.5
+honeybee-core==1.31.0


### PR DESCRIPTION
Thinking it over, I can't picture any case where someone wants to have their E+ results in kWh/mm2 or kBtu/in2.  So I'm editing the colorobj module to do the conversion in the event that the geometry is in mm or inches.