### PR TITLE
feat(ventcool): Add objects for simple window-based ventilative cooling

### DIFF
--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -3,6 +3,7 @@
 from ..construction.dictutil import dict_to_construction
 from ..construction.window import WindowConstruction
 from ..construction.windowshade import WindowConstructionShade
+from ..ventcool.opening import VentilationOpening
 from ..lib.constructionsets import generic_construction_set
 
 
@@ -14,19 +15,23 @@ class ApertureEnergyProperties(object):
         construction: An optional Honeybee WindowConstruction or WindowConstructionShade
             object for the aperture. If None, it will be set by the parent Room
             ConstructionSet or the the Honeybee default generic ConstructionSet.
+        vent_opening: An optional VentilationOpening to specify the operable
+            portion of the Aperture. (Default: None).
 
     Properties:
         * host
         * construction
+        * vent_opening
         * is_construction_set_on_object
     """
 
-    __slots__ = ('_host', '_construction')
+    __slots__ = ('_host', '_construction', '_vent_opening')
 
-    def __init__(self, host, construction=None):
+    def __init__(self, host, construction=None, vent_opening=None):
         """Initialize Aperture energy properties."""
         self._host = host
         self.construction = construction
+        self.vent_opening = vent_opening
 
     @property
     def host(self):
@@ -68,6 +73,30 @@ class ApertureEnergyProperties(object):
         self._construction = value
 
     @property
+    def vent_opening(self):
+        """Get or set a VentilationOpening object to specify the operable portion."""
+        return self._vent_opening
+
+    @vent_opening.setter
+    def vent_opening(self, value):
+        if value is not None:
+            assert isinstance(value, VentilationOpening), 'Expected VentilationOpening ' \
+                'for Aperture vent_opening. Got {}'.format(type(value))
+            assert self.host.is_operable, 'Aperture must have a "True" is_operable ' \
+                'property in order to assign vent_opening energy properties.'
+            if value._parent is None:
+                value._parent = self.host
+            elif value._parent.identifier != self.host.identifier:
+                raise ValueError(
+                    '{0} objects can be assigned to only one parent.\n{0} cannot be '
+                    'assigned to Aperture "{1}" since it is already assigned to "{2}".\n'
+                    'Try duplicating the object and then assign it.'.format(
+                        'VentilationOpening', self.host.identifier,
+                        value._parent.identifier))
+            value.lock()   # lock because we don't duplicate the object
+        self._vent_opening = value
+
+    @property
     def is_construction_set_on_object(self):
         """Boolean noting if construction is assigned on the level of this Aperture.
 
@@ -81,6 +110,7 @@ class ApertureEnergyProperties(object):
         This means the Aperture's construction will be assigned by a ConstructionSet.
         """
         self._construction = None
+        self._vent_opening = None
 
     @classmethod
     def from_dict(cls, data, host):
@@ -98,7 +128,8 @@ class ApertureEnergyProperties(object):
 
             {
             "type": 'ApertureEnergyProperties',
-            "construction": {}  # WindowConstruction or WindowConstructionShade dict
+            "construction": {},  # WindowConstruction or WindowConstructionShade dict
+            "vent_opening": {}  # VentilationOpening dict
             }
         """
         assert data['type'] == 'ApertureEnergyProperties', \
@@ -107,6 +138,8 @@ class ApertureEnergyProperties(object):
         new_prop = cls(host)
         if 'construction' in data and data['construction'] is not None:
             new_prop.construction = dict_to_construction(data['construction'])
+        if 'vent_opening' in data and data['vent_opening'] is not None:
+            new_prop.vent_opening = VentilationOpening.from_dict(data['vent_opening'])
         return new_prop
 
     def apply_properties_from_dict(self, abridged_data, constructions):
@@ -120,6 +153,9 @@ class ApertureEnergyProperties(object):
         """
         if 'construction' in abridged_data and abridged_data['construction'] is not None:
             self.construction = constructions[abridged_data['construction']]
+        if 'vent_opening' in abridged_data and abridged_data['vent_opening'] is not None:
+            self.vent_opening = \
+                VentilationOpening.from_dict(abridged_data['vent_opening'])
 
     def to_dict(self, abridged=False):
         """Return energy properties as a dictionary.
@@ -135,6 +171,8 @@ class ApertureEnergyProperties(object):
         if self._construction is not None:
             base['energy']['construction'] = \
                 self._construction.identifier if abridged else self._construction.to_dict()
+        if self._vent_opening is not None:
+            base['energy']['vent_opening'] = self._vent_opening.to_dict()
         return base
 
     def duplicate(self, new_host=None):
@@ -144,7 +182,7 @@ class ApertureEnergyProperties(object):
             If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
-        return ApertureEnergyProperties(_host, self._construction)
+        return ApertureEnergyProperties(_host, self._construction, self._vent_opening)
 
     def ToString(self):
         return self.__repr__()

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -208,6 +208,7 @@ class ModelEnergyProperties(object):
             infiltration = room.properties.energy._infiltration
             ventilation = room.properties.energy._ventilation
             setpoint = room.properties.energy._setpoint
