### PR TITLE
feat(shades): Add support for Blinds and Shades a way that E+ supports

### DIFF
--- a/honeybee_energy/construction/_base.py
+++ b/honeybee_energy/construction/_base.py
@@ -32,6 +32,7 @@ class _ConstructionBase(object):
         * u_factor
         * r_factor
         * is_symmetric
+        * has_shade
     """
     # generic air material used to compute indoor film coefficients.
     _air = EnergyWindowMaterialGas('generic air', gas_type='Air')
@@ -145,6 +146,14 @@ class _ConstructionBase(object):
             if self._materials[i] != self._materials[-(i + 1)]:
                 return False
         return True
+    
+    @property
+    def has_shade(self):
+        """Get a boolean noting whether dynamic materials are in the construction.
+
+        This should be False for all construction types except WindowConstructionShade.
+        """
+        return False
 
     def duplicate(self):
         """Get a copy of this construction."""

--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -2,6 +2,7 @@
 """AirBoundary Construction."""
 from __future__ import division
 
+from ..schedule.dictutil import dict_to_schedule
 from ..schedule.ruleset import ScheduleRuleset
 from ..schedule.fixedinterval import ScheduleFixedInterval
 from ..writer import generate_idf_string
@@ -122,9 +123,7 @@ class AirBoundaryConstruction(object):
             'Expected AirBoundaryConstruction. Got {}.'.format(data['type'])
         a_mix = data['air_mixing_per_area'] if 'air_mixing_per_area' in data else 0.1
         if 'air_mixing_schedule' in data:
-            a_sch = ScheduleRuleset.from_dict(data['air_mixing_schedule']) if \
-                data['air_mixing_schedule']['type'] == 'ScheduleRuleset' else \
-                ScheduleFixedInterval.from_dict(data['air_mixing_schedule'])
+            a_sch = dict_to_schedule(data['air_mixing_schedule'])
         else:
             a_sch = always_on
         new_obj = cls(data['identifier'], a_mix, a_sch)

--- a/honeybee_energy/construction/dictutil.py
+++ b/honeybee_energy/construction/dictutil.py
@@ -2,12 +2,14 @@
 """Utilities to convert construction dictionaries to Python objects."""
 from honeybee_energy.construction.opaque import OpaqueConstruction
 from honeybee_energy.construction.window import WindowConstruction
+from honeybee_energy.construction.windowshade import WindowConstructionShade
 from honeybee_energy.construction.shade import ShadeConstruction
 from honeybee_energy.construction.air import AirBoundaryConstruction
 
 
-CONSTRUCTION_TYPES = ('OpaqueConstruction', 'WindowConstruction', 'ShadeConstruction',
-                      'AirBoundaryConstruction')
+CONSTRUCTION_TYPES = \
+    ('OpaqueConstruction', 'WindowConstruction', 'WindowConstructionShade',
+     'ShadeConstruction', 'AirBoundaryConstruction')
 
 
 def dict_to_construction(constr_dict, raise_exception=True):
@@ -31,6 +33,8 @@ def dict_to_construction(constr_dict, raise_exception=True):
         return OpaqueConstruction.from_dict(constr_dict)
     elif constr_type == 'WindowConstruction':
         return WindowConstruction.from_dict(constr_dict)
+    elif constr_type == 'WindowConstructionShade':
+        return WindowConstructionShade.from_dict(constr_dict)
     elif constr_type == 'ShadeConstruction':
         return ShadeConstruction.from_dict(constr_dict)
     elif constr_type == 'AirBoundaryConstruction':
@@ -65,6 +69,9 @@ def dict_abridged_to_construction(constr_dict, materials, schedules,
         return OpaqueConstruction.from_dict_abridged(constr_dict, materials)
     elif constr_type == 'WindowConstructionAbridged':
         return WindowConstruction.from_dict_abridged(constr_dict, materials)
+    elif constr_type == 'WindowConstructionShade':
+        return WindowConstructionShade.from_dict_abridged(
+            constr_dict, materials, schedules)
     elif constr_type == 'ShadeConstruction':
         return ShadeConstruction.from_dict(constr_dict)
     elif constr_type == 'AirBoundaryConstructionAbridged':

--- a/honeybee_energy/construction/windowshade.py
+++ b/honeybee_energy/construction/windowshade.py
@@ -1,0 +1,694 @@
+# coding=utf-8
+"""Window Construction with shades/blinds or a dynamically-controlled glass pane."""
+from __future__ import division
+
+from .window import WindowConstruction
+from ..material.dictutil import dict_to_material
+from ..material.glazing import EnergyWindowMaterialGlazing, \
+    EnergyWindowMaterialSimpleGlazSys
+from ..material.shade import _EnergyWindowMaterialShadeBase, EnergyWindowMaterialBlind
+from ..schedule.dictutil import dict_to_schedule
+from ..schedule.ruleset import ScheduleRuleset
+from ..schedule.fixedinterval import ScheduleFixedInterval
+from ..writer import generate_idf_string
+
+from honeybee._lockable import lockable
+from honeybee.typing import valid_ep_string
+
+
+@lockable
+class WindowConstructionShade(object):
+    """Window Construction with shades/blinds or a dynamically-controlled glass pane.
+
+    Args:
+        identifier: Text string for a unique Construction ID. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        window_construction: A WindowConstruction object that serves as the
+            "switched off" version of the construction (aka. the "bare construction").
+            The shade_material and shade_location will be used to modify this
+            starting construction.
+        shade_material: An EnergyWindowMaterialShade or an EnergyWindowMaterialBlind
+            that serves as the shading layer for this construction. This can also
+            be an EnergyWindowMaterialGlazing, which will indicate that the
+            WindowConstruction has a dynamically-controlled glass pane like an
+            electrochromic window assembly.
+        shade_location: Text to indicate where in the window assembly the shade_material
+            is located. (Default: "Interior"). Choose from the following 3 options:
+
+                * Interior
+                * Between
+                * Exterior
+
+            Note that the WindowConstruction must have at least one gas gap to use
+            the "Between" option. Also note that, for a WindowConstruction with more
+            than one gas gap, the "Between" option defalts to using the inner gap
+            as this is the only option that EnergyPlus supports.
+        control_type: Text to indicate how the shading device is controlled, which
+             determines when the shading is “on” or “off.” (Default: "AlwaysOn").
+             Choose from the options below (units for the values of the corresponding
+             setpoint are noted in parentheses next to each option):
+
+                * AlwaysOn
+                * OnIfHighSolarOnWindow (W/m2)
+                * OnIfHighHorizontalSolar (W/m2)
+                * OnIfHighOutdoorAirTemperature (C)
+                * OnIfHighZoneAirTemperature (C)
+                * OnIfHighZoneCooling (W)
+                * OnNightIfLowOutdoorTempAndOffDay (C)
+                * OnNightIfLowInsideTempAndOffDay (C)
+                * OnNightIfHeatingAndOffDay (W)
+
+        setpoint: A number that corresponds to the specified control_type. This can
+            be a value in (W/m2), (C) or (W) depending upon the control type.
+        schedule: An optional ScheduleRuleset or ScheduleFixedInterval to be applied
+            on top of the control_type. If None, the control_type will govern all
+            behavior of the construction.
+
+    Properties:
+        * identifier
+        * display_name
+        * window_construction
+        * shade_material
+        * shade_location
+        * control_type
+        * setpoint
+        * schedule
+        * materials
+        * layers
+        * unique_materials
+        * r_value
+        * u_value
+        * u_factor
+        * r_factor
+        * is_symmetric
+        * is_switchable_glazing
+        * has_shade
+        * inside_emissivity
+        * outside_emissivity
+        * thickness
+        * glazing_count
+        * gap_count
+    """
+
+    __slots__ = ('_identifier', '_display_name', '_window_construction',
+                 '_shade_material', '_shade_location', '_control_type',
+                 '_setpoint', '_schedule', '_between_gap', '_locked')
+    SHADE_LOCATIONS = ('Interior', 'Between', 'Exterior')
+    CONTROL_TYPES = (
+        'AlwaysOn', 'OnIfHighSolarOnWindow', 'OnIfHighHorizontalSolar',
+        'OnIfHighOutdoorAirTemperature', 'OnIfHighZoneAirTemperature',
+        'OnIfHighZoneCooling', 'OnNightIfLowOutdoorTempAndOffDay',
+        'OnNightIfLowInsideTempAndOffDay', 'OnNightIfHeatingAndOffDay')
+
+    def __init__(self, identifier, window_construction, shade_material,
+                 shade_location='Interior', control_type='AlwaysOn',
+                 setpoint=None, schedule=None):
+        """Initialize shaded window construction."""
+        self._locked = False  # unlocked by default
+        self.identifier = identifier
+        self._display_name = None
+        self._between_gap = None  # will be used if 'Between' option is used
+
+        # check that the window construction, shade, and shade location are compatible
+        assert isinstance(window_construction, WindowConstruction), \
+            'Expected WindowConstruction for WindowConstructionShade. ' \
+            'Got {}.'.format(type(window_construction))
+        shade_types = (_EnergyWindowMaterialShadeBase, EnergyWindowMaterialGlazing)
+        assert isinstance(shade_material, shade_types), \
+            'Expected Shade/Blind or Glazing material for WindowConstructionShade. ' \
+            'Got {}.'.format(type(shade_material))
+        assert shade_location in self.SHADE_LOCATIONS, \
+            'Invalid input "{}" for shade location.  Must be one ' \
+            'of the following:\n'.format(shade_location, self.SHADE_LOCATIONS)
+        if isinstance(shade_material, EnergyWindowMaterialGlazing):
+            ext_pane = window_construction[0]
+            assert not isinstance(ext_pane, EnergyWindowMaterialSimpleGlazSys), \
+                'WindowConstruction cannot be a SimpleGlazSys when shading material ' \
+                'is a glass pane.'
+        elif shade_location == 'Between':  # it's a shade/blind between glass panes
+            assert window_construction.gap_count >= 1, 'WindowConstruction must have ' \
+                'at least one gap in order to use "Between" shade_location.'
+            # calculate the thickness of the gaps on either side of the shade
+            int_gap = window_construction[-2]
+            if isinstance(shade_material, EnergyWindowMaterialBlind):
+                assert shade_material.slat_width < int_gap.thickness, \
+                    'Blind slat_width must be less than the width of the gap in which ' \
+                    'it sits. {} > {}.'.format(shade_material.slat_width, int_gap.thickness)
+            shd_thick = 0 if isinstance(shade_material, EnergyWindowMaterialBlind) \
+                else shade_material.thickness
+            gap_thick = (int_gap.thickness - shd_thick) / 2
+            assert gap_thick > 0, \
+                'Shade thickness is greater than the gap in which it sits.'
+            # create the split gap material to be used on either side of the shade
+            between_int_gap = int_gap.duplicate()
+            between_int_gap.identifier = \
+                '{}_Split{}'.format(int_gap.identifier, round(gap_thick, 4))
+            between_int_gap.thickness = gap_thick
+            self._between_gap = between_int_gap
+        window_construction.lock()  # lock to avoid illegal shade/material combinations
+        self._window_construction = window_construction
+        self._shade_material = shade_material
+        self._shade_location = shade_location
+
+        # assign the control type, setpoint and schedule
+        assert control_type in self.CONTROL_TYPES, \
+            'Invalid input "{}" for shading control type.' \
+            ' Must be one of the following:\n'.format(control_type, self.CONTROL_TYPES)
+        self._control_type = control_type
+        self.setpoint = setpoint
+        self.schedule = schedule
+
+    @property
+    def identifier(self):
+        """Get or set the text string for construction identifier."""
+        return self._identifier
+
+    @identifier.setter
+    def identifier(self, identifier):
+        self._identifier = valid_ep_string(identifier, 'construction identifier')
+
+    @property
+    def display_name(self):
+        """Get or set a string for the object name without any character restrictions.
+
+        If not set, this will be equal to the identifier.
+        """
+        if self._display_name is None:
+            return self._identifier
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, value):
+        try:
+            self._display_name = str(value)
+        except UnicodeEncodeError:  # Python 2 machine lacking the character set
+            self._display_name = value  # keep it as unicode
+
+    @property
+    def window_construction(self):
+        """Get the WindowConstruction serving as the "switched off" version."""
+        return self._window_construction
+
+    @property
+    def shade_material(self):
+        """Get the material that serves as the shading layer for this construction."""
+        return self._shade_material
+
+    @property
+    def shade_location(self):
+        """Get text to indicate where in the construction the shade_material is located.
+
+        This will be either "Interior", "Between" or "Exterior". Note that, for a
+        WindowConstruction with more than one gas gap, the "Between" option defalts
+        to using the inner gap as this is the only option that EnergyPlus supports.
+        """
+        return self._shade_location
+
+    @property
+    def control_type(self):
+        """Get or set the text indicating how the shading device is controlled.
+
+        Choose from the options below:
+
+        * AlwaysOn
+        * OnIfHighSolarOnWindow
+        * OnIfHighHorizontalSolar
+        * OnIfHighOutdoorAirTemperature
+        * OnIfHighZoneAirTemperature
+        * OnIfHighZoneCooling
+        * OnNightIfLowOutdoorTempAndOffDay
+        * OnNightIfLowInsideTempAndOffDay
+        * OnNightIfHeatingAndOffDay
+        """
+        return self._control_type
+
+    @control_type.setter
+    def control_type(self, value):
+        assert value in self.CONTROL_TYPES, \
+            'Invalid input "{}" for shading control type.' \
+            ' Must be one of the following:\n'.format(value, self.CONTROL_TYPES)
+        if value != 'AlwaysOn':
+            assert self._setpoint is not None, 'Control setpoint must not ' \
+                'be None to use "{}" control type.'.format(value)
+        self._control_type = value
+
+    @property
+    def setpoint(self):
+        """A number for the setpoint that corresponds to the specified control_type.
+
+        This can be a value in (W/m2), (C) or (W) depending upon the control type.
+        """
+        return self._setpoint
+
+    @setpoint.setter
+    def setpoint(self, value):
+        if value is not None:
+            try:
+                value = float(value)
+            except (ValueError, TypeError):
+                raise TypeError('Input setpoint must be a number. Got '
+                                '{}: {}.'.format(type(value), value))
+        else:
+            assert self._control_type == 'AlwaysOn', 'Control setpoint cannot ' \
+                'be None for control type "{}"'.format(self._control_type)
+        self._setpoint = value
+
+    @property
+    def schedule(self):
+        """Get or set a fractional schedule to be applied on top of the control_type.
+
+        If None, the control_type will govern all behavior of the construction.
+        """
+        return self._schedule
+
+    @schedule.setter
+    def schedule(self, value):
+        if value is not None:
+            assert isinstance(value, (ScheduleRuleset, ScheduleFixedInterval)), \
+                'Expected schedule for window construction shaded schedule. ' \
+                'Got {}.'.format(type(value))
+            if value.schedule_type_limit is not None:
+                assert value.schedule_type_limit.unit == 'fraction', 'Window ' \
+                    'construction schedule should be fractional. Got a schedule ' \
+                    'of unit_type [{}].'.format(value.schedule_type_limit.unit_type)
+            value.lock()  # lock editing in case schedule has multiple references
+        self._schedule = value
+
+    @property
+    def materials(self):
+        """Get the list of materials in the construction (outside to inside).
+
+        This will include the shade material layer in its correct position.
+        """
+        base_mats = list(self._window_construction.materials)
+        if self.is_switchable_glazing:
+            if self._shade_location == 'Interior':
+                base_mats[-1] = self._shade_material
+            elif self._shade_location == 'Exterior' or \
+                    self._window_construction.gap_count == 0:
+                base_mats[0] = self._shade_material
+            else:  # middle glass pane
+                base_mats[-3] = self._shade_material
+        else:
+            if self._shade_location == 'Interior':
+                base_mats.append(self._shade_material)
+            elif self._shade_location == 'Exterior':
+                base_mats.insert(0, self._shade_material)
+            else:  # between glass shade/blind
+                base_mats[-2] = self._between_gap
+                base_mats.insert(-1, self._shade_material)
+                base_mats.insert(-1, self._between_gap)
+        return base_mats
+
+    @property
+    def layers(self):
+        """A list of material identifiers in the construction (outside to inside).
+
+        This will include the shade material layer in its correct position.
+        """
+        return [mat.identifier for mat in self.materials]
+
+    @property
+    def unique_materials(self):
+        """A set of only unique material objects in the construction.
+
+        This will include the shade material layer.
+        """
+        base = list(set(self._window_construction.materials + (self._shade_material,)))
+        if self._between_gap is not None:
+            base.append(self._between_gap)
+        return base
+
+    @property
+    def r_value(self):
+        """R-value of the bare window construction [m2-K/W] (excluding air films).
+
+        Note that this excludes all effects of the shade layer.
+        """
+        return self._window_construction.r_value
+
+    @property
+    def u_value(self):
+        """U-value of the bare window construction [W/m2-K] (excluding air films).
+
+        Note that this excludes all effects of the shade layer.
+        """
+        return self._window_construction.u_value
+
+    @property
+    def r_factor(self):
+        """Bare window construction R-factor [m2-K/W] (with standard air film resistances).
+
+        Note that this excludes all effects of the shade layer.
+        Formulas for film coefficients come from EN673 / ISO10292.
+        """
+        return self._window_construction.r_factor
+
+    @property
+    def u_factor(self):
+        """Bare window construction U-factor [W/m2-K] (with standard air film resistances).
+
+        Note that this excludes all effects of the shade layer.
+        Formulas for film coefficients come from EN673 / ISO10292.
+        """
+        return self._window_construction.u_factor
+
+    @property
+    def is_symmetric(self):
+        """Get a boolean to note whether the construction layers are symmetric.
+
+        Symmetric means that the materials in reversed order are equal to those
+        in the current order (eg. 'Glass', 'Air Gap', 'Glass'). This is particularly
+        helpful for interior constructions, which need to have matching materials
+        in reversed order between adjacent Faces.
+        """
+        mats = self.materials
+        half_mat = int(len(mats) / 2)
+        for i in range(half_mat):
+            if mats[i] != mats[-(i + 1)]:
+                return False
+        return True
+
+    @property
+    def has_shade(self):
+        """Get a boolean noting whether dynamic materials are in the construction.
+
+        This should always be True for this class.
+        """
+        return True
+
+    @property
+    def is_switchable_glazing(self):
+        """Get a boolean to note whether the construction is switchable glazing.
+
+        The construction is a switchable glazing if the shade material is a
+        glass material.
+        """
+        return isinstance(self.shade_material, EnergyWindowMaterialGlazing)
+
+    @property
+    def inside_emissivity(self):
+        """"The emissivity of the inside face of the construction.
+
+        This will use the emissivity of the shade layer if it is interior.
+        """
+        mats = self.materials
+        if isinstance(mats[-1], EnergyWindowMaterialSimpleGlazSys):
+            return 0.84
+        try:
+            return mats[-1].emissivity_back
+        except AttributeError:
+            return mats[-1].emissivity
+
+    @property
+    def outside_emissivity(self):
+        """"The emissivity of the outside face of the construction.
+
+        This will use the emissivity of the shade layer if it is interior.
+        """
+        mats = self.materials
+        if isinstance(mats[0], EnergyWindowMaterialSimpleGlazSys):
+            return 0.84
+        return mats[0].emissivity
+
+    @property
+    def thickness(self):
+        """Thickness of the construction [m], including the shade layer."""
+        thickness = 0
+        for mat in self.materials:
+            if isinstance(mat, EnergyWindowMaterialBlind):
+                thickness += mat.slat_width
+            else:
+                thickness += mat.thickness
+            thickness += mat.thickness
+        return thickness
+
+    @property
+    def glazing_count(self):
+        """The number of glazing materials contained within the construction.
+
+        Note that Simple Glazing System materials do not count.
+        """
+        return self._window_construction.glazing_count
+
+    @property
+    def gap_count(self):
+        """The number of gas gaps contained within the construction."""
+        count = self._window_construction.gap_count
+        if self.shade_location == 'Between' and not self.is_switchable_glazing:
+            count += 1
+        return count
+
+    @property
+    def _ep_shading_type(self):
+        """Text for the Shading Type field that EnergyPlus wants in the IDF."""
+        if self.is_switchable_glazing:
+            return 'SwitchableGlazing'
+        elif isinstance(self.shade_material, EnergyWindowMaterialBlind):
+            return 'BetweenGlassBlind' if self.shade_location == 'Between' \
+                else '{}Blind'.format(self.shade_location)
+        else:
+            return 'BetweenGlassShade' if self.shade_location == 'Between' \
+                else '{}Shade'.format(self.shade_location)
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a WindowConstructionShade from a dictionary.
+
+        Note that the dictionary must be a non-abridged version for this
+        classmethod to work.
+
+        Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: python
+
+            {
+            "type": 'WindowConstructionShade',
+            "identifier": 'Double Pane U-250 IntBlind-0025',
+            "display_name": 'Double Pane with Interior Blind',
+            "window_construction": {}  # a WindowConstruction dictionary representation
+            "shade_material": {}  # a shade/blind/glass dictionary representation
+            "shade_location": 'Interior',  # text for shade layer location
+            "control_type": 'OnIfHighSolarOnWindow',  # text for shade control type
+            "setpoint": 200,  # number for control setpoint
+            "schedule": {}  # optional ScheduleRuleset or ScheduleFixedInterval dict
+            }
+        """
+        # check the type
+        assert data['type'] == 'WindowConstructionShade', \
+            'Expected WindowConstructionShade. Got {}.'.format(data['type'])
+
+        # re-serialize required inputs
+        window_constr = WindowConstruction.from_dict(data['window_construction'])
+        shade_material = dict_to_material(data['shade_material'])
+
+        # re-serialize optional inputs
+        shade_location, control_type, setpoint = cls._from_dict_defaults(data)
+        schedule = dict_to_schedule(data['schedule']) if 'schedule' in data and \
+            data['schedule'] is not None else None
+
+        new_obj = cls(data['identifier'], window_constr, shade_material, shade_location,
+                      control_type, setpoint, schedule)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    @classmethod
+    def from_dict_abridged(cls, data, materials, schedules):
+        """Create a WindowConstructionShade from an abridged dictionary.
+
+        Args:
+            data: An WindowConstructionShade dictionary with the format below.
+            materials: A dictionary with identifiers of materials as keys and
+                Python material objects as values.
+            schedules: A dictionary with schedule identifiers as keys and
+                honeybee schedule objects as values. These will be used to
+                assign the schedule to the AirBoundaryConstruction object.
+
+        .. code-block:: python
+
+            {
+            "type": 'WindowConstructionShadeAbridged',
+            "identifier": 'Double Pane U-250 IntBlind-0025',
+            "display_name": 'Double Pane with Interior Blind',
+            "window_construction": {}  # a WindowConstructionAbridged dictionary
+            "shade_material": 'Blind-0025'  # a shade/blind/glass identifier
+            "shade_location": 'Interior',  # text for shade layer location
+            "control_type": 'OnIfHighSolarOnWindow',  # text for shade control type
+            "setpoint": 200,  # number for control setpoint
+            "schedule": 'DayNight_Schedule'  # optional schedule identifier
+            }
+        """
+        # check the type
+        assert data['type'] == 'WindowConstructionShadeAbridged', \
+            'Expected WindowConstructionShadeAbridged. Got {}.'.format(data['type'])
+
+        # re-serialize required inputs
+        window_constr = WindowConstruction.from_dict_abridged(
+            data['window_construction'], materials)
+        shade_material = materials[data['shade_material']]
+
+        # re-serialize optional inputs
+        shade_location, control_type, setpoint = cls._from_dict_defaults(data)
+        schedule = schedules[data['schedule']] if 'schedule' in data and \
+            data['schedule'] is not None else None
+
+        new_obj = cls(data['identifier'], window_constr, shade_material, shade_location,
+                      control_type, setpoint, schedule)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    def to_idf(self):
+        """IDF string representation of construction object.
+
+        Note that this method only outputs a single string for the bare window
+        construction and, to write the full construction into an IDF, the
+        construction's unique_materials must also be written along with the
+        output of to_idf_shaded, which contains the shaded construction.
+        Also, for each Aperture to which this construction is assigned, a
+        ShadingControl object must also be written, which can be obtained from
+        the to_idf_shading_control.
+
+        Returns:
+            Text string representation of the bare (unshaded) construction.
+        """
+        return self._window_construction.to_idf()
+
+    def to_shaded_idf(self):
+        """IDF string representation of construction in its shaded state.
+
+        Returns:
+            Text string representation of the shaded construction.
+        """
+        materials = self.materials
+        values = (self.identifier,) + tuple(mat.identifier for mat in materials)
+        comments = ('name',) + tuple('layer %s' % (i + 1) for i in range(len(materials)))
+        return generate_idf_string('Construction', values, comments)
+
+    def to_shading_control_idf(self, aperture_identifier, room_identifier):
+        """IDF string representation of a WindowShadingControl object.
+
+        This has to be written for every Aperture to which this construction is
+        assigned in order for EnergyPlus to simulate it correctly.
+
+        Args:
+            aperture_identifier: The identifier of the honeybee Aperture to
+                which this construction is assigned.
+            room_identifier: The identifier of the honeybee Room to which the
+                aperture belongs.
+
+        Returns:
+            Text string representation of the WindowShadingControl.
+        """
+        control_name = '{}_ShdControl'.format(aperture_identifier)
+        control_type = 'OnIfScheduleAllows' if self.schedule is not None and \
+            self.control_type == 'AlwaysOn' else self.control_type
+        sch = self.schedule if self.schedule is not None else ''
+        sch_bool = 'Yes' if self.schedule is not None else 'No'
+        setpt = self.setpoint if self.setpoint is not None else ''
+        values = (control_name, room_identifier, 1, self._ep_shading_type,
+                  self.identifier, control_type, sch, setpt, sch_bool,
+                  '', '', '', '', '', '', '', aperture_identifier)
+        comments = \
+            ('name', 'zone name', 'sequence number', 'shading type',
+             'construction with shade', 'control type', 'schedule', 'setpoint',
+             'is scheduled', 'is glare controlled', 'shade material', 'slat control',
+             'slat schedule', 'setpoint 2', 'daylight object', 'multiple control type',
+             'fenestration surface')
+        return generate_idf_string('WindowShadingControl', values, comments)
+
+    def to_radiance_solar(self):
+        """Honeybee Radiance material for the bare (unshaded) construction."""
+        # TODO: add method that represents blinds with BSDF + shades with Trans
+        return self._window_construction.to_radiance_solar()
+
+    def to_radiance_visible(self):
+        """Honeybee Radiance material for the bare (unshaded) construction."""
+        # TODO: add method that represents blinds with BSDF + shades with Trans
+        return self._window_construction.to_radiance_visible()
+
+    def to_dict(self, abridged=False):
+        """Window construction dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True),
+                which only specifies the identifiers of material layers and
+                schedules. Default: False.
+        """
+        base = {'type': 'WindowConstructionShade'} if not \
+            abridged else {'type': 'WindowConstructionShadeAbridged'}
+        base['identifier'] = self.identifier
+        base['window_construction'] = self.window_construction.to_dict(abridged)
+        base['shade_material'] = self.shade_material.identifier if abridged \
+            else self.shade_material.to_dict()
+        base['shade_location'] = self.shade_location
+        base['control_type'] = self.control_type
+        if self.control_type != 'AlwaysOn':
+            base['setpoint'] = self.setpoint
+        if self.schedule is not None:
+            base['schedule'] = self.schedule.identifier if abridged \
+                else self.schedule.to_dict()
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        return base
+
+    def lock(self):
+        """The lock() method will also lock the shade_material."""
+        self._locked = True
+        self.shade_material.lock()
+
+    def unlock(self):
+        """The unlock() method will also unlock the shade_material."""
+        self._locked = False
+        self.shade_material.unlock()
+
+    def duplicate(self):
+        """Get a copy of this construction."""
+        return self.__copy__()
+
+    @staticmethod
+    def _from_dict_defaults(data):
+        "Re-serialize default values from a dictionary."
+        shade_location = data['shade_location'] if 'shade_location' in data and \
+            data['shade_location'] is not None else 'Interior'
+        control_type = data['control_type'] if 'control_type' in data and \
+            data['control_type'] is not None else 'AlwaysOn'
+        setpoint = data['setpoint'] if 'setpoint' in data \
+            else None
+        return shade_location, control_type, setpoint
+
+    def __copy__(self):
+        new_con = WindowConstructionShade(
+            self.identifier, self.window_construction, self.shade_material,
+            self.shade_location, self.control_type, self.setpoint,
+            self.schedule)
+        new_con._display_name = self._display_name
+        return new_con
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        sch = hash(self.schedule) if self.schedule is not None else None
+        return (self._identifier, hash(self.window_construction),
+                hash(self.shade_material), self.shade_location, self.control_type,
+                self.setpoint, sch)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, WindowConstructionShade) and \
+            self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        return self.to_shaded_idf()

