### PR TITLE
fix(properties): Ensure that child objects are duplicated with parents

### DIFF
--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -22,6 +22,7 @@ import pkgutil
 # Matrix matching OpenStudio version to EnergyPlus version
 # https://github.com/NREL/OpenStudio/wiki/OpenStudio-Version-Compatibility-Matrix
 OPENSTUDIO_VERSIONS = {
+    (3, 0, 1): (9, 3, 0),
     (3, 0, 0): (9, 3, 0),
     (2, 9, 1): (9, 2, 0),
     (2, 9, 0): (9, 2, 0),

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -93,7 +93,6 @@ class ApertureEnergyProperties(object):
                     'Try duplicating the object and then assign it.'.format(
                         'VentilationOpening', self.host.identifier,
                         value._parent.identifier))
-            value.lock()   # lock because we don't duplicate the object
         self._vent_opening = value
 
     @property
@@ -182,7 +181,8 @@ class ApertureEnergyProperties(object):
             If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
-        return ApertureEnergyProperties(_host, self._construction, self._vent_opening)
+        vo = self._vent_opening.duplicate() if self._vent_opening is not None else None
+        return ApertureEnergyProperties(_host, self._construction, vo)
 
     def ToString(self):
         return self.__repr__()

--- a/honeybee_energy/properties/door.py
+++ b/honeybee_energy/properties/door.py
@@ -98,7 +98,6 @@ class DoorEnergyProperties(object):
                     'Try duplicating the object and then assign it.'.format(
                         'VentilationOpening', self.host.identifier,
                         value._parent.identifier))
-            value.lock()   # lock because we don't duplicate the object
         self._vent_opening = value
 
     @property
@@ -189,7 +188,8 @@ class DoorEnergyProperties(object):
                 If None, the properties will be duplicated with the same host.
         """
         _host = new_host or self._host
-        return DoorEnergyProperties(_host, self._construction, self._vent_opening)
+        vo = self._vent_opening.duplicate() if self._vent_opening is not None else None
+        return DoorEnergyProperties(_host, self._construction, vo)
 
     def ToString(self):
         return self.__repr__()

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -509,6 +509,8 @@ class RoomEnergyProperties(object):
         _host = new_host or self._host
         new_room = RoomEnergyProperties(
             _host, self._program_type, self._construction_set, self._hvac)
+        if self._hvac is not None and self._hvac.is_single_room:
+            new_room.hvac = self.hvac.duplicate()  # reassign parent to new host
         new_room._people = self._people
         new_room._lighting = self._lighting
         new_room._electric_equipment = self._electric_equipment

--- a/honeybee_energy/simulation/output.py
+++ b/honeybee_energy/simulation/output.py
@@ -479,7 +479,7 @@ output-table-summaryreports.html#outputtablesummaryreports)
         style = 'CommaAndHTML' if self.include_html else 'Comma'
         table_style = generate_idf_string(
             'OutputControl:Table:Style',
-            (style, 'JtoKWH'), ('column separator', 'unit conversion'))
+            (style, 'None'), ('column separator', 'unit conversion'))
         output_variables = [self._output_to_idf(out_p) for out_p in self.outputs] if \
             len(self._outputs) != 0 else None
         r_comments = ['report {}'.format(i) for i in range(len(self._summary_reports))]

--- a/honeybee_energy/ventcool/control.py
+++ b/honeybee_energy/ventcool/control.py
@@ -264,4 +264,4 @@ class VentilationControl(object):
             'schedule: {}'.format(
                 self.min_indoor_temperature, self.max_indoor_temperature,
                 self.min_outdoor_temperature, self.max_outdoor_temperature,
-                self.delta_temperature, self.schedule)
+                self.delta_temperature, self.schedule.identifier)

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -5,11 +5,9 @@ from __future__ import division
 from .control import VentilationControl
 from ..writer import generate_idf_string
 
-from honeybee._lockable import lockable
 from honeybee.typing import float_in_range
 
 
-@lockable
 class VentilationOpening(object):
     """Definition of window opening for ventilative cooling.
 
@@ -46,7 +44,7 @@ class VentilationOpening(object):
         * has_parent
     """
     __slots__ = ('_fraction_area_operable', '_fraction_height_operable',
-                 '_discharge_coefficient', '_wind_cross_vent', '_parent', '_locked')
+                 '_discharge_coefficient', '_wind_cross_vent', '_parent')
 
     def __init__(self, fraction_area_operable=0.5, fraction_height_operable=1.0,
                  discharge_coefficient=0.17, wind_cross_vent=False):

--- a/tests/ventcool_opening_test.py
+++ b/tests/ventcool_opening_test.py
@@ -69,18 +69,6 @@ def test_ventilation_opening_equality():
     assert ventilation != ventilation_alt
 
 
-def test_ventilation_opening_lockability():
-    """Test the lockability of Ventilation objects."""
-    ventilation = VentilationOpening(0.25, 0.5, 0.25, True)
-
-    ventilation.fraction_area_operable = 0.3
-    ventilation.lock()
-    with pytest.raises(AttributeError):
-        ventilation.wind_cross_vent = False
-    ventilation.unlock()
-    ventilation.wind_cross_vent = False
-
-
 def test_ventilation_opening_to_idf():
     """Test the initialization of Ventilation from_idf."""
     room = Room.from_box('ShoeBoxZone', 5, 10, 3)


### PR DESCRIPTION
This commit is primarily to fix an issue that I realized can arise from duplication of child objects (eg. HVAC systems or VentilationOpening objects) that have dependencies on parent honeybee-core objects (eg. Rooms, Apertures). The fix makes sure that the child objects get duplicated with the parent objects.

I also put in a few other small fixes:
* included the most recent openstudio version in the compatibility matrix of honeybee config.
* removed the JtoKWH converter in the diret-to-idf methods as I realized that this can never align with the OpenStudio workflows
* Added option to perform unit conversions from J to kWh upon import of summary report tables.