+            window_vent = room.properties.energy._window_vent_control
             if people is not None:
                 self._check_and_add_schedule(people.occupancy_schedule, scheds)
                 self._check_and_add_schedule(people.activity_schedule, scheds)
@@ -229,6 +230,8 @@ class ModelEnergyProperties(object):
                         setpoint.humidifying_schedule, scheds)
                     self._check_and_add_schedule(
                         setpoint.dehumidifying_schedule, scheds)
+            if window_vent is not None:
+                self._check_and_add_schedule(window_vent.schedule, scheds)
         return list(set(scheds))
 
     @property

--- a/honeybee_energy/result/sql.py
+++ b/honeybee_energy/result/sql.py
@@ -209,12 +209,15 @@ class SQLiteResult(object):
         try:
             # extract all indices in the ReportDataDictionary with the output_name
             c = conn.cursor()
-            if isinstance(output_name, str):
+            if isinstance(output_name, str):  # assume it's a single output
                 c.execute('SELECT * FROM ReportDataDictionary WHERE Name=?',
                           (output_name,))
-            else:
+            elif len(output_name) == 1:  # assume it's a list
+                c.execute('SELECT * FROM ReportDataDictionary WHERE Name=?',
+                          (output_name[0],))
+            else:  # assume it is a list of outputs
                 c.execute('SELECT * FROM ReportDataDictionary WHERE Name IN {}'.format(
-                    output_name))
+                    tuple(output_name)))
             header_rows = c.fetchall()
 
             # if nothing was found, return an empty list

--- a/honeybee_energy/ventcool/__init__.py
+++ b/honeybee_energy/ventcool/__init__.py
@@ -1,0 +1,5 @@
+"""honeybee-energy ventilative cooling definitions.
+
+This includes opening windows, turning on fans, and other forms of deliberately
+letting in outdoor air for cooling.
+"""

