### PR TITLE
perf(sql): Ensure all imported data get validated analysis periods

### DIFF
--- a/honeybee_energy/result/sql.py
+++ b/honeybee_energy/result/sql.py
@@ -211,6 +211,9 @@ class SQLiteResult(object):
                     head, values, head.analysis_period.months_int))
         else:  # Annual data; just return the values as they are
             return all_values
+        # ensure all imported data gets marked as valid; this increases speed elsewhere
+        for data in data_colls:
+            data._validated_a_period = True
 
         return data_colls
 


### PR DESCRIPTION
The data collection classes have a flag on them to note that a range of criteria that are expected of timeseries data has been satisfied. I am setting this to true for all imported data to boost performance.