### PR TITLE
fix(docker): add missing modules to pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
 # Install honeybee-energy cli
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . honeybee-energy
-RUN pip3 install setuptools 
-RUN pip3 install ./honeybee-energy[cli]
+RUN pip3 install setuptools wheel\
+    && pip3 install pydantic==1.5.1 honeybee-schema ./honeybee-energy[cli]
 
 # Set up working directory
 RUN mkdir -p /home/ladybugbot/run/simulation


### PR DESCRIPTION
This is technically CI but since we need a new docker image I'm pushing it as fix.

The issue was that pydantic and honeybee-schema were not installed successfully in Docker. There was also an error with Wheel not being installed.

The issue with Pydantic is most likely because we are currently install it for GitHub and not PyPI. For honeybee-schema we need to look into extras_require and if it can handle recursive dependencies. I'm not sure if honeybee-energy[cli] trigger honeybee-core[cli] successfully. If it was then we should have had honeybee-schema installed with no issues.

In any case, these changes will fix the issue for now so we can run honeybee-energy with no importing issues.