--- a/honeybee_energy/ventcool/control.py
+++ b/honeybee_energy/ventcool/control.py
@@ -1,0 +1,267 @@
+# coding=utf-8
+"""Object to dictate setpoints and schedule for ventilative cooling."""
+from __future__ import division
+
+from ..schedule.dictutil import dict_to_schedule
+from ..schedule.ruleset import ScheduleRuleset
+from ..schedule.fixedinterval import ScheduleFixedInterval
+from ..lib.schedules import always_on
+
+from honeybee._lockable import lockable
+from honeybee.typing import float_in_range
+
+
+@lockable
+class VentilationControl(object):
+    """Object to dictate setpoints and schedule for ventilative cooling.
+
+    Note the all of the default setpoints of this object are set to not perform
+    any ventilative cooling such that users can individually decide which setpoints
+    are relevant to a given ventilation strategy.
+
+    Args:
+        min_indoor_temperature: A number between -100 and 100 for the minimum
+            indoor temperature at which to ventilate in Celsius. Typically,
+            this variable is used to initiate ventilation. (Default: -100).
+        max_indoor_temperature: A number between -100 and 100 for the maximum
+            indoor temperature at which to ventilate in Celsius. This can be
+            used to set a maximum temperature at which point ventilation is
+            stopped and a cooling system is turned on. (Default: 100).
+        min_outdoor_temperature: A number between -100 and 100 for the minimum
+            outdoor temperature at which to ventilate in Celsius. This can be
+            used to ensure ventilative cooling doesn't happen during the winter
+            even if the Room is above the min_indoor_temperature. (Default: -100).
+        max_outdoor_temperature: A number between -100 and 100 for the maximum
+            outdoor temperature at which to ventilate in Celsius. This can be
+            used to set a limit for when it is considered too hot outside for
+            ventilative cooling. (Default: 100).
+        delta_temperature: A number between -100 and 100 for the temperature
+            differential in Celsius between indoor and outdoor below which
+            ventilation is shut off.  This should usually be a negative number
+            so that ventilation only occurs when the outdoors is cooler than the
+            indoors. Positive numbers indicate how much hotter the outdoors can
+            be than the indoors before ventilation is stopped. (Default: -100).
+        schedule: An optional ScheduleRuleset or ScheduleFixedInterval for the
+            ventilation over the course of the year. Note that this is applied
+            on top of any setpoints. The type of this schedule should be On/Off
+            and values should be either 0 (no possibility of ventilation) or 1
+            (ventilation possible). (Default: "Always On")
+
+    Properties:
+        * min_indoor_temperature
+        * max_indoor_temperature
+        * min_outdoor_temperature
+        * max_outdoor_temperature
+        * delta_temperature
+        * schedule
+    """
+    __slots__ = ('_min_indoor_temperature', '_max_indoor_temperature',
+                 '_min_outdoor_temperature', '_max_outdoor_temperature',
+                 '_delta_temperature', '_schedule', '_locked')
+
+    def __init__(self, min_indoor_temperature=-100, max_indoor_temperature=100,
+                 min_outdoor_temperature=-100, max_outdoor_temperature=100,
+                 delta_temperature=-100, schedule=always_on):
+        """Initialize VentilationControl."""
+        self.min_indoor_temperature = min_indoor_temperature
+        self.max_indoor_temperature = max_indoor_temperature
+        self.min_outdoor_temperature = min_outdoor_temperature
+        self.max_outdoor_temperature = max_outdoor_temperature
+        self.delta_temperature = delta_temperature
+        self.schedule = schedule
+
+    @property
+    def min_indoor_temperature(self):
+        """Get or set a number for the minimum indoor temperature for ventilation (C)."""
+        return self._min_indoor_temperature
+
+    @min_indoor_temperature.setter
+    def min_indoor_temperature(self, value):
+        self._min_indoor_temperature = \
+            float_in_range(value, -100.0, 100.0, 'min indoor temperature')
+
+    @property
+    def max_indoor_temperature(self):
+        """Get or set a number for the maximum indoor temperature for ventilation (C)."""
+        return self._max_indoor_temperature
+
+    @max_indoor_temperature.setter
+    def max_indoor_temperature(self, value):
+        self._max_indoor_temperature = \
+            float_in_range(value, -100.0, 100.0, 'max indoor temperature')
+
+    @property
+    def min_outdoor_temperature(self):
+        """Get or set a number for the minimum outdoor temperature for ventilation (C)."""
+        return self._min_outdoor_temperature
+
+    @min_outdoor_temperature.setter
+    def min_outdoor_temperature(self, value):
+        self._min_outdoor_temperature = \
+            float_in_range(value, -100.0, 100.0, 'min outdoor temperature')
+
+    @property
+    def max_outdoor_temperature(self):
+        """Get or set a number for the maximum outdoor temperature for ventilation (C)."""
+        return self._max_outdoor_temperature
+
+    @max_outdoor_temperature.setter
+    def max_outdoor_temperature(self, value):
+        self._max_outdoor_temperature = \
+            float_in_range(value, -100.0, 100.0, 'max outdoor temperature')
+
+    @property
+    def delta_temperature(self):
+        """Get or set the indoor/outdoor temperature difference for ventilation (C)."""
+        return self._delta_temperature
+
+    @delta_temperature.setter
+    def delta_temperature(self, value):
+        self._delta_temperature = \
+            float_in_range(value, -100.0, 100.0, 'delta temperature')
+
+    @property
+    def schedule(self):
+        """Get or set an On/Off schedule for the ventilation.
+
+        Note that this is applied on top of any setpoints.
+        """
+        return self._schedule
+
+    @schedule.setter
+    def schedule(self, value):
+        if value is not None:
+            assert isinstance(value, (ScheduleRuleset, ScheduleFixedInterval)), \
+                'Expected schedule for VentilationControl schedule. ' \
+                'Got {}.'.format(type(value))
+            if value.schedule_type_limit is not None:
+                assert value.schedule_type_limit.unit == 'fraction', 'VentilationControl ' \
+                    'schedule should be fractional [Dimensionless]. Got a schedule ' \
+                    'of unit_type [{}].'.format(value.schedule_type_limit.unit_type)
+            value.lock()  # lock editing in case schedule has multiple references
+            self._schedule = value
+        else:
+            self._schedule = always_on
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a VentilationControl from a dictionary.
+
+        Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: python
+
+            {
+            "type": 'VentilationControl',
+            "min_indoor_temperature": 22,
+            "max_indoor_temperature": 26,
+            "min_outdoor_temperature": 12,
+            "max_outdoor_temperature": 32,
+            "delta_temperature": -4,
+            "schedule": {}  # dictionary of a schedule
+            }
+        """
+        assert data['type'] == 'VentilationControl', \
+            'Expected VentilationControl. Got {}.'.format(data['type'])
+        min_in, max_in, min_out, max_out, delta = cls._default_dict_values(data)
+        sch = dict_to_schedule(data['schedule']) if 'schedule' in data and \
+            data['schedule'] is not None else always_on
+        vent_control = cls(min_in, max_in, min_out, max_out, delta, sch)
+        return vent_control
+
+    @classmethod
+    def from_dict_abridged(cls, data, schedule_dict):
+        """Create a VentilationControl from an abridged dictionary.
+
+        Args:
+            data: A VentilationControlAbridged dictionary with the format below.
+            schedule_dict: A dictionary with schedule identifiers as keys and
+                honeybee schedule objects as values. These will be used to
+                assign the schedule to the VentilationControl object.
+
+        .. code-block:: python
+
+            {
+            "type": 'VentilationControlAbridged',
+            "min_indoor_temperature": 22,
+            "max_indoor_temperature": 26,
+            "min_outdoor_temperature": 12,
+            "max_outdoor_temperature": 32,
+            "delta_temperature": -4,
+            "schedule": ""  # identifier of a schedule
+            }
+        """
+        assert data['type'] == 'VentilationControlAbridged', \
+            'Expected VentilationControlAbridged. Got {}.'.format(data['type'])
+        min_in, max_in, min_out, max_out, delta = cls._default_dict_values(data)
+        sch = schedule_dict[data['schedule']] if \
+            'schedule' in data and data['schedule'] is not None else always_on
+        vent_control = cls(min_in, max_in, min_out, max_out, delta, sch)
+        return vent_control
+
+    def to_dict(self, abridged=False):
+        """Ventilation Control dictionary representation."""
+        base = {'type': 'VentilationControl'} if not \
+            abridged else {'type': 'VentilationControlAbridged'}
+        base['min_indoor_temperature'] = self.min_indoor_temperature
+        base['max_indoor_temperature'] = self.max_indoor_temperature
+        base['min_outdoor_temperature'] = self.min_outdoor_temperature
+        base['max_outdoor_temperature'] = self.max_outdoor_temperature
+        base['delta_temperature'] = self.delta_temperature
+        base['schedule'] = self.schedule.identifier if abridged \
+            else self.schedule.to_dict()
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    @staticmethod
+    def _default_dict_values(data):
+        """Process dictionary values and include defaults for missing values."""
+        min_in = data['min_indoor_temperature'] if 'min_indoor_temperature' in data \
+            and data['min_indoor_temperature'] is not None else -100
+        max_in = data['max_indoor_temperature'] if 'max_indoor_temperature' in data \
+            and data['max_indoor_temperature'] is not None else 100
+        min_out = data['min_outdoor_temperature'] if 'min_outdoor_temperature' in data \
+            and data['min_outdoor_temperature'] is not None else -100
+        max_out = data['max_outdoor_temperature'] if 'max_outdoor_temperature' in data \
+            and data['max_outdoor_temperature'] is not None else 100
+        delta = data['delta_temperature'] if 'delta_temperature' in data \
+            and data['delta_temperature'] is not None else -100
+        return min_in, max_in, min_out, max_out, delta
+
+    def __copy__(self):
+        return VentilationControl(
+            self.min_indoor_temperature, self.max_indoor_temperature,
+            self.min_outdoor_temperature, self.max_outdoor_temperature,
+            self.delta_temperature, self.schedule)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.min_indoor_temperature, self.max_indoor_temperature,
+                self.min_outdoor_temperature, self.max_outdoor_temperature,
+                self.delta_temperature, hash(self._schedule))
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, VentilationControl) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        return 'VentilationControl,\n min in temperature: {}\n ' \
+            'max in temperature: {}\n min out temperature: {}\n ' \
+            'max out temperature: {}\n delta temperature: {}\n' \
+            'schedule: {}'.format(
+                self.min_indoor_temperature, self.max_indoor_temperature,
+                self.min_outdoor_temperature, self.max_outdoor_temperature,
+                self.delta_temperature, self.schedule)

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -1,0 +1,247 @@
+# coding=utf-8
+"""Definition of window opening for ventilative cooling."""
+from __future__ import division
+
+from .control import VentilationControl
+from ..writer import generate_idf_string
+
+from honeybee._lockable import lockable
+from honeybee.typing import float_in_range
+
+
+@lockable
+class VentilationOpening(object):
+    """Definition of window opening for ventilative cooling.
+
+    Args:
+        fraction_area_operable: A number between 0.0 and 1.0 for the fraction of the
+            window area that is operable. (Default: 0.5, typical of sliding windows).
+        fraction_height_operable: A number between 0.0 and 1.0 for the fraction
+            of the distance from the bottom of the window to the top that is
+            operable. (Default: 1.0, typical of windows that slide horizontally).
+        discharge_coefficient: A number between 0.0 and 1.0 that will be multipled
+            by the area of the window in the stack (buoyancy-driven) part of the
+            equation to account for additional friction from window geometry,
+            insect screens, etc. (Default: 0.17, for unobstructed windows with
+            insect screens). This value should be lowered if windows are of an
+            awning or casement type and not allowed to fully open. Some common
+            values for this coefficient include the following.
+
+                * 0.0 - Completely discount stack ventilation from the calculation.
+                * 0.17 - For unobstructed windows with an insect screen.
+                * 0.25 - For unobstructed windows with NO insect screen.
+
+        wind_cross_vent: Boolean to indicate if there is an opening of roughly
+            equal area on the opposite side of the Room such that wind-driven
+            cross ventilation will be induced. If False, the assumption is that
+            the operable area is primarily on one side of the Room and there is
+            no wind-driven ventilation. (Default: False)
+
+    Properties:
+        * fraction_area_operable
+        * fraction_height_operable
+        * discharge_coefficient
+        * wind_cross_vent
+        * parent
+        * has_parent
+    """
+    __slots__ = ('_fraction_area_operable', '_fraction_height_operable',
+                 '_discharge_coefficient', '_wind_cross_vent', '_parent', '_locked')
+
+    def __init__(self, fraction_area_operable=0.5, fraction_height_operable=1.0,
+                 discharge_coefficient=0.17, wind_cross_vent=False):
+        """Initialize VentilationOpening."""
+        self.fraction_area_operable = fraction_area_operable
+        self.fraction_height_operable = fraction_height_operable
+        self.discharge_coefficient = discharge_coefficient
+        self.wind_cross_vent = wind_cross_vent
+        self._parent = None  # this will be set when assigned to an aperture
+
+    @property
+    def fraction_area_operable(self):
+        """Get or set a number for the fraction of the window area that is operable."""
+        return self._fraction_area_operable
+
+    @fraction_area_operable.setter
+    def fraction_area_operable(self, value):
+        self._fraction_area_operable = \
+            float_in_range(value, 0.0, 1.0, 'fraction area operable')
+
+    @property
+    def fraction_height_operable(self):
+        """Get or set a number for the fraction of the window height that is operable."""
+        return self._fraction_height_operable
+
+    @fraction_height_operable.setter
+    def fraction_height_operable(self, value):
+        self._fraction_height_operable = \
+            float_in_range(value, 0.0, 1.0, 'fraction height operable')
+
+    @property
+    def discharge_coefficient(self):
+        """Get or set a number for the discharge coefficient."""
+        return self._discharge_coefficient
+
+    @discharge_coefficient.setter
+    def discharge_coefficient(self, value):
+        self._discharge_coefficient = \
+            float_in_range(value, 0.0, 1.0, 'discharge coefficient')
+
+    @property
+    def wind_cross_vent(self):
+        """Get or set a boolean for whether there is cross ventilation from the window.
+
+        Note that this property only has significance for simulations with simple
+        ZoneVentilation objects and has no bearing on simulations with the
+        Airflow Network.
+
+        This should be True if there is an opening of roughly equal area on the
+        opposite side of the Room such that wind-driven cross ventilation will
+        be induced. If False, the assumption is that the operable area is primarily
+        on one side of the Room and there is no wind-driven ventilation.
+        """
+        return self._wind_cross_vent
+
+    @wind_cross_vent.setter
+    def wind_cross_vent(self, value):
+        self._wind_cross_vent = bool(value)
+
+    @property
+    def parent(self):
+        """Get the parent of this object if it exists."""
+        return self._parent
+
+    @property
+    def has_parent(self):
+        """Get a boolean noting whether this VentilationOpening has a parent object."""
+        return self._parent is not None
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a VentilationOpening object from a dictionary.
+
+        Args:
+            data: A VentilationOpening dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "VentilationOpening",
+            "fraction_area_operable": 0.5,  # Fractional number for area operable
+            "fraction_height_operable": 0.5,  # Fractional number for height operable
+            "discharge_coefficient": 0.17,  # Fractional number for discharge coefficient
+            "wind_cross_vent": True  # Wind-driven cross ventilation
+            }
+        """
+        assert data['type'] == 'VentilationOpening', \
+            'Expected VentilationOpening dictionary. Got {}.'.format(data['type'])
+
+        area_op = data['fraction_area_operable'] if 'fraction_area_operable' in data \
+            and data['fraction_area_operable'] is not None else 0.5
+        height_op = data['fraction_height_operable'] if 'fraction_height_operable' in data \
+            and data['fraction_height_operable'] is not None else 1.0
+        discharge = data['discharge_coefficient'] if 'discharge_coefficient' in data \
+            and data['discharge_coefficient'] is not None else 0.17
+        cross_vent = data['wind_cross_vent'] if 'wind_cross_vent' in data \
+            and data['wind_cross_vent'] is not None else False
+
+        return cls(area_op, height_op, discharge, cross_vent)
+
+    def to_idf(self):
+        """IDF string representation of VentilationOpening object.
+
+        Note that this ventilation opening must be assigned to a honeybee Aperture
+        or Door for this method to run. This parent Aperture or Door must also have
+        a parent Room. It is also recommended that this Room have a VentilationControl
+        object under its energy properties. Otherwise, the default control sequence
+        will be used, which will likely result in the window never opening.
+
+        Also note that the parent's geometry should be in meters whenever calling
+        this method and that this method does not return full definitions of
+        ventilation control schedules. So these schedules must also be translated
+        into the final IDF file.
+        """
+        # check that a parent is assigned
+        assert self.parent is not None, \
+            'VentilationOpening must be assigned to an Aperture or Door to use to_idf().'
+
+        # get the VentilationControl object from the room
+        cntrl = None
+        room = None
+        if self.parent.has_parent:
+            if self.parent.parent.has_parent:
+                room = self.parent.parent.parent
+                if room.properties.energy.window_vent_control is not None:
+                    cntrl = room.properties.energy.window_vent_control
+        if cntrl is None:  # use default ventilation control
+            cntrl = VentilationControl()
+        assert room is not None, \
+            'VentilationOpening must have a parent Room to use to_idf().'
+
+        # process the properties on this object into IDF format
+        sch = '' if cntrl.schedule is None else cntrl.schedule.identifier
+        wind = 'autocalculate' if self.wind_cross_vent else 0
+        angle = self.parent.horizontal_orientation() if self.parent.normal.z != 1 else 0
+        height = (self.parent.geometry.max.z - self.parent.geometry.min.z) * \
+            self.fraction_height_operable
+
+        # create the final IDF string
+        values = (
+            '{}_Opening'.format(self.parent.identifier), room.identifier,
+            self.parent.area * self.fraction_area_operable, sch, wind, angle,
+            height, self.discharge_coefficient, cntrl.min_indoor_temperature, '',
+            cntrl.max_indoor_temperature, '', cntrl.delta_temperature, '',
+            cntrl.min_outdoor_temperature, '', cntrl.max_outdoor_temperature, '', 40)
+        comments = (
+            'name', 'zone name', 'opening area', 'opening schedule',
+            'opening effectiveness {m2}', 'horizontal orientation angle',
+            'height difference {m}', 'discharge coefficient',
+            'min indoor temperature {C}', 'min in temp schedule',
+            'max indoor temperature {C}', 'max in temp schedule',
+            'delta temperature {C}', 'delta temp schedule',
+            'min outdoor temperature {C}', 'min out temp schedule',
+            'max outdoor temperature {C}', 'max out temp schedule', 'max wind speed')
+        return generate_idf_string(
+            'ZoneVentilation:WindandStackOpenArea', values, comments)
+
+    def to_dict(self):
+        """Ventilation Opening dictionary representation."""
+        base = {'type': 'VentilationOpening'}
+        base['fraction_area_operable'] = self.fraction_area_operable
+        base['fraction_height_operable'] = self.fraction_height_operable
+        base['discharge_coefficient'] = self.discharge_coefficient
+        base['wind_cross_vent'] = self.wind_cross_vent
+        return base
+
+    def duplicate(self):
+        """Get a copy of this object."""
+        return self.__copy__()
+
+    def __copy__(self):
+        return VentilationOpening(
+            self.fraction_area_operable, self.fraction_height_operable,
+            self.discharge_coefficient, self.wind_cross_vent)
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.fraction_area_operable, self.fraction_height_operable,
+                self.discharge_coefficient, self.wind_cross_vent)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, VentilationOpening) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def ToString(self):
+        """Overwrite .NET ToString."""
+        return self.__repr__()
+
+    def __repr__(self):
+        return 'VentilationOpening,\n fraction area: {}\n ' \
+            'fration height: {}\n discharge coeff: {}'.format(
+                self.fraction_area_operable, self.fraction_height_operable,
+                self.discharge_coefficient)

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -120,11 +120,12 @@ def door_to_idf(door):
 
     Note that the resulting string does not include full construction definitions
     but it will include a WindowShadingControl definition if a WindowConstructionShade
