### PR TITLE
build(docker): set up docker container to run energy simulations using honeybee-energy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.dependabot
+.github
+.git
+docs
+tests
+
+Dockerfile

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
         [
             "@semantic-release/exec",
             {
-                "publishCmd": "bash deploy.sh"
+                "publishCmd": "bash deploy.sh ${nextRelease.version}"
             }
         ]
     ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     python3.7 \
     python3-pip \
     libx11-6 \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 # Create non-root user
@@ -45,7 +46,8 @@ RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
 # Install honeybee-energy cli
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . honeybee-energy
-RUN pip3 install honeybee-energy[cli]
+RUN pip3 install setuptools 
+RUN pip3 install ./honeybee-energy[cli]
 
 # Set up working directory
 RUN mkdir -p /home/ladybugbot/run/simulation

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM ubuntu:eoan
+
+MAINTAINER Ladybug Tools info@ladybug.tools
+
+# Install core software deps
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+    curl \
+    ca-certificates \
+    dpkg \
+    python3.7 \
+    python3-pip \
+    libx11-6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN adduser ladybugbot --uid 1000
+USER ladybugbot
+WORKDIR /home/ladybugbot
+RUN mkdir ladybug_tools && touch ladybug_tools/config.json
+
+# Install Open Studio
+ENV OPENSTUDIO_VERSION=3.0.1
+ENV OPENSTUDIO_FILENAME=OpenStudio-3.0.1+09b7c8a554-Linux
+ENV OPENSTUDIO_DOWNLOAD_URL=https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.0.1/OpenStudio-3.0.1%2B09b7c8a554-Linux.tar.gz
+RUN mkdir ladybug_tools/openstudio/ \
+    && curl -SL -o openstudio.tar.gz $OPENSTUDIO_DOWNLOAD_URL \
+    && tar zxvf openstudio.tar.gz \
+    && mv $OPENSTUDIO_FILENAME/usr/local/openstudio-$OPENSTUDIO_VERSION/EnergyPlus ladybug_tools/openstudio/EnergyPlus \
+    && mv $OPENSTUDIO_FILENAME/usr/local/openstudio-$OPENSTUDIO_VERSION/bin ladybug_tools/openstudio/bin \
+    && rm -r $OPENSTUDIO_FILENAME \
+    && rm openstudio.tar.gz
+
+
+# Add honeybee-openstudio-gem lib to ladybug_tools folder
+ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.3.0
+RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
+    && curl -SL -o honeybee-openstudio-gem.tar.gz https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v$HONEYBEE_OPENSTUDIO_GEM_VERSION.tar.gz \
+    && tar zxvf honeybee-openstudio-gem.tar.gz \
+    && mv honeybee-openstudio-gem-$HONEYBEE_OPENSTUDIO_GEM_VERSION/lib ladybug_tools/resources/measures/honeybee_openstudio_gem \
+    && rm -r honeybee-openstudio-gem-$HONEYBEE_OPENSTUDIO_GEM_VERSION \
+    && rm honeybee-openstudio-gem.tar.gz
+
+
+# Install honeybee-energy cli
+ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
+COPY . honeybee-energy
+RUN pip3 install honeybee-energy[cli]
+
+# Set up working directory
+RUN mkdir -p /home/ladybugbot/run/simulation
+WORKDIR /home/ladybugbot/run

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,28 @@
 #!/bin/sh
 
+if [ -n "$1" ]
+then
+  NEXT_RELEASE_VERSION=$1
+else
+  echo "A release version must be supplied"
+  exit 1
+fi
+
+CONTAINER_NAME="ladybugtools/honeybee-energy"
+
+echo "PyPi Deployment..."
 echo "Building distribution"
 python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
-twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
+
+
+echo "Docker Deployment..."
+echo "Login to Docker"
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+
+docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
+docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
+
+docker push $CONTAINER_NAME:latest
+docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION 


### PR DESCRIPTION
Note that the dockerfile hard codes the depdency versions (openstudio and honeybee-openstudio-gem). The image size for this implementation is roughly 550 MB.

#253