--- a/honeybee_energy/constructionset.py
+++ b/honeybee_energy/constructionset.py
@@ -2,8 +2,10 @@
 """Energy Construction Set."""
 from __future__ import division
 
+from .construction.dictutil import dict_to_construction
 from .construction.opaque import OpaqueConstruction
 from .construction.window import WindowConstruction
+from .construction.windowshade import WindowConstructionShade
 from .construction.shade import ShadeConstruction
 from .construction.air import AirBoundaryConstruction
 import honeybee_energy.lib.constructions as _lib
@@ -1103,16 +1105,16 @@ class ApertureConstructionSet(object):
         """
         assert data['type'] == 'ApertureConstructionSet', \
             'Expected ApertureConstructionSet. Got {}.'.format(data['type'])
-        winc = WindowConstruction.from_dict(data['window_construction']) \
+        winc = dict_to_construction(data['window_construction']) \
             if 'window_construction' in data and data['window_construction'] \
             is not None else None
-        intc = WindowConstruction.from_dict(data['interior_construction']) \
+        intc = dict_to_construction(data['interior_construction']) \
             if 'interior_construction' in data and data['interior_construction'] \
             is not None else None
-        skyc = WindowConstruction.from_dict(data['skylight_construction']) \
+        skyc = dict_to_construction(data['skylight_construction']) \
             if 'skylight_construction' in data and data['skylight_construction'] \
             is not None else None
-        opc = WindowConstruction.from_dict(data['operable_construction'])\
+        opc = dict_to_construction(data['operable_construction'])\
             if 'operable_construction' in data and data['operable_construction'] \
             is not None else None
         return cls(winc, intc, skyc, opc)
@@ -1168,7 +1170,7 @@ class ApertureConstructionSet(object):
 
     def _check_window_construction(self, value):
         """Check that a construction is valid before assigning it."""
-        assert isinstance(value, WindowConstruction), \
+        assert isinstance(value, (WindowConstruction, WindowConstructionShade)), \
             'Expected WindowConstruction. Got {}'.format(type(value))
         value.lock()   # lock editing in case construction has multiple references
 
@@ -1356,10 +1358,10 @@ class DoorConstructionSet(object):
         intc = OpaqueConstruction.from_dict(data['interior_construction']) \
             if 'interior_construction' in data and data['interior_construction'] \
             is not None else None
-        egc = WindowConstruction.from_dict(data['exterior_glass_construction']) \
+        egc = dict_to_construction(data['exterior_glass_construction']) \
             if 'exterior_glass_construction' in data and \
             data['exterior_glass_construction'] is not None else None
-        igc = WindowConstruction.from_dict(data['interior_glass_construction']) \
+        igc = dict_to_construction(data['interior_glass_construction']) \
             if 'interior_glass_construction' in data and \
             data['interior_glass_construction'] is not None else None
         ohc = OpaqueConstruction.from_dict(data['overhead_construction']) \
@@ -1434,7 +1436,7 @@ class DoorConstructionSet(object):
 
     def _check_window_construction(self, value):
         """Check that a construction is valid before assigning it."""
-        assert isinstance(value, WindowConstruction), \
+        assert isinstance(value, (WindowConstruction, WindowConstructionShade)), \
             'Expected WindowConstruction. Got {}'.format(type(value))
         value.lock()   # lock editing in case construction has multiple references
 

--- a/honeybee_energy/lib/_loadconstructions.py
+++ b/honeybee_energy/lib/_loadconstructions.py
@@ -2,6 +2,7 @@
 from honeybee_energy.config import folders
 from honeybee_energy.construction.opaque import OpaqueConstruction
 from honeybee_energy.construction.window import WindowConstruction
+from honeybee_energy.construction.windowshade import WindowConstructionShade
 from honeybee_energy.construction.air import AirBoundaryConstruction
 from honeybee_energy.construction.dictutil import dict_abridged_to_construction, \
     dict_to_construction
@@ -56,9 +57,9 @@ for f in os.listdir(folders.construction_lib):
                         constr.lock()
                         if isinstance(constr, (OpaqueConstruction, AirBoundaryConstruction)):
                             _opaque_constructions[constr_identifier] = constr
-                        elif isinstance(constr, WindowConstruction):
+                        elif isinstance(constr, (WindowConstruction, WindowConstructionShade)):
                             _window_constructions[constr_identifier] = constr
-                        else:
+                        else:  # it's a shade construction
                             _shade_constructions[constr_identifier] = constr
                 except KeyError:
                     pass  # not a Honeybee JSON file with Constructions

--- a/honeybee_energy/material/shade.py
+++ b/honeybee_energy/material/shade.py
@@ -6,7 +6,7 @@ They can exist in only one of three possible locations in a window construction:
 1) On the innermost material layer.
 2) On the outermost material layer.
 3) In between two glazing materials. In the case of window constructions with
-   multiple glazing surfaces, the shade mateerial must be between the two
+   multiple glazing surfaces, the shade material must be between the two
    inner glass layers.
 
 Note that shade materials should never be bounded by gas gap layers in honeybee-energy.
@@ -125,11 +125,11 @@ class _EnergyWindowMaterialShadeBase(_EnergyMaterialWindowBase):
         """Get an estimate of the R-value of the shade + air gap when it is exterior.
 
         Args:
-            delta_t: The temperature diference across the air gap [C]. This
+            delta_t: The temperature difference across the air gap [C]. This
                 influences how strong the convection is within the air gap. Default is
                 7.5C, which is consistent with the NFRC standard for double glazed units.
             emissivity: The emissivity of the glazing surface adjacent to the shade.
-                Default is 0.84, which is tyical of clear, uncoated glass.
+                Default is 0.84, which is typical of clear, uncoated glass.
             height: An optional height for the cavity between the shade and the
                 glass in meters. Default is 1.0.
             angle: An angle in degrees between 0 and 180.
@@ -161,11 +161,11 @@ class _EnergyWindowMaterialShadeBase(_EnergyMaterialWindowBase):
         """Get an estimate of the R-value of the shade + air gap when it is interior.
 
         Args:
-            delta_t: The temperature diference across the air gap [C]. This
+            delta_t: The temperature difference across the air gap [C]. This
                 influences how strong the convection is within the air gap. Default is
                 7.5C, which is consistent with the NFRC standard for double glazed units.
             emissivity: The emissivity of the glazing surface adjacent to the shade.
-                Default is 0.84, which is tyical of clear, uncoated glass.
+                Default is 0.84, which is typical of clear, uncoated glass.
             height: An optional height for the cavity between the shade and the
                 glass in meters. Default is 1.0.
             angle: An angle in degrees between 0 and 180.
@@ -194,13 +194,13 @@ class _EnergyWindowMaterialShadeBase(_EnergyMaterialWindowBase):
         """Get an estimate of the R-value of the shade + air gap when it is interior.
 
         Args:
-            delta_t: The temperature diference across the air gap [C]. This
+            delta_t: The temperature difference across the air gap [C]. This
                 influences how strong the convection is within the air gap. Default is
                 7.5C, which is consistent with the NFRC standard for double glazed units.
             emissivity_1: The emissivity of the glazing surface on one side of the shade.
-                Default is 0.84, which is tyical of clear, uncoated glass.
+                Default is 0.84, which is typical of clear, uncoated glass.
             emissivity_2: The emissivity of the glazing surface on the other side of
-                the shade. Default is 0.84, which is tyical of clear, uncoated glass.
+                the shade. Default is 0.84, which is typical of clear, uncoated glass.
             height: An optional height for the cavity between the shade and the
                 glass in meters. Default is 1.0.
             angle: An angle in degrees between 0 and 180.
@@ -249,7 +249,7 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
         visible_reflectance: Number between 0 and 1 for the reflectance of
             visible light off of the shade.
             Default: 0.4, which is typical of a white diffusing shade.
-        infrared_transmittance: Long-wave hemisperical transmittance of the shade.
+        infrared_transmittance: Long-wave hemispherical transmittance of the shade.
             Default: 0, which is typical of diffusing shades.
         emissivity: Number between 0 and 1 for the infrared hemispherical
             emissivity of the front side of the shade.  Default: 0.9, which