-    is assigned to the door.
+    is assigned to the door. It will also include a ventilation object if the door
+    has a VentilationOpening object assigned to it.
 
-    Also note that shades assigned to the Aperture are not included in the resulting
+    Also note that shades assigned to the Door are not included in the resulting
     string. To write these objects into a final string, you must loop through the
-    Aperture.shades, and call the to.idf method on each one.
+    Door.shades, and call the to.idf method on each one.
 
     Args:
         door: A honeybee Door for which an IDF representation will be returned.
@@ -167,11 +168,18 @@ def door_to_idf(door):
     fen_str = generate_idf_string('FenestrationSurface:Detailed', values, comments)
 
     # create the WindowShadingControl object if it is needed
-    if not construction.has_shade:
-        return fen_str
-    else:
+    if construction.has_shade:
         shd_prop_str = construction.to_shading_control_idf(door.identifier, parent_room)
-        return '\n\n'.join((fen_str, shd_prop_str))
+        fen_str = '\n\n'.join((fen_str, shd_prop_str))
+
+    # create the VentilationOpening object if it is needed
+    if door.properties.energy.vent_opening is not None:
+        try:
+            vent_str = door.properties.energy.vent_opening.to_idf()
+            fen_str = '\n\n'.join((fen_str, vent_str))
+        except AssertionError:  # door does not have a parent room
+            pass
+    return fen_str
 
 
 def aperture_to_idf(aperture):
