### PR TITLE
fix(cli): Have honeybee-energy commands to use click.Path as the type

### DIFF
--- a/honeybee_energy/cli/result.py
+++ b/honeybee_energy/cli/result.py
@@ -22,7 +22,8 @@ def result():
 
 
 @result.command('available-results')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional file to output the list of available '
               'outputs. By default, it will be printed to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -43,7 +44,8 @@ def available_results(result_sql, output_file):
 
 
 @result.command('available-results-info')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional file to output the list of available '
               'outputs. By default, it will be printed to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -82,7 +84,8 @@ def available_results_info(result_sql, output_file):
 
 
 @result.command('available-run-period-info')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional file to output the list of available '
               'outputs. By default, it will be printed to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -113,7 +116,8 @@ def available_run_period_info(result_sql, output_file):
 
 
 @result.command('all-available-info')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional file to output the list of available '
               'outputs. By default, it will be printed to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -172,7 +176,8 @@ def all_available_info(result_sql, output_file):
 
 
 @result.command('data-by-output')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.argument('output-name', type=str)
 @click.option('--output-file', help='Optional file to output the JSON strings of '
               'the data collections. By default, it will be printed to stdout',
@@ -205,7 +210,8 @@ def data_by_output(result_sql, output_name, output_file):
 
 
 @result.command('data-by-outputs')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.argument('output-names', type=str, nargs=-1)
 @click.option('--output-file', help='Optional file to output the JSON strings of '
               'the data collections. By default, it will be printed to stdout',
@@ -239,7 +245,8 @@ def data_by_outputs(result_sql, output_names, output_file):
 
 
 @result.command('output-csv')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.argument('output-names', type=str, nargs=-1)
 @click.option('--output-file', help='Optional file to output the CSV data of '
               'the results. By default, it will be printed to stdout',
@@ -303,7 +310,8 @@ def output_csv(result_sql, output_names, output_file):
 
 
 @result.command('zone-sizes')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional file to output the JSON strings of '
               'the ZoneSize objects. By default, it will be printed to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -327,7 +335,8 @@ def zone_sizes(result_sql, output_file):
 
 
 @result.command('component-sizes')
-@click.argument('result-sql')
+@click.argument('result-sql', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--component-type', help='A name of a HVAC component type, which will '
               'be used to filter the output HVAC components. If None, all HVAC component'
               ' sizes will be output.', type=str, default=None, show_default=True)

--- a/honeybee_energy/cli/settings.py
+++ b/honeybee_energy/cli/settings.py
@@ -14,7 +14,6 @@ from ladybug.analysisperiod import AnalysisPeriod
 from ladybug.dt import Date
 
 import sys
-import os
 import logging
 import json
 
@@ -27,10 +26,12 @@ def settings():
 
 
 @settings.command('default-sim-par')
-@click.argument('ddy-file')
+@click.argument('ddy-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--run-period-json', help='Full path to a honeybee energy RunPeriod'
               ' JSON that describes the duration of the simulation. If None the simulation'
-              'will be run for the whole year.', default=None, show_default=True)
+              'will be run for the whole year.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--filter-des-days', help='Boolean to note whether the design days in the '
               'ddy-file should be filtered to only include 99.6 and 0.4 design days.',
               type=bool, default=True, show_default=True)
@@ -45,13 +46,10 @@ def default_sim_par(ddy_file, run_period_json, filter_des_days, output_file):
             within the simulation parameter.
     """
     try:
-        assert os.path.isfile(ddy_file), 'No DDY file found at {}.'.format(ddy_file)
         sim_par = SimulationParameter()
         sim_par.output.add_zone_energy_use()
         sim_par.output.add_hvac_energy_use()
         if run_period_json:
-            assert os.path.isfile(run_period_json), \
-                'No run period JSON file found at {}.'.format(run_period_json)
             with open(run_period_json) as json_file:
                 data = json.load(json_file)
             sim_par.run_period = RunPeriod.from_dict(data)
@@ -68,7 +66,8 @@ def default_sim_par(ddy_file, run_period_json, filter_des_days, output_file):
 
 
 @settings.command('load-balance-sim-par')
-@click.argument('ddy-file')
+@click.argument('ddy-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--load-type', help='A text value to set the type of load outputs '
               'requested. Choose from the following:\nAll - all energy use '
               'including heat lost from the zone\nTotal - the total load added to the '
@@ -77,7 +76,8 @@ def default_sim_par(ddy_file, run_period_json, filter_des_days, output_file):
               type=str, default='Total', show_default=True)
 @click.option('--run-period-json', help='Full path to a honeybee energy RunPeriod'
               ' JSON that describes the duration of the simulation. If None the simulation'
-              'will be run for the whole year.', default=None, show_default=True)
+              'will be run for the whole year.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--filter-des-days', help='Boolean to note whether the design days in the '
               'ddy-file should be filtered to only include 99.6 and 0.4 design days.',
               type=bool, default=True, show_default=True)
@@ -93,15 +93,12 @@ def load_balance_sim_par(ddy_file, load_type, run_period_json, filter_des_days,
             within the simulation parameter.
     """
     try:
-        assert os.path.isfile(ddy_file), 'No DDY file found at {}.'.format(ddy_file)
         sim_par = SimulationParameter()
         sim_par.output.add_zone_energy_use(load_type)
         gl_load_type = load_type if load_type != 'All' else 'Total'
         sim_par.output.add_gains_and_losses(gl_load_type)
         sim_par.output.add_surface_energy_flow()
         if run_period_json:
-            assert os.path.isfile(run_period_json), \
-                'No run period JSON file found at {}.'.format(run_period_json)
             with open(run_period_json) as json_file:
                 data = json.load(json_file)
             sim_par.run_period = RunPeriod.from_dict(data)
@@ -118,10 +115,12 @@ def load_balance_sim_par(ddy_file, load_type, run_period_json, filter_des_days,
 
 
 @settings.command('comfort-sim-par')
-@click.argument('ddy-file')
+@click.argument('ddy-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--run-period-json', help='Full path to a honeybee energy RunPeriod'
               ' JSON that describes the duration of the simulation. If None the simulation'
-              'will be run for the whole year.', default=None, show_default=True)
+              'will be run for the whole year.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--filter-des-days', help='Boolean to note whether the design days in the '
               'ddy-file should be filtered to only include 99.6 and 0.4 design days.',
               type=bool, default=True, show_default=True)
@@ -136,13 +135,10 @@ def comfort_sim_par(ddy_file, run_period_json, filter_des_days, output_file):
             within the simulation parameter.
     """
     try:
-        assert os.path.isfile(ddy_file), 'No DDY file found at {}.'.format(ddy_file)
         sim_par = SimulationParameter()
         sim_par.output.add_comfort_metrics()
         sim_par.output.add_surface_temperature()
         if run_period_json:
-            assert os.path.isfile(run_period_json), \
-                'No run period JSON file found at {}.'.format(run_period_json)
             with open(run_period_json) as json_file:
                 data = json.load(json_file)
             sim_par.run_period = RunPeriod.from_dict(data)
@@ -159,7 +155,8 @@ def comfort_sim_par(ddy_file, run_period_json, filter_des_days, output_file):
 
 
 @settings.command('sizing-sim-par')
-@click.argument('ddy-file')
+@click.argument('ddy-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--load-type', help='A text value to set the type of load outputs '
               'requested. Choose from the following:\nAll - all energy use '
               'including heat lost from the zone\nTotal - the total load added to the '
@@ -180,7 +177,6 @@ def sizing_sim_par(ddy_file, load_type, filter_des_days, output_file):
             within the simulation parameter.
     """
     try:
-        assert os.path.isfile(ddy_file), 'No DDY file found at {}.'.format(ddy_file)
         sim_par = SimulationParameter()
         sim_par.output.add_zone_energy_use(load_type)
         gl_load_type = load_type if load_type != 'All' else 'Total'
@@ -200,10 +196,12 @@ def sizing_sim_par(ddy_file, load_type, filter_des_days, output_file):
 
 
 @settings.command('custom-sim-par')
-@click.argument('ddy-file')
+@click.argument('ddy-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--run-period-json', help='Full path to a honeybee energy RunPeriod'
               ' JSON that describes the duration of the simulation. If None the simulation'
-              'will be run for the whole year.', default=None, show_default=True)
+              'will be run for the whole year.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.argument('output-names', nargs=-1)
 @click.option('--filter-des-days', help='Boolean to note whether the design days in the '
               'ddy-file should be filtered to only include 99.6 and 0.4 design days.',
@@ -222,13 +220,10 @@ def custom_sim_par(ddy_file, output_names, run_period_json, filter_des_days, out
             requested from the simulation.
     """
     try:
-        assert os.path.isfile(ddy_file), 'No DDY file found at {}.'.format(ddy_file)
         sim_par = SimulationParameter()
         for output_name in output_names:
             sim_par.output.add_output(output_name)
         if run_period_json:
-            assert os.path.isfile(run_period_json), \
-                'No run period JSON file found at {}.'.format(run_period_json)
             with open(run_period_json) as json_file:
                 data = json.load(json_file)
             sim_par.run_period = RunPeriod.from_dict(data)

--- a/honeybee_energy/cli/simulate.py
+++ b/honeybee_energy/cli/simulate.py
@@ -27,10 +27,10 @@ def simulate():
 
 
 @simulate.command('model')
-@click.argument('model-json',
-                type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
-@click.argument('epw-file',
-                type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.argument('epw-file', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--sim-par-json', help='Full path to a honeybee energy SimulationParameter'
               ' JSON that describes all of the settings for the simulation.',
               default=None, show_default=True,
@@ -42,7 +42,8 @@ def simulate():
 @click.option('--folder', help='Folder on this computer, into which the IDF and result'
               'files will be written. If None, the files will be output to the honeybee '
               'default simulation folder and placed in a project folder with the same '
-              'name as the model_json.', default=None, show_default=True)
+              'name as the model_json.', default=None, show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True))
 @click.option('--check-model/--bypass-check', help='Flag to note whether the Model '
               'should be re-serialized to Python and checked before it is translated '
               'to .osm. The check is not needed if the model-json was expored directly '
@@ -60,12 +61,7 @@ def simulate_model(model_json, epw_file, sim_par_json, base_osw, folder,
         epw_file: Full path to an .epw file.
     """
     try:
-        # check that the model JSON and the EPW file is there
-        assert os.path.isfile(model_json), \
-            'No Model JSON file found at {}.'.format(model_json)
-        assert os.path.isfile(epw_file), \
-            'No EPW file found at {}.'.format(epw_file)
-        # ddy variable that might get used later
+        # get a ddy variable that might get used later
         epw_folder, epw_file_name = os.path.split(epw_file)
         ddy_file = os.path.join(epw_folder, epw_file_name.replace('.epw', '.ddy'))
 
@@ -97,8 +93,6 @@ def simulate_model(model_json, epw_file, sim_par_json, base_osw, folder,
                     'for a successful simulation.')
             sim_par_json = write_sim_par(sim_par)
         else:
-            assert os.path.isfile(sim_par_json), \
-                'No simulation parameter file found at {}.'.format(sim_par_json)
             with open(sim_par_json) as json_file:
                 data = json.load(json_file)
             sim_par = SimulationParameter.from_dict(data)

--- a/honeybee_energy/cli/translate.py
+++ b/honeybee_energy/cli/translate.py
@@ -34,13 +34,16 @@ def translate():
 
 
 @translate.command('model-to-osm')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--sim-par-json', help='Full path to a honeybee energy SimulationParameter'
               ' JSON that describes all of the settings for the simulation. If None '
-              'default parameters will be generated.', default=None, show_default=True)
+              'default parameters will be generated.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--folder', help='Folder on this computer, into which the OSM and IDF '
               'files will be written. If None, the files will be output in the'
-              'same location as the model_json.', default=None, show_default=True)
+              'same location as the model_json.', default=None, show_default=True,
+              type=click.Path(file_okay=False, dir_okay=True, resolve_path=True))
 @click.option('--check-model/--bypass-check', help='Flag to note whether the Model '
               'should be re-serialized to Python and checked before it is translated '
               'to .osm. The check is not needed if the model-json was expored directly '
@@ -56,19 +59,12 @@ def model_to_osm(model_json, sim_par_json, folder, check_model, log_file):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the model JSON is there
-        assert os.path.isfile(model_json), \
-            'No Model JSON file found at {}.'.format(model_json)
-
         # set the default folder if it's not specified
         if folder is None:
             folder = os.path.dirname(os.path.abspath(model_json))
 
         # check that the simulation parameters are there
-        if sim_par_json is not None:
-            assert os.path.isfile(sim_par_json), \
-                'No simulation parameter file found at {}.'.format(sim_par_json)
-        else:
+        if sim_par_json is None:
             sim_par = SimulationParameter()
             sim_par.output.add_zone_energy_use()
             sim_par.output.add_hvac_energy_use()
@@ -102,10 +98,12 @@ def model_to_osm(model_json, sim_par_json, folder, check_model, log_file):
 
 
 @translate.command('model-to-idf')
-@click.argument('model-json')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--sim-par-json', help='Full path to a honeybee energy SimulationParameter'
               ' JSON that describes all of the settings for the simulation. If None '
-              'default parameters will be generated.', default=None, show_default=True)
+              'default parameters will be generated.', default=None, show_default=True,
+              type=click.Path(exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--additional-str', help='Text string for additional lines that '
               'should be added to the IDF.', type=str, default='', show_default=True)
 @click.option('--output-file', help='Optional IDF file to output the IDF string of the '
@@ -121,14 +119,8 @@ def model_to_idf(model_json, sim_par_json, additional_str, output_file):
         model_json: Full path to a Model JSON file.
     """
     try:
-        # check that the model JSON is there
-        assert os.path.isfile(model_json), \
-            'No Model JSON file found at {}.'.format(model_json)
-
         # check that the simulation parameters are there and load them
         if sim_par_json is not None:
-            assert os.path.isfile(sim_par_json), \
-                'No simulation parameter file found at {}.'.format(sim_par_json)
             with open(sim_par_json) as json_file:
                 data = json.load(json_file)
             sim_par = SimulationParameter.from_dict(data)
@@ -164,7 +156,8 @@ def model_to_idf(model_json, sim_par_json, additional_str, output_file):
 
 
 @translate.command('constructions-to-idf')
-@click.argument('construction-json')
+@click.argument('construction-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional IDF file to output the IDF string of the '
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -177,10 +170,6 @@ def construction_to_idf(construction_json, output_file):
             the values are non-abridged Constructions.
     """
     try:
-        # check that the construction JSON is there
-        assert os.path.isfile(construction_json), \
-            'No Construction JSON file found at {}.'.format(construction_json)
-
         # re-serialize the Constructions to Python
         with open(construction_json) as json_file:
             data = json.load(json_file)
@@ -209,7 +198,8 @@ def construction_to_idf(construction_json, output_file):
 
 
 @translate.command('constructions-from-idf')
-@click.argument('construction-idf')
+@click.argument('construction-idf', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional JSON file to output the JSON string of the'
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -221,10 +211,6 @@ def construction_from_idf(construction_idf, output_file):
             and materials in this file will be extracted.
     """
     try:
-        # check that the construction JSON is there
-        assert os.path.isfile(construction_idf), \
-            'No Construction IDF file found at {}.'.format(construction_idf)
-
         # re-serialize the Constructions to Python
         opaque_constrs = OpaqueConstruction.extract_all_from_idf_file(construction_idf)
         win_constrs = WindowConstruction.extract_all_from_idf_file(construction_idf)
@@ -246,7 +232,8 @@ def construction_from_idf(construction_idf, output_file):
 
 
 @translate.command('schedules-to-idf')
-@click.argument('schedule-json')
+@click.argument('schedule-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional IDF file to output the IDF string of the '
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -259,10 +246,6 @@ def schedule_to_idf(schedule_json, output_file):
             the values are non-abridged Schedules.
     """
     try:
-        # check that the Schedule JSON is there
-        assert os.path.isfile(schedule_json), \
-            'No Schedule JSON file found at {}.'.format(schedule_json)
-
         # re-serialize the Schedule to Python
         with open(schedule_json) as json_file:
             data = json.load(json_file)
@@ -312,7 +295,8 @@ def schedule_to_idf(schedule_json, output_file):
 
 
 @translate.command('schedules-from-idf')
-@click.argument('schedule-idf')
+@click.argument('schedule-idf', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
 @click.option('--output-file', help='Optional JSON file to output the JSON string of the'
               'translation. By default this will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -324,10 +308,6 @@ def schedule_from_idf(schedule_idf, output_file):
             and schedule type limits in this file will be extracted.
     """
     try:
-        # check that the schedule JSON is there
-        assert os.path.isfile(schedule_idf), \
-            'No Schedule IDF file found at {}.'.format(schedule_idf)
-
         # re-serialize the schedules to Python
         schedules = ScheduleRuleset.extract_all_from_idf_file(schedule_idf)
 


### PR DESCRIPTION
This should mean that the use of relative paths are now supported throughout the CLI.

It also saved me several extra lines of code to have the file existence checks taken care of with the decorator.
Thanks for the original tip about this @AntoineDao .