@@ -614,8 +614,8 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
             of visible light through the blind material. Default : 0.
         visible_reflectance: Number between 0 and 1 for the reflectance of
             visible light off of the blind. Default: 0.5.
-        infrared_transmittance: Long-wave hemisperical transmittance of the blind.
-            Default vallue is 0.
+        infrared_transmittance: Long-wave hemispherical transmittance of the blind.
+            Default value is 0.
         emissivity: Number between 0 and 1 for the infrared hemispherical
             emissivity of the blind.  Default is 0.9.
         distance_to_glass: A number between 0.001 and 1.0 for the distance from
@@ -675,7 +675,7 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
                  visible_transmittance=0, visible_reflectance=0.5,
                  infrared_transmittance=0, emissivity=0.9,
                  distance_to_glass=0.05, opening_multiplier=0.5):
-        """Initialize energy windoww material glazing."""
+        """Initialize energy window material blind."""
         _EnergyWindowMaterialShadeBase.__init__(
             self, identifier, infrared_transmittance, emissivity,
             distance_to_glass, opening_multiplier)
@@ -974,7 +974,7 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
     def u_value(self):
         """U-value of the blind slats [W/m2-K] (excluding air film resistance).
 
-        Note that this value assumes that blinds are cmpletely closed (at 0 degrees).
+        Note that this value assumes that blinds are completely closed (at 0 degrees).
         """
         return self.slat_conductivity / self.slat_thickness
 