@@ -179,7 +187,8 @@ def aperture_to_idf(aperture):
 
     Note that the resulting string does not include full construction definitions
     but it will include a WindowShadingControl definition if a WindowConstructionShade
-    is assigned to the aperture.
+    is assigned to the aperture. It will also include a ventilation object if the
+    aperture has a VentilationOpening object assigned to it.
 
     Also note that shades assigned to the Aperture are not included in the resulting
     string. To write these objects into a final string, you must loop through the
@@ -226,12 +235,19 @@ def aperture_to_idf(aperture):
     fen_str = generate_idf_string('FenestrationSurface:Detailed', values, comments)
 
     # create the WindowShadingControl object if it is needed
-    if not construction.has_shade:
-        return fen_str
-    else:
+    if construction.has_shade:
         shd_prop_str = construction.to_shading_control_idf(
             aperture.identifier, parent_room)
-        return '\n\n'.join((fen_str, shd_prop_str))
+        fen_str = '\n\n'.join((fen_str, shd_prop_str))
+    
+    # create the VentilationOpening object if it is needed
+    if aperture.properties.energy.vent_opening is not None:
+        try:
+            vent_str = aperture.properties.energy.vent_opening.to_idf()
+            fen_str = '\n\n'.join((fen_str, vent_str))
+        except AssertionError:  # aperture does not have a parent room
+            pass
+    return fen_str
 
 
 def face_to_idf(face):