@@ -986,7 +986,7 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
     def r_value(self):
         """R-value of the blind slats [m2-K/W] (excluding air film resistance).
 
-        Note that this value assumes that blinds are cmpletely closed (at 0 degrees).
+        Note that this value assumes that blinds are completely closed (at 0 degrees).
         """
         return self.slat_thickness / self.slat_conductivity
 

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 """Aperture Energy Properties."""
+from ..construction.dictutil import dict_to_construction
 from ..construction.window import WindowConstruction
+from ..construction.windowshade import WindowConstructionShade
 from ..lib.constructionsets import generic_construction_set
 
 
@@ -9,9 +11,9 @@ class ApertureEnergyProperties(object):
 
     Args:
         host: A honeybee_core Aperture object that hosts these properties.
-        construction: An optional Honeybee WindowConstruction object for
-            the aperture. If None, it will be set by the parent Room ConstructionSet
-            or the the Honeybee default generic ConstructionSet.
+        construction: An optional Honeybee WindowConstruction or WindowConstructionShade
+            object for the aperture. If None, it will be set by the parent Room
+            ConstructionSet or the the Honeybee default generic ConstructionSet.
 
     Properties:
         * host
@@ -59,8 +61,9 @@ class ApertureEnergyProperties(object):
     @construction.setter
     def construction(self, value):
         if value is not None:
-            assert isinstance(value, WindowConstruction), \
-                'Expected Window Construction for aperture. Got {}'.format(type(value))
+            assert isinstance(value, (WindowConstruction, WindowConstructionShade)), \
+                'Expected WindowConstruction or WindowConstructionShade for aperture.' \
+                ' Got {}'.format(type(value))
             value.lock()  # lock editing in case construction has multiple references
         self._construction = value
 
@@ -95,12 +98,7 @@ class ApertureEnergyProperties(object):
 
             {
             "type": 'ApertureEnergyProperties',
-            "construction": {
-                "type": 'WindowConstruction',
-                "identifier": 'Generic Double Pane Window',
-                "layers": [],  # list of material identifiers (from outside to inside)
-                "materials": []  # list of material objects
-                }
+            "construction": {}  # WindowConstruction or WindowConstructionShade dict
             }
         """
         assert data['type'] == 'ApertureEnergyProperties', \
@@ -108,7 +106,7 @@ class ApertureEnergyProperties(object):
 
         new_prop = cls(host)
         if 'construction' in data and data['construction'] is not None:
-            new_prop.construction = WindowConstruction.from_dict(data['construction'])
+            new_prop.construction = dict_to_construction(data['construction'])
         return new_prop
 
     def apply_properties_from_dict(self, abridged_data, constructions):

--- a/honeybee_energy/properties/door.py
+++ b/honeybee_energy/properties/door.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 """Door Energy Properties."""
+from ..construction.dictutil import dict_to_construction
 from ..construction.opaque import OpaqueConstruction
 from ..construction.window import WindowConstruction
+from ..construction.windowshade import WindowConstructionShade
 from ..lib.constructionsets import generic_construction_set
 
 
@@ -12,9 +14,9 @@ class DoorEnergyProperties(object):
         host_door: A honeybee_core Door object that hosts these properties.
         construction: An optional Honeybee OpaqueConstruction or WindowConstruction
             object for the door. Note that the host Door must have the is_glass
-            property set to True to assign a WindowConstruction. If None, it will
-            be set by the parent Room ConstructionSet or the the Honeybee default
-            generic ConstructionSet.
+            property set to True to assign a WindowConstruction or
+            WindowConstructionShade. If None, it will be set by the parent
+            Room ConstructionSet or the the Honeybee default generic ConstructionSet.
 
     Properties:
         * host
@@ -66,8 +68,9 @@ class DoorEnergyProperties(object):
                 assert isinstance(value, OpaqueConstruction), 'Expected ' \
                     'OpaqueConstruction for door. Got {}'.format(type(value))
             else:
-                assert isinstance(value, WindowConstruction), 'Expected ' \
-                    'WindowConstruction for glass door. Got {}'.format(type(value))
+                assert isinstance(value, (WindowConstruction, WindowConstructionShade)), \
+                    'Expected WindowConstruction or WindowConstructionShade for ' \
+                    'glass door. Got {}'.format(type(value))
             value.lock()  # lock editing in case construction has multiple references
         self._construction = value
 
@@ -102,12 +105,7 @@ class DoorEnergyProperties(object):
 
             {
             "type": 'DoorEnergyProperties',
-            "construction": {
-                "type": 'OpaqueConstruction',
-                "identifier": str,  # construction identifier
-                "layers": [],  # list of material identifiers (from outside to inside)
-                "materials": []  # list of unique material objects
-                }
+            "construction": {}  # OpaqueConstruction or WindowConstruction dict
             }
         """
         assert data['type'] == 'DoorEnergyProperties', \
@@ -115,12 +113,7 @@ class DoorEnergyProperties(object):
 
         new_prop = cls(host)
         if 'construction' in data and data['construction'] is not None:
-            if not host.is_glass:
-                new_prop.construction = OpaqueConstruction.from_dict(
-                    data['construction'])
-            else:
-                new_prop.construction = WindowConstruction.from_dict(
-                    data['construction'])
+            new_prop.construction = dict_to_construction(data['construction'])
         return new_prop
 
     def apply_properties_from_dict(self, abridged_data, constructions):

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -7,6 +7,7 @@ from ..lib.constructionsets import generic_construction_set
 from ..material.dictutil import dict_to_material
 from ..construction.dictutil import CONSTRUCTION_TYPES, dict_to_construction, \
     dict_abridged_to_construction
+from ..construction.windowshade import WindowConstructionShade
 from ..construction.air import AirBoundaryConstruction
 from ..constructionset import ConstructionSet
 from ..schedule.typelimit import ScheduleTypeLimit
@@ -181,6 +182,9 @@ class ModelEnergyProperties(object):
         for constr in self.constructions:
             if isinstance(constr, AirBoundaryConstruction):
                 self._check_and_add_schedule(constr.air_mixing_schedule, schedules)
+            elif isinstance(constr, WindowConstructionShade):
+                if constr.schedule is not None:
+                    self._check_and_add_schedule(constr.schedule, schedules)
         return list(set(schedules))
 
     @property

--- a/tests/construction_test.py
+++ b/tests/construction_test.py
@@ -7,16 +7,16 @@ from honeybee_energy.material.shade import EnergyWindowMaterialShade, \
     EnergyWindowMaterialBlind
 from honeybee_energy.construction.opaque import OpaqueConstruction
 from honeybee_energy.construction.window import WindowConstruction
+from honeybee_energy.construction.windowshade import WindowConstructionShade
 from honeybee_energy.construction.shade import ShadeConstruction
 from honeybee_energy.construction.air import AirBoundaryConstruction
 from honeybee_energy.schedule.ruleset import ScheduleRuleset
-import honeybee_energy.lib.scheduletypelimits as schedule_types
 
 import pytest
 
 
 def test_opaque_construction_init():
-    """Test the initalization of OpaqueConstruction objects and basic properties."""
+    """Test the initialization of OpaqueConstruction objects and basic properties."""
     concrete = EnergyMaterial('Concrete', 0.15, 2.31, 2322, 832, 'MediumRough',
                               0.95, 0.75, 0.8)
     insulation = EnergyMaterialNoMass('Insulation R-3', 3, 'MediumSmooth')
@@ -185,7 +185,7 @@ def test_opaque_dict_methods():
 
 
 def test_window_construction_init():
-    """Test the initalization of WindowConstruction objects and basic properties."""
+    """Test the initialization of WindowConstruction objects and basic properties."""
     lowe_glass = EnergyWindowMaterialGlazing(
         'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
         0, 0.84, 0.046578, 1.0)
@@ -216,14 +216,12 @@ def test_window_construction_init():
         double_low_e_dup.inside_emissivity == 0.84
     assert double_low_e.outside_emissivity == \
         double_low_e_dup.outside_emissivity == 0.84
-    assert double_low_e.unshaded_solar_transmittance == \
-        double_low_e_dup.unshaded_solar_transmittance == 0.4517 * 0.770675
-    assert double_low_e.unshaded_visible_transmittance == \
-        double_low_e_dup.unshaded_visible_transmittance == 0.714 * 0.8836
+    assert double_low_e.solar_transmittance == \
+        double_low_e_dup.solar_transmittance == 0.4517 * 0.770675
+    assert double_low_e.visible_transmittance == \
+        double_low_e_dup.visible_transmittance == 0.714 * 0.8836
     assert double_low_e.glazing_count == double_low_e_dup.glazing_count == 2
     assert double_low_e.gap_count == double_low_e_dup.gap_count == 1
-    assert double_low_e.has_shade is double_low_e_dup.has_shade is False
-    assert double_low_e.shade_location is double_low_e_dup.shade_location is None
 
     assert double_clear.u_factor == pytest.approx(2.72, rel=1e-2)
     assert double_low_e.u_factor == pytest.approx(1.698, rel=1e-2)
@@ -298,62 +296,8 @@ def test_window_symmetric():
     assert triple_clear.is_symmetric
 
 
-def test_window_construction_init_shade():
-    """Test the initalization of WindowConstruction objects with shades."""
-    lowe_glass = EnergyWindowMaterialGlazing(
-        'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
-        0, 0.84, 0.046578, 1.0)
-    clear_glass = EnergyWindowMaterialGlazing(
-        'Clear Glass', 0.005715, 0.770675, 0.07, 0.8836, 0.0804,
-        0, 0.84, 0.84, 1.0)
-    gap = EnergyWindowMaterialGas('air gap', thickness=0.0127)
-    shade_mat = EnergyWindowMaterialShade(
-        'Low-e Diffusing Shade', 0.025, 0.15, 0.5, 0.25, 0.5, 0, 0.4,
-        0.2, 0.1, 0.75, 0.25)
-    double_low_e_shade = WindowConstruction(
-        'Double Low-E with Shade', [lowe_glass, gap, clear_glass, shade_mat])
-    double_low_e_between_shade = WindowConstruction(
-        'Double Low-E Between Shade', [lowe_glass, shade_mat, clear_glass])
-    double_low_e_ext_shade = WindowConstruction(
-        'Double Low-E Outside Shade', [shade_mat, lowe_glass, gap, clear_glass])
-
-    assert double_low_e_shade.identifier == 'Double Low-E with Shade'
-    assert double_low_e_shade.u_factor == pytest.approx(0.9091, rel=1e-2)
-    assert double_low_e_between_shade.identifier == 'Double Low-E Between Shade'
-    assert double_low_e_between_shade.u_factor == pytest.approx(1.13374, rel=1e-2)
-    assert double_low_e_ext_shade.identifier == 'Double Low-E Outside Shade'
-    assert double_low_e_ext_shade.u_factor == pytest.approx(0.97678, rel=1e-2)
-
-
-def test_window_construction_init_blind():
-    """Test the initalization of WindowConstruction objects with blinds."""
-    lowe_glass = EnergyWindowMaterialGlazing(
-        'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
-        0, 0.84, 0.046578, 1.0)
-    clear_glass = EnergyWindowMaterialGlazing(
-        'Clear Glass', 0.005715, 0.770675, 0.07, 0.8836, 0.0804,
-        0, 0.84, 0.84, 1.0)
-    gap = EnergyWindowMaterialGas('air gap', thickness=0.0127)
-    shade_mat = EnergyWindowMaterialBlind(
-        'Plastic Blind', 'Vertical', 0.025, 0.01875, 0.003, 90, 0.2, 0.05, 0.4,
-        0.05, 0.45, 0, 0.95, 0.1, 1)
-    double_low_e_shade = WindowConstruction(
-        'Double Low-E with Shade', [lowe_glass, gap, clear_glass, shade_mat])
-    double_low_e_between_shade = WindowConstruction(
-        'Double Low-E Between Shade', [lowe_glass, shade_mat, clear_glass])
-    double_low_e_ext_shade = WindowConstruction(
-        'Double Low-E Outside Shade', [shade_mat, lowe_glass, gap, clear_glass])
-
-    assert double_low_e_shade.identifier == 'Double Low-E with Shade'
-    assert double_low_e_shade.u_factor == pytest.approx(1.26296, rel=1e-2)
-    assert double_low_e_between_shade.identifier == 'Double Low-E Between Shade'
-    assert double_low_e_between_shade.u_factor == pytest.approx(1.416379, rel=1e-2)
-    assert double_low_e_ext_shade.identifier == 'Double Low-E Outside Shade'
-    assert double_low_e_ext_shade.u_factor == pytest.approx(1.2089, rel=1e-2)
-
-
 def test_window_construction_init_gas_mixture():
-    """Test the initalization of WindowConstruction objects with a gas mixture."""
+    """Test the initialization of WindowConstruction objects with a gas mixture."""
     lowe_glass = EnergyWindowMaterialGlazing(
         'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
         0, 0.84, 0.046578, 1.0)