--- a/tests/result_test.py
+++ b/tests/result_test.py
@@ -195,6 +195,10 @@ def test_sqlite_data_collections_by_output_names():
         assert len(coll) == len(coll.header.analysis_period.hoys)
         assert isinstance(coll.header.data_type, (Energy, Temperature))
 
+    data_colls = sql_obj.data_collections_by_output_name(
+        ('Zone Lights Electric Energy',))
+    assert len(data_colls) == 7
+
 
 def test_sqlite_data_collections_by_output_name_openstudio():
     """Test the data_collections_by_output_name method with openstudio values."""

--- a/tests/ventcool_control_test.py
+++ b/tests/ventcool_control_test.py
@@ -1,0 +1,101 @@
+# coding=utf-8
+from honeybee_energy.ventcool.control import VentilationControl
+from honeybee_energy.schedule.day import ScheduleDay
+from honeybee_energy.schedule.ruleset import ScheduleRuleset
+from honeybee_energy.lib.schedules import always_on
+import honeybee_energy.lib.scheduletypelimits as schedule_types
+
+from ladybug.dt import Time
+
+import pytest
+
+
+def test_ventilation_control_init():
+    """Test the initialization of VentilationControl and basic properties."""
+    ventilation = VentilationControl()
+    str(ventilation)  # test the string representation
+
+    assert ventilation.min_indoor_temperature == -100
+    assert ventilation.max_indoor_temperature == 100
+    assert ventilation.min_outdoor_temperature == -100
+    assert ventilation.max_outdoor_temperature == 100
+    assert ventilation.delta_temperature == -100
+    assert ventilation.schedule == always_on
+
+    ventilation.min_indoor_temperature = 22
+    ventilation.max_indoor_temperature = 28
+    ventilation.min_outdoor_temperature = 12
+    ventilation.max_outdoor_temperature = 32
+    ventilation.delta_temperature = 0
+
+    assert ventilation.min_indoor_temperature == 22
+    assert ventilation.max_indoor_temperature == 28
+    assert ventilation.min_outdoor_temperature == 12
+    assert ventilation.max_outdoor_temperature == 32
+    assert ventilation.delta_temperature == 0
+
+
+def test_ventilation_control_init_schedule():
+    """Test the initialization of VentilationControl with a schedule."""
+    simple_office = ScheduleDay('Simple Flush', [1, 0, 1],
+                                [Time(0, 0), Time(9, 0), Time(22, 0)])
+    schedule = ScheduleRuleset('Night Flush Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = VentilationControl(100, schedule=schedule)
+    str(ventilation)  # test the string representation
+
+    assert ventilation.min_indoor_temperature == 100
+    assert ventilation.schedule.identifier == 'Night Flush Schedule'
+    assert ventilation.schedule.schedule_type_limit == schedule_types.fractional
+    assert ventilation.schedule == schedule
+
+
+def test_ventilation_control_equality():
+    """Test the equality of VentilationControl objects."""
+    simple_office = ScheduleDay('Simple Flush', [1, 0, 1],
+                                [Time(0, 0), Time(9, 0), Time(22, 0)])
+    schedule = ScheduleRuleset('Night Flush Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = VentilationControl(18, schedule=schedule)
+    ventilation_dup = ventilation.duplicate()
+    ventilation_alt = VentilationControl(20)
+    ventilation_alt.schedule = schedule
+
+    assert ventilation is ventilation
+    assert ventilation is not ventilation_dup
+    assert ventilation == ventilation_dup
+    ventilation_dup.delta_temperature = -2
+    assert ventilation != ventilation_dup
+    assert ventilation != ventilation_alt
+
+
+def test_ventilation_control_lockability():
+    """Test the lockability of Ventilation objects."""
+    ventilation = VentilationControl(20)
+
+    ventilation.delta_temperature = -2
+    ventilation.lock()
+    with pytest.raises(AttributeError):
+        ventilation.min_indoor_temperature = 22
+    ventilation.unlock()
+    ventilation.min_indoor_temperature = 22
+
+
+def test_ventilation_dict_methods():
+    """Test the to/from dict methods."""
+    simple_office = ScheduleDay('Simple Flush', [1, 0, 1],
+                                [Time(0, 0), Time(9, 0), Time(22, 0)])
+    schedule = ScheduleRuleset('Night Flush Schedule', simple_office,
+                               None, schedule_types.fractional)
+    ventilation = VentilationControl(22, 28, 12, 32, 0)
+
+    vent_dict = ventilation.to_dict()
+    new_ventilation = VentilationControl.from_dict(vent_dict)
+    assert new_ventilation == ventilation
+    assert vent_dict == new_ventilation.to_dict()
+
+    ventilation.schedule = schedule
+    vent_dict = ventilation.to_dict()
+    new_ventilation = VentilationControl.from_dict(vent_dict)
+    assert new_ventilation == ventilation
+    assert vent_dict == new_ventilation.to_dict()

--- a/tests/ventcool_opening_test.py
+++ b/tests/ventcool_opening_test.py
@@ -1,0 +1,115 @@
+# coding=utf-8
+from honeybee_energy.ventcool.opening import VentilationOpening
+from honeybee_energy.ventcool.control import VentilationControl
+from honeybee_energy.schedule.day import ScheduleDay
+from honeybee_energy.schedule.ruleset import ScheduleRuleset
+import honeybee_energy.lib.scheduletypelimits as schedule_types
+
+from honeybee.room import Room
+
+from ladybug.dt import Time
+
+import pytest
+
+
+def test_ventilation_opening_init():
+    """Test the initialization of VentilationOpening and basic properties."""
+    ventilation = VentilationOpening()
+    str(ventilation)  # test the string representation
+
+    assert ventilation.fraction_area_operable == 0.5
+    assert ventilation.fraction_height_operable == 1.0
+    assert ventilation.discharge_coefficient == 0.17
+    assert not ventilation.wind_cross_vent
+    assert not ventilation.has_parent
+    assert ventilation.parent is None
+
+    ventilation.fraction_area_operable = 0.25
+    ventilation.fraction_height_operable = 0.5
+    ventilation.discharge_coefficient = 0.25
+    ventilation.wind_cross_vent = True
+
+    assert ventilation.fraction_area_operable == 0.25
+    assert ventilation.fraction_height_operable == 0.5
+    assert ventilation.discharge_coefficient == 0.25
+    assert ventilation.wind_cross_vent
+
+
+def test_ventilation_opening_parent():
+    """Test the VentilationOpening with a parent."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    south_face = room[3]
+    south_face.apertures_by_ratio(0.4, 0.01)
+    aperture = south_face.apertures[0]
+
+    ventilation = VentilationOpening()
+    assert not ventilation.has_parent
+    assert ventilation.parent is None
+
+    with pytest.raises(AssertionError):
+        aperture.properties.energy.vent_opening = ventilation
+
+    aperture.is_operable = True
+    aperture.properties.energy.vent_opening = ventilation
+    assert ventilation.has_parent
+    assert ventilation.parent.identifier == aperture.identifier
+
+
+def test_ventilation_opening_equality():
+    """Test the equality of Ventilation objects."""
+    ventilation = VentilationOpening(0.25, 0.5, 0.25, True)
+    ventilation_dup = ventilation.duplicate()
+    ventilation_alt = VentilationOpening(0.5, 0.5, 0.25, True)
+
+    assert ventilation is ventilation
+    assert ventilation is not ventilation_dup
+    assert ventilation == ventilation_dup
+    ventilation_dup.fraction_area_operable = 0.3
+    assert ventilation != ventilation_dup
+    assert ventilation != ventilation_alt
+
+
+def test_ventilation_opening_lockability():
+    """Test the lockability of Ventilation objects."""
+    ventilation = VentilationOpening(0.25, 0.5, 0.25, True)
+
+    ventilation.fraction_area_operable = 0.3
+    ventilation.lock()
+    with pytest.raises(AttributeError):
+        ventilation.wind_cross_vent = False
+    ventilation.unlock()
+    ventilation.wind_cross_vent = False
+
+
+def test_ventilation_opening_to_idf():
+    """Test the initialization of Ventilation from_idf."""
+    room = Room.from_box('ShoeBoxZone', 5, 10, 3)
+    south_face = room[3]
+    south_face.apertures_by_ratio(0.4, 0.01)
+    aperture = south_face.apertures[0]
+    aperture.is_operable = True
+    simple_office = ScheduleDay('Simple Flush', [1, 0, 1],
+                                [Time(0, 0), Time(9, 0), Time(22, 0)])
+    schedule = ScheduleRuleset('Night Flush Schedule', simple_office,
+                               None, schedule_types.fractional)
+    vent_control = VentilationControl(18, schedule=schedule)
+    room.properties.energy.window_vent_control = vent_control
+
+    ventilation = VentilationOpening()
+    with pytest.raises(AssertionError):
+        ventilation.to_idf()
+    aperture.properties.energy.vent_opening = ventilation
+
+    idf_str = ventilation.to_idf()
+    assert room.identifier in idf_str
+    assert schedule.identifier in idf_str
+
+
+def test_ventilation_dict_methods():
+    """Test the to/from dict methods."""
+    ventilation = VentilationOpening(0.25, 0.5, 0.25, True)
+
+    vent_dict = ventilation.to_dict()
+    new_ventilation = VentilationOpening.from_dict(vent_dict)
+    assert new_ventilation == ventilation
+    assert vent_dict == new_ventilation.to_dict()


### PR DESCRIPTION
This commit adds objects for simple window-based ventilative cooling. While this commit only includes enough objects to model windows with ZoneVentilation:WindandStackOpenArea objects, many of these objects should also be used in the future AFN.

@saeranv , Please feel free to review and post any questions that you have as comments. It may take me a day or two before I have enough tests in place to merge this in.  FYI, I am not expecting you to add any `to_idf` method as part of your work (you can see one of them in this PR). I only included this so that we have some way of exporting simple window-based ventilation objects in direct-to-idf workflows. I'm imagining that all of the AFN export happens through the honeybee_openstudio_gem.