@@ -394,7 +338,7 @@ def test_window_temperature_profile():
 
 
 def test_window_construction_init_from_idf_file():
-    """Test the initalization of WindowConstruction from file."""
+    """Test the initialization of WindowConstruction from file."""
     lbnl_window_idf_file = './tests/idf/GlzSys_Triple Clear_Avg.idf'
     glaz_constrs, glaz_mats = WindowConstruction.extract_all_from_idf_file(
         lbnl_window_idf_file)
@@ -427,8 +371,58 @@ def test_window_dict_methods():
     assert constr_dict == new_constr.to_dict()
 
 
+def test_window_construction_shade_init():
+    """Test the initialization of WindowConstructionShade objects with shades."""
+    lowe_glass = EnergyWindowMaterialGlazing(
+        'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
+        0, 0.84, 0.046578, 1.0)
+    clear_glass = EnergyWindowMaterialGlazing(
+        'Clear Glass', 0.005715, 0.770675, 0.07, 0.8836, 0.0804,
+        0, 0.84, 0.84, 1.0)
+    gap = EnergyWindowMaterialGas('air gap', thickness=0.03)
+    shade_mat = EnergyWindowMaterialShade(
+        'Low-e Diffusing Shade', 0.025, 0.15, 0.5, 0.25, 0.5, 0, 0.4,
+        0.2, 0.1, 0.75, 0.25)
+    window_constr = WindowConstruction('Double Low-E', [lowe_glass, gap, clear_glass])
+    double_low_e_shade = WindowConstructionShade(
+        'Double Low-E with Shade', window_constr, shade_mat, 'Exterior')
+    double_low_e_between_shade = WindowConstructionShade(
+        'Double Low-E Between Shade', window_constr, shade_mat, 'Between')
+    double_low_e_ext_shade = WindowConstructionShade(
+        'Double Low-E Outside Shade', window_constr, shade_mat, 'Interior')
+
+    assert double_low_e_shade.identifier == 'Double Low-E with Shade'
+    assert double_low_e_between_shade.identifier == 'Double Low-E Between Shade'
+    assert double_low_e_ext_shade.identifier == 'Double Low-E Outside Shade'
+
+
+def test_window_construction_blind_init():
+    """Test the initialization of WindowConstructionShade objects with blinds."""
+    lowe_glass = EnergyWindowMaterialGlazing(
+        'Low-e Glass', 0.00318, 0.4517, 0.359, 0.714, 0.207,
+        0, 0.84, 0.046578, 1.0)
+    clear_glass = EnergyWindowMaterialGlazing(
+        'Clear Glass', 0.005715, 0.770675, 0.07, 0.8836, 0.0804,
+        0, 0.84, 0.84, 1.0)
+    gap = EnergyWindowMaterialGas('air gap', thickness=0.03)
+    shade_mat = EnergyWindowMaterialBlind(
+        'Plastic Blind', 'Vertical', 0.025, 0.01875, 0.003, 90, 0.2, 0.05, 0.4,
+        0.05, 0.45, 0, 0.95, 0.1, 1)
+    window_constr = WindowConstruction('Double Low-E', [lowe_glass, gap, clear_glass])
+    double_low_e_shade = WindowConstructionShade(
+        'Double Low-E with Blind', window_constr, shade_mat, 'Exterior')
+    double_low_e_between_shade = WindowConstructionShade(
+        'Double Low-E Between Blind', window_constr, shade_mat, 'Between')
+    double_low_e_ext_shade = WindowConstructionShade(
+        'Double Low-E Outside Blind', window_constr, shade_mat, 'Interior')
+
+    assert double_low_e_shade.identifier == 'Double Low-E with Blind'
+    assert double_low_e_between_shade.identifier == 'Double Low-E Between Blind'
+    assert double_low_e_ext_shade.identifier == 'Double Low-E Outside Blind'
+
+
 def test_shade_construction_init():
-    """Test the initalization of ShadeConstruction objects and basic properties."""
+    """Test the initialization of ShadeConstruction objects and basic properties."""
     default_constr = ShadeConstruction('Default Shade Construction')
     light_shelf_out = ShadeConstruction('Outdoor Light Shelf', 0.5, 0.6)
     str(light_shelf_out)  # test the string representation of the construction
@@ -444,7 +438,7 @@ def test_shade_construction_init():
 
 
 def test_shade_construction_to_idf():
-    """Test the initalization of ShadeConstruction objects and basic properties."""
+    """Test the initialization of ShadeConstruction objects and basic properties."""
     default_constr = ShadeConstruction('Default Shade Construction')
     light_shelf_out = ShadeConstruction('Outdoor Light Shelf', 0.5, 0.6, True)
 
@@ -493,7 +487,7 @@ def test_shade_dict_methods():
 
 
 def test_air_construction_init():
-    """Test the initalization of AirBoundaryConstruction objects and basic properties."""
+    """Test the initialization of AirBoundaryConstruction objects and basic properties."""
     default_constr = AirBoundaryConstruction('Default Air Construction')
 
     night_flush = ScheduleRuleset.from_daily_values(
@@ -510,7 +504,7 @@ def test_air_construction_init():
 
 
 def test_air_construction_to_idf():
-    """Test the initalization of AirBoundaryConstruction objects and basic properties."""
+    """Test the initialization of AirBoundaryConstruction objects and basic properties."""
     night_flush = ScheduleRuleset.from_daily_values(
         'Night Flush', [1, 1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5,
                         0.5, 0.5, 0.5, 0.5, 0.5, 1, 1, 1])

--- a/tests/schedule_fixedinterval_test.py
+++ b/tests/schedule_fixedinterval_test.py
@@ -264,7 +264,7 @@ def test_schedule_fixedinterval_from_idf():
 
 
 def test_schedule_fixedinterval_from_idf_file():
-    """Test the initalization of ScheduleFixedInterval from file."""
+    """Test the initialization of ScheduleFixedInterval from file."""
     ec_sched_idf = './tests/idf/ElectrochromicControlSchedules.idf'
     ec_scheds = ScheduleFixedInterval.extract_all_from_idf_file(ec_sched_idf)
 


### PR DESCRIPTION
This commit might be called a fix as much as it is a new feature. Long story short is that the way that blinds and shades were represented in the schema previously, they could never be simulated by EnergyPlus since E+ always needs a ShadingControl object in order to be able to simulate them.  So I added a new WindowConstructionShaded class to handle the creation of this ShadingControl object and allow users to change some of its properties.

I still have to add tests here and send parallel PRs to honeybee-schema and the honeybee-openstudio-gem but I have verified that it's working in the direct-to-idf case.

@mostaphaRoudsari , I mostly requested your review here to get your thoughts on the name of the new class: `WindowConstructionShaded`.  If my goal is to communicate that this is a version of the `WindowConstruction` class that includes an extra shade layer, I feel that this name is clearer than `ShadedWindowConstruction`. But let me know if you feel otherwise.

Also FYI, while the dynamic behavior of these objects can be mapped to honeybee-radiance, the reverse isn't necessarily true right now and these dynamic construction objects are a lot simpler than the very flexible capabilities we have in honeybee-radiance. At a later point, I will add options in honeybee-energy for more sophisticated dynamic constructions in honeybee-energy that will be map-able back and forth from radiance to energy. At some point, it might also be helpful to add simple dynamic modifiers to honeybee-radiance that mimic what is happening here in honeybee-energy.