### PR TITLE
feat(hvac): Add classes for detailed HVAC templates

### DIFF
--- a/honeybee_energy/hvac/__init__.py
+++ b/honeybee_energy/hvac/__init__.py
@@ -5,10 +5,15 @@ a single class inheriting from _HVACSystem in hvac._base. Then, add the class to
 HVAC_TYPES_DICT using the name of the class as the key.
 
 Properties:
-    * HVAC_TYPES_DICT: A dictionary containing pointers to the classes of each HVAC system.
-      The keys of this dictionary are the names of the HVAC classes.
+    * HVAC_TYPES_DICT: A dictionary containing pointers to the classes of each
+        HVAC system. The keys of this dictionary are the names of the HVAC classes.
 """
 from .idealair import IdealAirSystem
-
+from .allair import HVAC_TYPES_DICT as allair_types
+from .doas import HVAC_TYPES_DICT as doas_types
+from .heatcool import HVAC_TYPES_DICT as heatcool_types
 
 HVAC_TYPES_DICT = {'IdealAirSystem': IdealAirSystem}
+HVAC_TYPES_DICT.update(allair_types)
+HVAC_TYPES_DICT.update(doas_types)
+HVAC_TYPES_DICT.update(heatcool_types)

--- a/honeybee_energy/hvac/_base.py
+++ b/honeybee_energy/hvac/_base.py
@@ -114,4 +114,4 @@ class _HVACSystem(object):
         return new_obj
 
     def __repr__(self):
-        return 'HVACSystem:\n is single room: {}'.format(self.is_single_room)
+        return 'HVACSystem: {}'.format(self.identifier)

--- a/honeybee_energy/hvac/_template.py
+++ b/honeybee_energy/hvac/_template.py
@@ -1,0 +1,248 @@
+# coding=utf-8
+"""Base class for HVAC systems following a template from the OpenStudio standards gem."""
+from __future__ import division
+
+from ._base import _HVACSystem
+
+from honeybee._lockable import lockable
+from honeybee.typing import valid_ep_string
+
+import os
+import importlib
+
+
+@lockable
+class _TemplateSystem(_HVACSystem):
+    """Base class for HVAC systems following a standards template.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment.
+            For example, 'VAV chiller with gas boiler reheat'.
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ('_vintage', '_equipment_type')
+
+    VINTAGES = ('DOE Ref Pre-1980', 'DOE Ref 1980-2004', '90.1-2004', '90.1-2007',
+                '90.1-2010', '90.1-2013')
+    EQUIPMENT_TYPES = ('Inferred',)
+
+    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None):
+        """Initialize HVACSystem."""
+        # initialize base HVAC system properties
+        _HVACSystem.__init__(self, identifier, is_single_room=False)
+        self.vintage = vintage
+        self.equipment_type = equipment_type
+
+    @property
+    def vintage(self):
+        """Get or set text to indicate the vintage of the template system.
+
+        Choose from the following options:
+
+        * DOE Ref Pre-1980
+        * DOE Ref 1980-2004
+        * 90.1-2004
+        * 90.1-2007
+        * 90.1-2010
+        * 90.1-2013
+        """
+        return self._vintage
+
+    @vintage.setter
+    def vintage(self, value):
+        clean_input = valid_ep_string(value).lower()
+        for key in self.VINTAGES:
+            if key.lower() == clean_input:
+                value = key
+                break
+        else:
+            raise ValueError(
+                'Template HVAC vintage "{}" is not recognized.\nChoose from the '
+                'following:\n{}'.format(value, self.VINTAGES))
+        self._vintage = value
+
+    @property
+    def equipment_type(self):
+        """Get or set text for the system's equipment specification.
+
+        For example, 'VAV chiller with gas boiler reheat'.
+        """
+        return self._equipment_type
+
+    @equipment_type.setter
+    def equipment_type(self, value):
+        if value is not None:
+            clean_input = valid_ep_string(value).lower()
+            for key in self.EQUIPMENT_TYPES:
+                if key.lower() == clean_input:
+                    value = key
+                    break
+            else:
+                raise ValueError(
+                    'HVAC equipment_type "{}" is not supported for {}.\n'
+                    'Choose from the following:\n{}'.format(
+                        value, self.__class__.__name__, '\n'.join(self.EQUIPMENT_TYPES)))
+            self._equipment_type = value
+        else:
+            self._equipment_type = self.EQUIPMENT_TYPES[0]
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a HVAC object from a dictionary.
+
+        Args:
+            data: A HVAC dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": ""  # text for the HVAC equipment type
+            }
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {} dictionary. Got {}.'.format(cls.__name__, data['type'])
+        new_obj = cls(data['identifier'], data['vintage'], data['equipment_type'])
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    @classmethod
+    def from_dict_abridged(cls, data, schedule_dict):
+        """Create a HVAC object from an abridged dictionary.
+
+        Args:
+            data: An abridged dictionary in following the format below.
+            schedule_dict: A dictionary with schedule identifiers as keys and honeybee
+                schedule objects as values (either ScheduleRuleset or
+                ScheduleFixedInterval). These will be used to assign the schedules
+                to the Setpoint object.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": ""  # text for the HVAC equipment type
+            }
+        """
+        # this is the same as the from_dict method for as long as there are not schedules
+        return cls.from_dict(data)
+
+    def to_dict(self, abridged=False):
+        """All air system dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                This input currently has no effect but may eventually have one if
+                schedule-type properties are exposed on this template.
+        """
+        base = {'type': self.__class__.__name__}
+        base['identifier'] = self.identifier
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        base['vintage'] = self.vintage
+        base['equipment_type'] = self.equipment_type
+        return base
+
+    def __copy__(self):
+        new_obj = self.__class__(self.identifier, self.vintage, self.equipment_type)
+        new_obj._display_name = self._display_name
+        return new_obj
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self._identifier, self._vintage, self._equipment_type)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}: {}\n type: {}\n vintage: {}'.format(
+            self.__class__.__name__, self.identifier, self.equipment_type, self.vintage)
+
+
+class _EnumerationBase(object):
+    """Enumerates the systems that inherit from a given template class."""
+
+    def __init__(self):
+        pass  # this class is only intended to be used in child objects
+
+    @property
+    def types(self):
+        """A tuple indicating the currently supported HVAC types."""
+        return tuple(sorted(self._HVAC_TYPES.keys()))
+
+    @property
+    def equipment_types(self):
+        """A tuple indicating the supported equipment types."""
+        return tuple(sorted(self._EQUIPMENT_TYPES.keys()))
+
+    @property
+    def types_dict(self):
+        """A dictionary containing pointers to the classes of each HVAC type.
+
+        The keys of this dictionary are the names of the HVAC classes (eg. 'FCU').
+        """
+        return self._HVAC_TYPES
+
+    @property
+    def equipment_types_dict(self):
+        """A dictionary containing pointers to the classes of each equipment type.
+
+        The keys of this dictionary are the names of the HVAC systems as they
+        appear in the OpenStudio standards gem and include the specific equipment
+        in the system (eg. 'DOAS with fan coil chiller with boiler').
+        """
+        return self._EQUIPMENT_TYPES
+
+    @staticmethod
+    def _import_modules(root_dir, base_package):
+        """Import all of the modules in the root_dir.
+
+        Args:
+            root_dir: The directory from which modules will be imported.
+            base_package: Text for the start of the import statement
+                (eg. 'honeybee_energy.hvac.heatcool').
+        """
+        exclude = ('__init__.py', '_base.py')
+        modules = [mod for mod in os.listdir(root_dir)
+                   if mod not in exclude]
+        modules = [os.path.join(root_dir, mod) for mod in modules]
+        importable = ['.{}'.format(os.path.basename(f)[:-3]) for f in modules
+                      if os.path.isfile(f) and f.endswith('.py')]
+        for mod in importable:
+            importlib.import_module(mod, base_package)

--- a/honeybee_energy/hvac/allair/__init__.py
+++ b/honeybee_energy/hvac/allair/__init__.py
@@ -1,0 +1,20 @@
+"""Template All-air HVAC definitions.
+
+All-air systems provide both ventilation and satisfaction of heating + cooling
+demand with the same stream of warm/cool air. As such, they often have really
+good humidity control. However, because such systems often involve the 
+
+Properties:
+    * HVAC_TYPES_DICT: A dictionary containing pointers to the classes of each
+        HVAC system. The keys of this dictionary are the names of the HVAC
+        classes (eg. 'VAV').
+    * EQUIPMENT_TYPES_DICT: A dictionary containing pointers to the classes of
+        the HVAC systems. The keys of this dictionary are the names of the HVAC
+        systems as they appear in the OpenStudio standards gem and include the
+        specific equipment in the system (eg. 'VAV chiller with gas boiler reheat').
+"""
+from ._base import _AllAirEnumeration
+
+_all_air_types = _AllAirEnumeration(import_modules=True)
+HVAC_TYPES_DICT = _all_air_types.types_dict
+EQUIPMENT_TYPES_DICT = _all_air_types.equipment_types_dict

--- a/honeybee_energy/hvac/allair/_base.py
+++ b/honeybee_energy/hvac/allair/_base.py
@@ -1,0 +1,270 @@
+# coding=utf-8
+"""Base class for All-Air HVAC systems."""
+from __future__ import division
+
+from .._template import _TemplateSystem, _EnumerationBase
+
+from honeybee._lockable import lockable
+from honeybee.typing import valid_string, float_in_range
+from honeybee.altnumber import autosize
+
+import os
+
+
+@lockable
+class _AllAirBase(_TemplateSystem):
+    """Base class for All-Air HVAC systems.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment.
+            For example, 'VAV chiller with gas boiler reheat'.
+        economizer_type: Text to indicate the type of air-side economizer used on
+            the system. If Inferred, the economizer will be set to whatever is
+            recommended for the given vintage. (Default: Inferred).
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * economizer_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ('_economizer_type', '_sensible_heat_recovery', '_latent_heat_recovery')
+    ECONOMIZER_TYPES = ('Inferred', 'NoEconomizer', 'DifferentialDryBulb',
+                        'DifferentialEnthalpy')
+    _has_air_loop = True
+
+    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None,
+                 economizer_type='Inferred',
+                 sensible_heat_recovery=autosize, latent_heat_recovery=autosize):
+        """Initialize HVACSystem."""
+        # initialize base HVAC system properties
+        _TemplateSystem.__init__(self, identifier, vintage, equipment_type)
+
+        # set the main features of the HVAC system
+        self.economizer_type = economizer_type
+        self.sensible_heat_recovery = sensible_heat_recovery
+        self.latent_heat_recovery = latent_heat_recovery
+
+    @property
+    def economizer_type(self):
+        """Get or set text to indicate the type of air-side economizer.
+
+        Choose from the following options:
+
+        * Inferred
+        * NoEconomizer
+        * DifferentialDryBulb
+        * DifferentialEnthalpy
+        """
+        return self._economizer_type
+
+    @economizer_type.setter
+    def economizer_type(self, value):
+        clean_input = valid_string(value).lower()
+        for key in self.ECONOMIZER_TYPES:
+            if key.lower() == clean_input:
+                value = key
+                break
+        else:
+            raise ValueError(
+                'economizer_type {} is not recognized.\nChoose from the '
+                'following:\n{}'.format(value, self.ECONOMIZER_TYPES))
+        if value != 'Inferred':
+            assert self._has_air_loop, \
+                'HVAC system must have an air loop to assign an economizer.'
+        self._economizer_type = value
+
+    @property
+    def sensible_heat_recovery(self):
+        """Get or set a number for the effectiveness of sensible heat recovery.
+
+        If None or autosize, it will be whatever is recommended for the given vintage.
+        """
+        return self._sensible_heat_recovery
+
+    @sensible_heat_recovery.setter
+    def sensible_heat_recovery(self, value):
+        if value == autosize or value is None:
+            self._sensible_heat_recovery = autosize
+        else:
+            assert self._has_air_loop, \
+                'HVAC system must have an air loop to set sensible_heat_recovery.'
+            self._sensible_heat_recovery = \
+                float_in_range(value, 0.0, 1.0, 'hvac sensible heat recovery')
+
+    @property
+    def latent_heat_recovery(self):
+        """Get or set a number for the effectiveness of latent heat recovery.
+
+        If None or autosize, it will be whatever is recommended for the given vintage.
+        """
+        return self._latent_heat_recovery
+
+    @latent_heat_recovery.setter
+    def latent_heat_recovery(self, value):
+        if value == autosize or value is None:
+            self._latent_heat_recovery = autosize
+        else:
+            assert self._has_air_loop, \
+                'HVAC system must have an air loop to set latent_heat_recovery.'
+            self._latent_heat_recovery = \
+                float_in_range(value, 0.0, 1.0, 'hvac latent heat recovery')
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a HVAC object from a dictionary.
+
+        Args:
+            data: An all-air dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": "",  # text for the HVAC equipment type
+            "economizer_type": 'DifferentialDryBulb',  # Economizer type
+            "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
+            "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
+            }
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {} dictionary. Got {}.'.format(cls.__name__, data['type'])
+
+        # extract the key features and properties of the HVAC
+        econ = data['economizer_type'] if 'economizer_type' in data and \
+            data['economizer_type'] is not None else 'Inferred'
+        sensible = data['sensible_heat_recovery'] if \
+            'sensible_heat_recovery' in data else None
+        sensible = sensible if sensible != autosize.to_dict() else autosize
+        latent = data['latent_heat_recovery'] if \
+            'latent_heat_recovery' in data else None
+        latent = latent if latent != autosize.to_dict() else autosize
+
+        new_obj = cls(data['identifier'], data['vintage'], data['equipment_type'],
+                      econ, sensible, latent)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    @classmethod
+    def from_dict_abridged(cls, data, schedule_dict):
+        """Create a HVAC object from an abridged dictionary.
+
+        Args:
+            data: An all-air abridged dictionary in following the format below.
+            schedule_dict: A dictionary with schedule identifiers as keys and honeybee
+                schedule objects as values (either ScheduleRuleset or
+                ScheduleFixedInterval). These will be used to assign the schedules
+                to the Setpoint object.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": "",  # text for the HVAC equipment type
+            "economizer_type": 'DifferentialDryBulb',  # Economizer type
+            "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
+            "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
+            }
+        """
+        # this is the same as the from_dict method for as long as there are not schedules
+        return cls.from_dict(data)
+
+    def to_dict(self, abridged=False):
+        """All air system dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                This input currently has no effect but may eventually have one if
+                schedule-type properties are exposed on this template.
+        """
+        base = {'type': self.__class__.__name__}
+        base['identifier'] = self.identifier
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        base['vintage'] = self.vintage
+        base['equipment_type'] = self.equipment_type
+        if self.economizer_type != 'Inferred':
+            base['economizer_type'] = self.economizer_type
+        if self.sensible_heat_recovery != autosize:
+            base['sensible_heat_recovery'] = self.sensible_heat_recovery
+        if self.latent_heat_recovery != autosize:
+            base['latent_heat_recovery'] = self.latent_heat_recovery
+        return base
+
+    def __copy__(self):
+        new_obj = self.__class__(
+            self._identifier, self._vintage, self._equipment_type, self._economizer_type,
+            self._sensible_heat_recovery, self._latent_heat_recovery)
+        new_obj._display_name = self._display_name
+        return new_obj
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self._identifier, self._vintage, self._equipment_type,
+                self._economizer_type, self._sensible_heat_recovery,
+                self._latent_heat_recovery)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}: {}\n type: {}\n vintage: {}\n economizer: {}\n sensible recovery:' \
+            ' {} \n latent recovery: {}'.format(
+                self.__class__.__name__, self.identifier, self.equipment_type,
+                self.vintage, self.economizer_type, self.sensible_heat_recovery,
+                self.latent_heat_recovery)
+
+
+class _AllAirEnumeration(_EnumerationBase):
+    """Enumerates the systems that inherit from _AllAirBase."""
+
+    def __init__(self, import_modules=True):
+        if import_modules:
+            self._import_modules(
+                os.path.dirname(__file__), 'honeybee_energy.hvac.allair')
+
+        self._HVAC_TYPES = {}
+        self._EQUIPMENT_TYPES = {}
+        for clss in _AllAirBase.__subclasses__():
+            self._HVAC_TYPES[clss.__name__] = clss
+            for equip_type in clss.EQUIPMENT_TYPES:
+                self._EQUIPMENT_TYPES[equip_type] = clss

--- a/honeybee_energy/hvac/allair/furnace.py
+++ b/honeybee_energy/hvac/allair/furnace.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+"""Forced Air Furnace HVAC system."""
+from __future__ import division
+
+from ._base import _AllAirBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class ForcedAirFurnace(_AllAirBase):
+    """Forced Air Furnace HVAC system. Intended for spaces only requiring heating.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Forced air furnace
+
+        economizer_type: Text to indicate the type of air-side economizer used on
+            the system. If Inferred, the economizer will be set to whatever is
+            recommended for the given vintage. (Default: Inferred).
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * economizer_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+
+    Note:
+        [1] American Society of Heating, Refrigerating and Air-Conditioning Engineers,
+        Inc. (2007). Ashrae standard 90.1. Atlanta, GA. https://www.ashrae.org/\
+technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standards
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = ('Forced air furnace',)

--- a/honeybee_energy/hvac/allair/psz.py
+++ b/honeybee_energy/hvac/allair/psz.py
@@ -1,0 +1,104 @@
+# coding=utf-8
+"""Packaged Single-Zone (PSZ) HVAC system."""
+from __future__ import division
+
+from ._base import _AllAirBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class PSZ(_AllAirBase):
+    """Packaged Single-Zone (PSZ) HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * PSZ-AC with baseboard electric
+            * PSZ-AC with baseboard gas boiler
+            * PSZ-AC with baseboard district hot water
+            * PSZ-AC with gas unit heaters
+            * PSZ-AC with electric coil
+            * PSZ-AC with gas coil
+            * PSZ-AC with gas boiler
+            * PSZ-AC with central air source heat pump
+            * PSZ-AC with district hot water
+            * PSZ-AC with no heat
+            * PSZ-AC district chilled water with baseboard electric
+            * PSZ-AC district chilled water with baseboard gas boiler
+            * PSZ-AC district chilled water with baseboard district hot water
+            * PSZ-AC district chilled water with gas unit heaters
+            * PSZ-AC district chilled water with electric coil
+            * PSZ-AC district chilled water with gas coil
+            * PSZ-AC district chilled water with gas boiler
+            * PSZ-AC district chilled water with central air source heat pump
+            * PSZ-AC district chilled water with district hot water
+            * PSZ-AC district chilled water with no heat
+            * PSZ-HP
+
+        economizer_type: Text to indicate the type of air-side economizer used on
+            the system. If Inferred, the economizer will be set to whatever is
+            recommended for the given vintage. (Default: Inferred).
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * economizer_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+
+    Note:
+        [1] American Society of Heating, Refrigerating and Air-Conditioning Engineers,
+        Inc. (2007). Ashrae standard 90.1. Atlanta, GA. https://www.ashrae.org/\
+technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standards
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'PSZ-AC with baseboard electric',
+        'PSZ-AC with baseboard gas boiler',
+        'PSZ-AC with baseboard district hot water',
+        'PSZ-AC with gas unit heaters',
+        'PSZ-AC with electric coil',
+        'PSZ-AC with gas coil',
+        'PSZ-AC with gas boiler',
+        'PSZ-AC with central air source heat pump',
+        'PSZ-AC with district hot water',
+        'PSZ-AC with no heat',
+        'PSZ-AC district chilled water with baseboard electric',
+        'PSZ-AC district chilled water with baseboard gas boiler',
+        'PSZ-AC district chilled water with baseboard district hot water',
+        'PSZ-AC district chilled water with gas unit heaters',
+        'PSZ-AC district chilled water with electric coil',
+        'PSZ-AC district chilled water with gas coil',
+        'PSZ-AC district chilled water with gas boiler',
+        'PSZ-AC district chilled water with central air source heat pump',
+        'PSZ-AC district chilled water with district hot water',
+        'PSZ-AC district chilled water with no heat',
+        'PSZ-HP'
+    )

--- a/honeybee_energy/hvac/allair/ptac.py
+++ b/honeybee_energy/hvac/allair/ptac.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+"""Packaged Terminal Air Conditioning (PTAC) or Heat Pump (PTHP) HVAC system."""
+from __future__ import division
+
+from ._base import _AllAirBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class PTAC(_AllAirBase):
+    """Packaged Terminal Air Conditioning (PTAC) or Heat Pump (PTHP) HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * PTAC with baseboard electric
+            * PTAC with baseboard gas boiler
+            * PTAC with baseboard district hot water
+            * PTAC with gas unit heaters
+            * PTAC with electric coil
+            * PTAC with gas coil
+            * PTAC with gas boiler
+            * PTAC with central air source heat pump
+            * PTAC with district hot water
+            * PTAC with no heat
+            * PTHP
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+
+    Note:
+        [1] American Society of Heating, Refrigerating and Air-Conditioning Engineers,
+        Inc. (2007). Ashrae standard 90.1. Atlanta, GA. https://www.ashrae.org/\
+technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standards
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'PTAC with baseboard electric',
+        'PTAC with baseboard gas boiler',
+        'PTAC with baseboard district hot water',
+        'PTAC with gas unit heaters',
+        'PTAC with electric coil',
+        'PTAC with gas coil',
+        'PTAC with gas boiler',
+        'PTAC with central air source heat pump',
+        'PTAC with district hot water',
+        'PTAC with no heat',
+        'PTHP'
+    )
+    _has_air_loop = False

--- a/honeybee_energy/hvac/allair/pvav.py
+++ b/honeybee_energy/hvac/allair/pvav.py
@@ -1,0 +1,72 @@
+# coding=utf-8
+"""Packaged Variable Air Volume (PVAV) HVAC system."""
+from __future__ import division
+
+from ._base import _AllAirBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class PVAV(_AllAirBase):
+    """Packaged Variable Air Volume (PVAV) HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * PVAV with gas boiler reheat
+            * PVAV with central air source heat pump reheat
+            * PVAV with district hot water reheat
+            * PVAV with PFP boxes
+            * PVAV with gas heat with electric reheat
+
+        economizer_type: Text to indicate the type of air-side economizer used on
+            the system. If Inferred, the economizer will be set to whatever is
+            recommended for the given vintage. (Default: Inferred).
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * economizer_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+
+    Note:
+        [1] American Society of Heating, Refrigerating and Air-Conditioning Engineers,
+        Inc. (2007). Ashrae standard 90.1. Atlanta, GA. https://www.ashrae.org/\
+technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standards
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'PVAV with gas boiler reheat',
+        'PVAV with central air source heat pump reheat',
+        'PVAV with district hot water reheat',
+        'PVAV with PFP boxes',
+        'PVAV with gas heat with electric reheat'
+    )

--- a/honeybee_energy/hvac/allair/vav.py
+++ b/honeybee_energy/hvac/allair/vav.py
@@ -1,0 +1,110 @@
+# coding=utf-8
+"""Variable Air Volume (VAV) HVAC system."""
+from __future__ import division
+
+from ._base import _AllAirBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class VAV(_AllAirBase):
+    """Variable Air Volume (VAV) HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * VAV chiller with gas boiler reheat
+            * VAV chiller with central air source heat pump reheat
+            * VAV chiller with district hot water reheat
+            * VAV chiller with PFP boxes
+            * VAV chiller with gas coil reheat
+            * VAV chiller with no reheat with baseboard electric
+            * VAV chiller with no reheat with gas unit heaters
+            * VAV chiller with no reheat with zone heat pump
+            * VAV air-cooled chiller with gas boiler reheat
+            * VAV air-cooled chiller with central air source heat pump reheat
+            * VAV air-cooled chiller with district hot water reheat
+            * VAV air-cooled chiller with PFP boxes
+            * VAV air-cooled chiller with gas coil reheat
+            * VAV air-cooled chiller with no reheat with baseboard electric
+            * VAV air-cooled chiller with no reheat with gas unit heaters
+            * VAV air-cooled chiller with no reheat with zone heat pump
+            * VAV district chilled water with gas boiler reheat
+            * VAV district chilled water with central air source heat pump reheat
+            * VAV district chilled water with district hot water reheat
+            * VAV district chilled water with PFP boxes
+            * VAV district chilled water with gas coil reheat
+            * VAV district chilled water with no reheat with baseboard electric
+            * VAV district chilled water with no reheat with gas unit heaters
+            * VAV district chilled water with no reheat with zone heat pump
+
+        economizer_type: Text to indicate the type of air-side economizer used on
+            the system. If Inferred, the economizer will be set to whatever is
+            recommended for the given vintage. (Default: Inferred).
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * economizer_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+
+    Note:
+        [1] American Society of Heating, Refrigerating and Air-Conditioning Engineers,
+        Inc. (2007). Ashrae standard 90.1. Atlanta, GA. https://www.ashrae.org/\
+technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standards
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'VAV chiller with gas boiler reheat',
+        'VAV chiller with central air source heat pump reheat',
+        'VAV chiller with district hot water reheat',
+        'VAV chiller with PFP boxes',
+        'VAV chiller with gas coil reheat',
+        'VAV chiller with no reheat with baseboard electric',
+        'VAV chiller with no reheat with gas unit heaters',
+        'VAV chiller with no reheat with zone heat pump',
+        'VAV air-cooled chiller with gas boiler reheat',
+        'VAV air-cooled chiller with central air source heat pump reheat',
+        'VAV air-cooled chiller with district hot water reheat',
+        'VAV air-cooled chiller with PFP boxes',
+        'VAV air-cooled chiller with gas coil reheat',
+        'VAV air-cooled chiller with no reheat with baseboard electric',
+        'VAV air-cooled chiller with no reheat with gas unit heaters',
+        'VAV air-cooled chiller with no reheat with zone heat pump',
+        'VAV district chilled water with gas boiler reheat',
+        'VAV district chilled water with central air source heat pump reheat',
+        'VAV district chilled water with district hot water reheat',
+        'VAV district chilled water with PFP boxes',
+        'VAV district chilled water with gas coil reheat',
+        'VAV district chilled water with no reheat with baseboard electric',
+        'VAV district chilled water with no reheat with gas unit heaters',
+        'VAV district chilled water with no reheat with zone heat pump'
+    )

--- a/honeybee_energy/hvac/doas/__init__.py
+++ b/honeybee_energy/hvac/doas/__init__.py
@@ -1,0 +1,28 @@
+"""Template Dedicated Outdoor Air System (DOAS) HVAC definitions.
+
+DOAS systems separate minimum ventilation supply from the satisfaction of heating
++ cooling demand. Ventilation air tends to be supplied at neutral temperatures
+(close to room air temperature) and heating / cooling loads are met with additional
+pieces of zone equipment (eg. Fan Coil Units (FCUs)).
+
+Because DOAS systems only have to cool down and re-heat the minimum ventilation air,
+they tend to use less energy than all-air systems. They also tend to use less energy
+to distribute heating + cooling by puping around hot/cold water or refrigerant
+instead of blowing hot/cold air. However, they do not provide as good of control
+over humidity and so they may not be appropriate for rooms with high latent loads
+like auditoriums, kitchens, laundromats, etc.
+
+Properties:
+    * HVAC_TYPES_DICT: A dictionary containing pointers to the classes of each
+        HVAC system. The keys of this dictionary are the names of the HVAC
+        classes (eg. 'FCU').
+    * EQUIPMENT_TYPES_DICT: A dictionary containing pointers to the classes of
+        the HVAC systems. The keys of this dictionary are the names of the HVAC
+        systems as they appear in the OpenStudio standards gem and include the
+        specific equipment in the system (eg. 'DOAS with fan coil chiller with boiler').
+"""
+from ._base import _DOASEnumeration
+
+_doas_types = _DOASEnumeration(import_modules=True)
+HVAC_TYPES_DICT = _doas_types.types_dict
+EQUIPMENT_TYPES_DICT = _doas_types.equipment_types_dict

--- a/honeybee_energy/hvac/doas/_base.py
+++ b/honeybee_energy/hvac/doas/_base.py
@@ -1,0 +1,219 @@
+# coding=utf-8
+"""Base class for all HVAC systems with DOAS ventilation."""
+from __future__ import division
+
+from .._template import _TemplateSystem, _EnumerationBase
+
+from honeybee._lockable import lockable
+from honeybee.typing import float_in_range
+from honeybee.altnumber import autosize
+
+import os
+
+
+@lockable
+class _DOASBase(_TemplateSystem):
+    """Base class for all HVAC systems with DOAS ventilation.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment.
+            For example, 'DOAS with fan coil chiller with boiler'.
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: autosize).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: autosize).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ('_sensible_heat_recovery', '_latent_heat_recovery')
+
+    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None,
+                 sensible_heat_recovery=autosize, latent_heat_recovery=autosize):
+        """Initialize HVACSystem."""
+        # initialize base HVAC system properties
+        _TemplateSystem.__init__(self, identifier, vintage, equipment_type)
+
+        # set the main features of the HVAC system
+        self.sensible_heat_recovery = sensible_heat_recovery
+        self.latent_heat_recovery = latent_heat_recovery
+
+    @property
+    def sensible_heat_recovery(self):
+        """Get or set a number for the effectiveness of sensible heat recovery.
+
+        If None or autosize, it will be whatever is recommended for the given vintage.
+        """
+        return self._sensible_heat_recovery
+
+    @sensible_heat_recovery.setter
+    def sensible_heat_recovery(self, value):
+        if value == autosize or value is None:
+            self._sensible_heat_recovery = autosize
+        else:
+            self._sensible_heat_recovery = \
+                float_in_range(value, 0.0, 1.0, 'hvac sensible heat recovery')
+
+    @property
+    def latent_heat_recovery(self):
+        """Get or set a number for the effectiveness of latent heat recovery.
+
+        If None or autosize, it will be whatever is recommended for the given vintage.
+        """
+        return self._latent_heat_recovery
+
+    @latent_heat_recovery.setter
+    def latent_heat_recovery(self, value):
+        if value == autosize or value is None:
+            self._latent_heat_recovery = autosize
+        else:
+            self._latent_heat_recovery = \
+                float_in_range(value, 0.0, 1.0, 'hvac latent heat recovery')
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create a HVAC object from a dictionary.
+
+        Args:
+            data: A DOAS dictionary in following the format below.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": "",  # text for the HVAC equipment type
+            "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
+            "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
+            }
+        """
+        assert data['type'] == cls.__name__, \
+            'Expected {} dictionary. Got {}.'.format(cls.__name__, data['type'])
+
+        # extract the key features and properties of the HVAC
+        sensible = data['sensible_heat_recovery'] if \
+            'sensible_heat_recovery' in data else None
+        sensible = sensible if sensible != autosize.to_dict() else autosize
+        latent = data['latent_heat_recovery'] if \
+            'latent_heat_recovery' in data else None
+        latent = latent if latent != autosize.to_dict() else autosize
+
+        new_obj = cls(data['identifier'], data['vintage'], data['equipment_type'],
+                      sensible, latent)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_obj.display_name = data['display_name']
+        return new_obj
+
+    @classmethod
+    def from_dict_abridged(cls, data, schedule_dict):
+        """Create a HVAC object from an abridged dictionary.
+
+        Args:
+            data: A DOAS abridged dictionary in following the format below.
+            schedule_dict: A dictionary with schedule identifiers as keys and honeybee
+                schedule objects as values (either ScheduleRuleset or
+                ScheduleFixedInterval). These will be used to assign the schedules
+                to the Setpoint object.
+
+        .. code-block:: python
+
+            {
+            "type": "",  # text for the class name of the HVAC
+            "identifier": "Classroom1_System",  # identifier for the HVAC
+            "display_name": "Standard System",  # name for the HVAC
+            "vintage": "90.1-2013",  # text for the vintage of the template
+            "equipment_type": "",  # text for the HVAC equipment type
+            "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
+            "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
+            }
+        """
+        # this is the same as the from_dict method for as long as there are not schedules
+        return cls.from_dict(data)
+
+    def to_dict(self, abridged=False):
+        """All air system dictionary representation.
+
+        Args:
+            abridged: Boolean to note whether the full dictionary describing the
+                object should be returned (False) or just an abridged version (True).
+                This input currently has no effect but may eventually have one if
+                schedule-type properties are exposed on this template.
+        """
+        base = {'type': self.__class__.__name__}
+        base['identifier'] = self.identifier
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        base['vintage'] = self.vintage
+        base['equipment_type'] = self.equipment_type
+        if self.sensible_heat_recovery != autosize:
+            base['sensible_heat_recovery'] = self.sensible_heat_recovery
+        if self.latent_heat_recovery != autosize:
+            base['latent_heat_recovery'] = self.latent_heat_recovery
+        return base
+
+    def __copy__(self):
+        new_obj = self.__class__(
+            self._identifier, self._vintage, self._equipment_type,
+            self._sensible_heat_recovery, self._latent_heat_recovery)
+        new_obj._display_name = self._display_name
+        return new_obj
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self._identifier, self._vintage, self._equipment_type,
+                self._sensible_heat_recovery, self._latent_heat_recovery)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, self.__class__) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __repr__(self):
+        return '{}: {}\n type: {}\n vintage: {}\n sensible recovery:' \
+            ' {} \n latent recovery: {}'.format(
+                self.__class__.__name__, self.identifier, self.equipment_type,
+                self.vintage, self.sensible_heat_recovery, self.latent_heat_recovery)
+
+
+class _DOASEnumeration(_EnumerationBase):
+    """Enumerates the systems that inherit from _DOASBase."""
+
+    def __init__(self, import_modules=True):
+        if import_modules:
+            self._import_modules(os.path.dirname(__file__), 'honeybee_energy.hvac.doas')
+
+        self._HVAC_TYPES = {}
+        self._EQUIPMENT_TYPES = {}
+        for clss in _DOASBase.__subclasses__():
+            self._HVAC_TYPES[clss.__name__] = clss
+            for equip_type in clss.EQUIPMENT_TYPES:
+                self._EQUIPMENT_TYPES[equip_type] = clss

--- a/honeybee_energy/hvac/doas/fcu.py
+++ b/honeybee_energy/hvac/doas/fcu.py
@@ -1,0 +1,92 @@
+# coding=utf-8
+"""Fan Coil Unit (FCU) with DOAS HVAC system."""
+from __future__ import division
+
+from ._base import _DOASBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class FCUwithDOAS(_DOASBase):
+    """Fan Coil Unit (FCU) with DOAS HVAC system.
+
+    This template is also relatively close to active chilled beams in performance,
+    though the energy use of the fans in the units can be zeroed out for this case.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * DOAS with fan coil chiller with boiler
+            * DOAS with fan coil chiller with central air source heat pump
+            * DOAS with fan coil chiller with district hot water
+            * DOAS with fan coil chiller with baseboard electric
+            * DOAS with fan coil chiller with gas unit heaters
+            * DOAS with fan coil chiller with no heat
+            * DOAS with fan coil air-cooled chiller with boiler
+            * DOAS with fan coil air-cooled chiller with central air source heat pump
+            * DOAS with fan coil air-cooled chiller with district hot water
+            * DOAS with fan coil air-cooled chiller with baseboard electric
+            * DOAS with fan coil air-cooled chiller with gas unit heaters
+            * DOAS with fan coil air-cooled chiller with no heat
+            * DOAS with fan coil district chilled water with boiler
+            * DOAS with fan coil district chilled water with central air source heat pump
+            * DOAS with fan coil district chilled water with district hot water
+            * DOAS with fan coil district chilled water with baseboard electric
+            * DOAS with fan coil district chilled water with gas unit heaters
+            * DOAS with fan coil district chilled water with no heat
+
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'DOAS with fan coil chiller with boiler',
+        'DOAS with fan coil chiller with central air source heat pump',
+        'DOAS with fan coil chiller with district hot water',
+        'DOAS with fan coil chiller with baseboard electric',
+        'DOAS with fan coil chiller with gas unit heaters',
+        'DOAS with fan coil chiller with no heat',
+        'DOAS with fan coil air-cooled chiller with boiler',
+        'DOAS with fan coil air-cooled chiller with central air source heat pump',
+        'DOAS with fan coil air-cooled chiller with district hot water',
+        'DOAS with fan coil air-cooled chiller with baseboard electric',
+        'DOAS with fan coil air-cooled chiller with gas unit heaters',
+        'DOAS with fan coil air-cooled chiller with no heat',
+        'DOAS with fan coil district chilled water with boiler',
+        'DOAS with fan coil district chilled water with central air source heat pump',
+        'DOAS with fan coil district chilled water with district hot water',
+        'DOAS with fan coil district chilled water with baseboard electric',
+        'DOAS with fan coil district chilled water with gas unit heaters',
+        'DOAS with fan coil district chilled water with no heat'
+    )

--- a/honeybee_energy/hvac/doas/vrf.py
+++ b/honeybee_energy/hvac/doas/vrf.py
@@ -1,0 +1,53 @@
+# coding=utf-8
+"""Variable Refrigerant Flow (VRF) with DOAS HVAC system."""
+from __future__ import division
+
+from ._base import _DOASBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class VRFwithDOAS(_DOASBase):
+    """Variable Refrigerant Flow (VRF) with DOAS HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * DOAS with VRF
+
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = ('DOAS with VRF',)

--- a/honeybee_energy/hvac/doas/wshp.py
+++ b/honeybee_energy/hvac/doas/wshp.py
@@ -1,0 +1,61 @@
+# coding=utf-8
+"""Water Source Heat Pump (WSHP) with DOAS HVAC system."""
+from __future__ import division
+
+from ._base import _DOASBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class WSHPwithDOAS(_DOASBase):
+    """Water Source Heat Pump (WSHP) with DOAS HVAC system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * DOAS with water source heat pumps fluid cooler with boiler
+            * DOAS with water source heat pumps cooling tower with boiler
+            * DOAS with water source heat pumps with ground source heat pump
+            * DOAS with water source heat pumps district chilled water with district hot water
+
+        sensible_heat_recovery: A number between 0 and 1 for the effectiveness
+            of sensible heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+        latent_heat_recovery: A number between 0 and 1 for the effectiveness
+            of latent heat recovery within the system. If None, it will be
+            whatever is recommended for the given vintage (Default: None).
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'DOAS with water source heat pumps fluid cooler with boiler',
+        'DOAS with water source heat pumps cooling tower with boiler',
+        'DOAS with water source heat pumps with ground source heat pump',
+        'DOAS with water source heat pumps district chilled water with district hot water'
+    )

--- a/honeybee_energy/hvac/heatcool/__init__.py
+++ b/honeybee_energy/hvac/heatcool/__init__.py
@@ -1,0 +1,23 @@
+"""Template HVAC definitions that only supply heating + cooling (no ventilation).
+
+These HVAC systems are only designed to satisfy heating + cooling demand and they
+cannot meet any minimum ventilation requirements.
+
+As such, these systems tend to be used more in residential or storage settings
+where meeting minimum ventilation requirements is not be required or the density
+of occupancy is so low that infiltration is enough to meet fresh air demand.
+
+Properties:
+    * HVAC_TYPES_DICT: A dictionary containing pointers to the classes of each
+        HVAC system. The keys of this dictionary are the names of the HVAC
+        classes (eg. 'Baseboard').
+    * EQUIPMENT_TYPES_DICT: A dictionary containing pointers to the classes of
+        the HVAC systems. The keys of this dictionary are the names of the HVAC
+        systems as they appear in the OpenStudio standards gem and include the
+        specific equipment in the system (eg. 'Baseboard gas boiler').
+"""
+from ._base import _HeatCoolEnumeration
+
+_heat_cool_types = _HeatCoolEnumeration(import_modules=True)
+HVAC_TYPES_DICT = _heat_cool_types.types_dict
+EQUIPMENT_TYPES_DICT = _heat_cool_types.equipment_types_dict

--- a/honeybee_energy/hvac/heatcool/_base.py
+++ b/honeybee_energy/hvac/heatcool/_base.py
@@ -1,0 +1,60 @@
+# coding=utf-8
+"""Base class for all heating/cooling systems without any ventilation."""
+from __future__ import division
+
+from .._template import _TemplateSystem, _EnumerationBase
+
+from honeybee._lockable import lockable
+
+import os
+
+
+@lockable
+class _HeatCoolBase(_TemplateSystem):
+    """Base class for all heating/cooling systems without any ventilation.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment.
+            For example, 'Baseboard gas boiler'.
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * sensible_heat_recovery
+        * latent_heat_recovery
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+
+class _HeatCoolEnumeration(_EnumerationBase):
+    """Enumerates the systems that inherit from _HeatCoolBase."""
+
+    def __init__(self, import_modules=True):
+        if import_modules:
+            self._import_modules(
+                os.path.dirname(__file__), 'honeybee_energy.hvac.heatcool')
+
+        self._HVAC_TYPES = {}
+        self._EQUIPMENT_TYPES = {}
+        for clss in _HeatCoolBase.__subclasses__():
+            self._HVAC_TYPES[clss.__name__] = clss
+            for equip_type in clss.EQUIPMENT_TYPES:
+                self._EQUIPMENT_TYPES[equip_type] = clss

--- a/honeybee_energy/hvac/heatcool/baseboard.py
+++ b/honeybee_energy/hvac/heatcool/baseboard.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+"""Baseboard heating system. Intended for spaces only requiring heating."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class Baseboard(_HeatCoolBase):
+    """Baseboard heating system. Intended for spaces only requiring heating.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Baseboard electric
+            * Baseboard gas boiler
+            * Baseboard central air source heat pump
+            * Baseboard district hot water
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Baseboard electric',
+        'Baseboard gas boiler',
+        'Baseboard central air source heat pump',
+        'Baseboard district hot water'
+    )

--- a/honeybee_energy/hvac/heatcool/evapcool.py
+++ b/honeybee_energy/hvac/heatcool/evapcool.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+"""Direct evaporative cooling systems (with optional heating)."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class EvaporativeCooler(_HeatCoolBase):
+    """Direct evaporative cooling systems (with optional heating).
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Direct evap coolers with baseboard electric
+            * Direct evap coolers with baseboard gas boiler
+            * Direct evap coolers with baseboard central air source heat pump
+            * Direct evap coolers with baseboard district hot water
+            * Direct evap coolers with forced air furnace
+            * Direct evap coolers with gas unit heaters
+            * Direct evap coolers with no heat
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Direct evap coolers with baseboard electric',
+        'Direct evap coolers with baseboard gas boiler',
+        'Direct evap coolers with baseboard central air source heat pump',
+        'Direct evap coolers with baseboard district hot water',
+        'Direct evap coolers with forced air furnace',
+        'Direct evap coolers with gas unit heaters',
+        'Direct evap coolers with no heat'
+    )

--- a/honeybee_energy/hvac/heatcool/fcu.py
+++ b/honeybee_energy/hvac/heatcool/fcu.py
@@ -1,0 +1,80 @@
+# coding=utf-8
+"""Fan Coil Unit (FCU) heating/cooling system (with no ventilation)."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class FCU(_HeatCoolBase):
+    """Fan Coil Unit (FCU) heating/cooling system (with no ventilation).
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Fan coil chiller with boiler
+            * Fan coil chiller with central air source heat pump
+            * Fan coil chiller with district hot water
+            * Fan coil chiller with baseboard electric
+            * Fan coil chiller with gas unit heaters
+            * Fan coil chiller with no heat
+            * Fan coil air-cooled chiller with boiler
+            * Fan coil air-cooled chiller with central air source heat pump
+            * Fan coil air-cooled chiller with district hot water
+            * Fan coil air-cooled chiller with baseboard electric
+            * Fan coil air-cooled chiller with gas unit heaters
+            * Fan coil air-cooled chiller with no heat
+            * Fan coil district chilled water with boiler
+            * Fan coil district chilled water with central air source heat pump
+            * Fan coil district chilled water with district hot water
+            * Fan coil district chilled water with baseboard electric
+            * Fan coil district chilled water with gas unit heaters
+            * Fan coil district chilled water with no heat
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Fan coil chiller with boiler',
+        'Fan coil chiller with central air source heat pump',
+        'Fan coil chiller with district hot water',
+        'Fan coil chiller with baseboard electric',
+        'Fan coil chiller with gas unit heaters',
+        'Fan coil chiller with no heat',
+        'Fan coil air-cooled chiller with boiler',
+        'Fan coil air-cooled chiller with central air source heat pump',
+        'Fan coil air-cooled chiller with district hot water',
+        'Fan coil air-cooled chiller with baseboard electric',
+        'Fan coil air-cooled chiller with gas unit heaters',
+        'Fan coil air-cooled chiller with no heat',
+        'Fan coil district chilled water with boiler',
+        'Fan coil district chilled water with central air source heat pump',
+        'Fan coil district chilled water with district hot water',
+        'Fan coil district chilled water with baseboard electric',
+        'Fan coil district chilled water with gas unit heaters',
+        'Fan coil district chilled water with no heat'
+    )

--- a/honeybee_energy/hvac/heatcool/gasunit.py
+++ b/honeybee_energy/hvac/heatcool/gasunit.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+"""Gas unit heating system. Intended for spaces only requiring heating."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class GasUnitHeater(_HeatCoolBase):
+    """Gas unit heating system. Intended for spaces only requiring heating.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Gas unit heaters
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = ('Gas unit heaters',)

--- a/honeybee_energy/hvac/heatcool/residential.py
+++ b/honeybee_energy/hvac/heatcool/residential.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+"""Residential Air Conditioning, Heat Pump or Furnace system."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class Residential(_HeatCoolBase):
+    """Residential Air Conditioning, Heat Pump or Furnace system.
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Residential AC with baseboard electric
+            * Residential AC with baseboard gas boiler
+            * Residential AC with baseboard central air source heat pump
+            * Residential AC with baseboard district hot water
+            * Residential AC with residential forced air furnace
+            * Residential AC with no heat
+            * Residential heat pump
+            * Residential heat pump with no cooling
+            * Residential forced air furnace
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Residential AC with baseboard electric',
+        'Residential AC with baseboard gas boiler',
+        'Residential AC with baseboard central air source heat pump',
+        'Residential AC with baseboard district hot water',
+        'Residential AC with residential forced air furnace',
+        'Residential AC with no heat',
+        'Residential heat pump',
+        'Residential heat pump with no cooling',
+        'Residential forced air furnace'
+    )

--- a/honeybee_energy/hvac/heatcool/vrf.py
+++ b/honeybee_energy/hvac/heatcool/vrf.py
@@ -1,0 +1,44 @@
+# coding=utf-8
+"""Variable Refrigerant Flow (VRF) heating/cooling system (with no ventilation)."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class VRF(_HeatCoolBase):
+    """Variable Refrigerant Flow (VRF) heating/cooling system (with no ventilation).
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * VRF
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = ('VRF',)

--- a/honeybee_energy/hvac/heatcool/windowac.py
+++ b/honeybee_energy/hvac/heatcool/windowac.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+"""Window Air Conditioning cooling system (with optional heating)."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class WindowAC(_HeatCoolBase):
+    """Window Air Conditioning cooling system (with optional heating).
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Window AC with baseboard electric
+            * Window AC with baseboard gas boiler
+            * Window AC with baseboard central air source heat pump
+            * Window AC with baseboard district hot water
+            * Window AC with forced air furnace
+            * Window AC with unit heaters
+            * Window AC with no heat
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Window AC with baseboard electric',
+        'Window AC with baseboard gas boiler',
+        'Window AC with baseboard central air source heat pump',
+        'Window AC with baseboard district hot water',
+        'Window AC with forced air furnace',
+        'Window AC with unit heaters',
+        'Window AC with no heat'
+    )

--- a/honeybee_energy/hvac/heatcool/wshp.py
+++ b/honeybee_energy/hvac/heatcool/wshp.py
@@ -1,0 +1,52 @@
+# coding=utf-8
+"""Water Source Heat Pump (WSHP) heating/cooling system (with no ventilation)."""
+from __future__ import division
+
+from ._base import _HeatCoolBase
+
+from honeybee._lockable import lockable
+
+
+@lockable
+class WSHP(_HeatCoolBase):
+    """Water Source Heat Pump (WSHP) heating/cooling system (with no ventilation).
+
+    Args:
+        identifier: Text string for system identifier. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        vintage: Text for the vintage of the template system. This will be used
+            to set efficiencies for various pieces of equipment within the system.
+            Choose from the following.
+
+            * DOE Ref Pre-1980
+            * DOE Ref 1980-2004
+            * 90.1-2004
+            * 90.1-2007
+            * 90.1-2010
+            * 90.1-2013
+
+        equipment_type: Text for the specific type of the system and equipment. (Default:
+            the first option below) Choose from.
+
+            * Water source heat pumps fluid cooler with boiler
+            * Water source heat pumps cooling tower with boiler
+            * Water source heat pumps with ground source heat pump
+            * Water source heat pumps district chilled water with district hot water
+
+    Properties:
+        * identifier
+        * display_name
+        * vintage
+        * equipment_type
+        * is_single_room
+        * schedules
+    """
+    __slots__ = ()
+
+    EQUIPMENT_TYPES = (
+        'Water source heat pumps fluid cooler with boiler',
+        'Water source heat pumps cooling tower with boiler',
+        'Water source heat pumps with ground source heat pump',
+        'Water source heat pumps district chilled water with district hot water'
+    )

--- a/honeybee_energy/hvac/idealair.py
+++ b/honeybee_energy/hvac/idealair.py
@@ -15,10 +15,6 @@ from honeybee.altnumber import autosize, no_limit
 class IdealAirSystem(_HVACSystem):
     """Simple ideal air system object used to condition zones.
 
-    Note that this is the only HVAC system supported by honeybee_energy and, to
-    access more advanced HVAC systems, a honeybee_energy extension should be
-    installed.
-
     Args:
         identifier: Text string for ideal air system identifier. Must be < 100 characters
             and not contain any EnergyPlus special characters. This will be used to
@@ -75,6 +71,8 @@ class IdealAirSystem(_HVACSystem):
         * cooling_limit
         * heating_availability
         * cooling_availability
+        * is_single_room
+        * schedules
     """
     __slots__ = ('_economizer_type', '_demand_controlled_ventilation',
                  '_sensible_heat_recovery', '_latent_heat_recovery',
@@ -553,14 +551,6 @@ class IdealAirSystem(_HVACSystem):
         if self._display_name is not None:
             base['display_name'] = self.display_name
         return base
-
-    def duplicate(self):
-        """Get a copy of this object."""
-        return self.__copy__()
-
-    def ToString(self):
-        """Overwrite .NET ToString."""
-        return self.__repr__()
 
     def _air_temperature_check(self):
         """Check that heating_air_temperature is greater than cooling_air_temperature."""

--- a/tests/hvac_allair_test.py
+++ b/tests/hvac_allair_test.py
@@ -1,0 +1,336 @@
+# coding=utf-8
+from honeybee_energy.hvac.allair.vav import VAV
+from honeybee_energy.hvac.allair.pvav import PVAV
+from honeybee_energy.hvac.allair.psz import PSZ
+from honeybee_energy.hvac.allair.ptac import PTAC
+from honeybee_energy.hvac.allair.furnace import ForcedAirFurnace
+
+from honeybee.model import Model
+from honeybee.room import Room
+from honeybee.altnumber import autosize
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+
+import pytest
+
+
+def test_vav_init():
+    """Test the initialization of VAV and basic properties."""
+    hvac_sys = VAV('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'VAV chiller with gas boiler reheat'
+    assert hvac_sys.economizer_type == 'Inferred'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'VAV district chilled water with district hot water reheat'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'VAV district chilled water with district hot water reheat'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_vav_equality():
+    """Test the equality of VAV objects."""
+    hvac_sys = VAV('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = VAV(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_vav_multi_room():
+    """Test that VAV systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = VAV('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_vav_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = VAV('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'VAV district chilled water with district hot water reheat'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = VAV.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_pvav_init():
+    """Test the initialization of PVAV and basic properties."""
+    hvac_sys = PVAV('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'PVAV with gas boiler reheat'
+    assert hvac_sys.economizer_type == 'Inferred'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PVAV with district hot water reheat'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'PVAV with district hot water reheat'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_pvav_equality():
+    """Test the equality of PVAV objects."""
+    hvac_sys = PVAV('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = PVAV(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_pvav_multi_room():
+    """Test that PVAV systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = PVAV('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_pvav_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = PVAV('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PVAV with district hot water reheat'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = PVAV.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_psz_init():
+    """Test the initialization of PSZ and basic properties."""
+    hvac_sys = PSZ('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'PSZ-AC with baseboard electric'
+    assert hvac_sys.economizer_type == 'Inferred'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PSZ-AC district chilled water with baseboard district hot water'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'PSZ-AC district chilled water with baseboard district hot water'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_psz_equality():
+    """Test the equality of PSZ objects."""
+    hvac_sys = PSZ('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = PSZ(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_psz_multi_room():
+    """Test that PSZ systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = PSZ('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_psz_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = PSZ('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PSZ-AC district chilled water with baseboard district hot water'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = PSZ.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_ptac_init():
+    """Test the initialization of PTAC and basic properties."""
+    hvac_sys = PTAC('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'PTAC with baseboard electric'
+    assert hvac_sys.economizer_type == 'Inferred'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PTAC with district hot water'
+    with pytest.raises(AssertionError):
+        hvac_sys.economizer_type = 'DifferentialDryBulb'
+    with pytest.raises(AssertionError):
+        hvac_sys.sensible_heat_recovery = 0.8
+    with pytest.raises(AssertionError):
+        hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'PTAC with district hot water'
+
+
+def test_ptac_equality():
+    """Test the equality of PTAC objects."""
+    hvac_sys = PTAC('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = PTAC(
+        'Test System', equipment_type='PTAC with district hot water')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.equipment_type = 'PTAC with gas coil'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_ptac_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = PTAC('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'PTAC with district hot water'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = PTAC.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_furnace_init():
+    """Test the initialization of ForcedAirFurnace and basic properties."""
+    hvac_sys = ForcedAirFurnace('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Forced air furnace'
+    assert hvac_sys.economizer_type == 'Inferred'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    with pytest.raises(ValueError):
+        hvac_sys.equipment_type = 'Air furnace'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_furnace_equality():
+    """Test the equality of ForcedAirFurnace objects."""
+    hvac_sys = ForcedAirFurnace('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = ForcedAirFurnace(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_furnace_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = ForcedAirFurnace('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = ForcedAirFurnace.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()

--- a/tests/hvac_doas_test.py
+++ b/tests/hvac_doas_test.py
@@ -1,0 +1,180 @@
+# coding=utf-8
+from honeybee_energy.hvac.doas.fcu import FCUwithDOAS
+from honeybee_energy.hvac.doas.vrf import VRFwithDOAS
+from honeybee_energy.hvac.doas.wshp import WSHPwithDOAS
+
+from honeybee.model import Model
+from honeybee.room import Room
+from honeybee.altnumber import autosize
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+
+import pytest
+
+
+def test_fcu_with_doas_init():
+    """Test the initialization of FCUwithDOAS and basic properties."""
+    hvac_sys = FCUwithDOAS('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'DOAS with fan coil chiller with boiler'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'DOAS with fan coil district chilled water with district hot water'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'DOAS with fan coil district chilled water with district hot water'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_fcu_with_doas_equality():
+    """Test the equality of FCUwithDOAS objects."""
+    hvac_sys = FCUwithDOAS('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = FCUwithDOAS(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_fcu_with_doas_multi_room():
+    """Test that FCUwithDOAS systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = FCUwithDOAS('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_fcu_with_doas_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = FCUwithDOAS('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'DOAS with fan coil district chilled water with district hot water'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = FCUwithDOAS.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_vrf_with_doas_init():
+    """Test the initialization of VRFwithDOAS and basic properties."""
+    hvac_sys = VRFwithDOAS('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'DOAS with VRF'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    with pytest.raises(ValueError):
+        hvac_sys.equipment_type = 'DOAS with ground sourced VRF'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_vrf_with_doas_equality():
+    """Test the equality of VRFwithDOAS objects."""
+    hvac_sys = VRFwithDOAS('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = VRFwithDOAS(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_vrf_with_doas_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = VRFwithDOAS('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = VRFwithDOAS.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_wshp_with_doas_init():
+    """Test the initialization of WSHPwithDOAS and basic properties."""
+    hvac_sys = WSHPwithDOAS('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'DOAS with water source heat pumps fluid cooler with boiler'
+    assert hvac_sys.sensible_heat_recovery == autosize
+    assert hvac_sys.latent_heat_recovery == autosize
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'DOAS with water source heat pumps with ground source heat pump'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'DOAS with water source heat pumps with ground source heat pump'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+
+
+def test_wshp_with_doas_equality():
+    """Test the equality of WSHPwithDOAS objects."""
+    hvac_sys = WSHPwithDOAS('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = WSHPwithDOAS(
+        'Test System', sensible_heat_recovery=0.75, latent_heat_recovery=0.6)
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.sensible_heat_recovery = 0.6
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_wshp_with_doas_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = WSHPwithDOAS('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'DOAS with water source heat pumps with ground source heat pump'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = WSHPwithDOAS.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()

--- a/tests/hvac_heatcool_test.py
+++ b/tests/hvac_heatcool_test.py
@@ -1,0 +1,445 @@
+# coding=utf-8
+from honeybee_energy.hvac.heatcool.fcu import FCU
+from honeybee_energy.hvac.heatcool.vrf import VRF
+from honeybee_energy.hvac.heatcool.wshp import WSHP
+from honeybee_energy.hvac.heatcool.baseboard import Baseboard
+from honeybee_energy.hvac.heatcool.evapcool import EvaporativeCooler
+from honeybee_energy.hvac.heatcool.gasunit import GasUnitHeater
+from honeybee_energy.hvac.heatcool.residential import Residential
+from honeybee_energy.hvac.heatcool.windowac import WindowAC
+
+from honeybee.model import Model
+from honeybee.room import Room
+
+from ladybug_geometry.geometry3d.pointvector import Point3D
+
+import pytest
+
+
+def test_fcu_init():
+    """Test the initialization of FCU and basic properties."""
+    hvac_sys = FCU('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Fan coil chiller with boiler'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Fan coil district chilled water with district hot water'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Fan coil district chilled water with district hot water'
+
+
+def test_fcu_equality():
+    """Test the equality of FCU objects."""
+    hvac_sys = FCU('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = FCU(
+        'Test System',
+        equipment_type='Fan coil air-cooled chiller with central air source heat pump')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_fcu_multi_room():
+    """Test that FCU systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = FCU('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_fcu_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = FCU('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Fan coil district chilled water with district hot water'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = FCU.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_vrf_init():
+    """Test the initialization of VRF and basic properties."""
+    hvac_sys = VRF('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'VRF'
+
+    hvac_sys.vintage = '90.1-2010'
+    with pytest.raises(ValueError):
+        hvac_sys.equipment_type = 'Ground sourced VRF'
+    assert hvac_sys.vintage == '90.1-2010'
+
+
+def test_vrf_equality():
+    """Test the equality of VRF objects."""
+    hvac_sys = VRF('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = VRF('Test System', vintage='90.1-2010')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_vrf_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = VRF('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = VRF.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_wshp_init():
+    """Test the initialization of WSHP and basic properties."""
+    hvac_sys = WSHP('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Water source heat pumps fluid cooler with boiler'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Water source heat pumps with ground source heat pump'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Water source heat pumps with ground source heat pump'
+
+
+def test_wshp_equality():
+    """Test the equality of WSHP objects."""
+    hvac_sys = WSHP('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = WSHP(
+        'Test System',
+        equipment_type='Water source heat pumps with ground source heat pump')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_wshp_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = WSHP('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Water source heat pumps with ground source heat pump'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = WSHP.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_baseboard_init():
+    """Test the initialization of Baseboard and basic properties."""
+    hvac_sys = Baseboard('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Baseboard electric'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Baseboard district hot water'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Baseboard district hot water'
+
+
+def test_baseboard_equality():
+    """Test the equality of Baseboard objects."""
+    hvac_sys = Baseboard('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = Baseboard(
+        'Test System', equipment_type='Baseboard district hot water')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_baseboard_multi_room():
+    """Test that Baseboard systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = Baseboard('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_baseboard_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = Baseboard('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Baseboard district hot water'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = Baseboard.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_evap_cool_init():
+    """Test the initialization of EvaporativeCooler and basic properties."""
+    hvac_sys = EvaporativeCooler('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Direct evap coolers with baseboard electric'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Direct evap coolers with baseboard district hot water'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Direct evap coolers with baseboard district hot water'
+
+
+def test_evap_cool_equality():
+    """Test the equality of EvaporativeCooler objects."""
+    hvac_sys = EvaporativeCooler('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = EvaporativeCooler(
+        'Test System',
+        equipment_type='Direct evap coolers with baseboard district hot water')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_evap_cool_multi_room():
+    """Test that EvaporativeCooler systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = EvaporativeCooler('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_evap_cool_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = EvaporativeCooler('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Direct evap coolers with baseboard district hot water'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = EvaporativeCooler.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_gasunit_init():
+    """Test the initialization of GasUnitHeater and basic properties."""
+    hvac_sys = GasUnitHeater('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Gas unit heaters'
+
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys.vintage == '90.1-2010'
+
+
+def test_gasunit_equality():
+    """Test the equality of GasUnitHeater objects."""
+    hvac_sys = GasUnitHeater('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = GasUnitHeater('Test System', vintage='90.1-2010')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys_dup.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_gasunit_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = GasUnitHeater('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = GasUnitHeater.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_residential_init():
+    """Test the initialization of Residential and basic properties."""
+    hvac_sys = Residential('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Residential AC with baseboard electric'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Residential forced air furnace'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Residential forced air furnace'
+
+
+def test_residential_equality():
+    """Test the equality of Residential objects."""
+    hvac_sys = Residential('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = Residential(
+        'Test System', equipment_type='Residential forced air furnace')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_residential_multi_room():
+    """Test that Residential systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = Residential('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_residential_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = Residential('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Residential forced air furnace'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = Residential.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_window_ac_init():
+    """Test the initialization of WindowAC and basic properties."""
+    hvac_sys = WindowAC('Test System')
+    str(hvac_sys)  # test the string representation
+
+    assert hvac_sys.identifier == 'Test System'
+    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.equipment_type == 'Window AC with baseboard electric'
+
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Window AC with baseboard central air source heat pump'
+    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.equipment_type == 'Window AC with baseboard central air source heat pump'
+
+
+def test_window_ac_equality():
+    """Test the equality of WindowAC objects."""
+    hvac_sys = WindowAC('Test System')
+    hvac_sys_dup = hvac_sys.duplicate()
+    hvac_sys_alt = WindowAC(
+        'Test System',
+        equipment_type='Window AC with baseboard central air source heat pump')
+
+    assert hvac_sys is hvac_sys
+    assert hvac_sys is not hvac_sys_dup
+    assert hvac_sys == hvac_sys_dup
+    hvac_sys.vintage = '90.1-2010'
+    assert hvac_sys != hvac_sys_dup
+    assert hvac_sys != hvac_sys_alt
+
+
+def test_window_ac_multi_room():
+    """Test that WindowAC systems can be assigned to multiple Rooms."""
+    first_floor = Room.from_box('First_Floor', 10, 10, 3, origin=Point3D(0, 0, 0))
+    second_floor = Room.from_box('Second_Floor', 10, 10, 3, origin=Point3D(0, 0, 3))
+    hvac_sys = WindowAC('Test System')
+
+    first_floor.properties.energy.hvac = hvac_sys
+    second_floor.properties.energy.hvac = hvac_sys
+
+    model = Model('Test_Bldg', [first_floor, second_floor])
+    hvacs = model.properties.energy.hvacs
+    assert len(hvacs) == 1
+    assert hvacs[0] == hvac_sys
+
+    model_dict = model.to_dict()
+    assert len(model_dict['properties']['energy']['hvacs']) == 1
+    assert model_dict['rooms'][0]['properties']['energy']['hvac'] == hvac_sys.identifier
+
+
+def test_window_ac_dict_methods():
+    """Test the to/from dict methods."""
+    hvac_sys = WindowAC('High Efficiency HVAC System')
+    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.equipment_type = 'Window AC with baseboard central air source heat pump'
+
+    hvac_dict = hvac_sys.to_dict()
+    new_hvac_sys = WindowAC.from_dict(hvac_dict)
+    assert new_hvac_sys == hvac_sys
+    assert hvac_dict == new_hvac_sys.to_dict()

--- a/tests/hvac_idealair_test.py
+++ b/tests/hvac_idealair_test.py
@@ -6,7 +6,7 @@ from honeybee_energy.schedule.ruleset import ScheduleRuleset
 import honeybee_energy.lib.scheduletypelimits as schedule_types
 
 from honeybee.room import Room
-from honeybee.altnumber import autosize, no_limit
+from honeybee.altnumber import autosize
 
 from ladybug.dt import Time
 
@@ -118,7 +118,7 @@ def test_ideal_air_init_from_idf():
 def test_ideal_air_to_dict():
     """Test the to_dict method."""
     ideal_air = IdealAirSystem('Passive House HVAC System')
-    
+
     ideal_air.economizer_type = 'DifferentialEnthalpy'
     ideal_air.demand_controlled_ventilation = True
     ideal_air.sensible_heat_recovery = 0.75
@@ -135,7 +135,7 @@ def test_ideal_air_to_dict():
     ideal_air_dict = ideal_air.to_dict(abridged=True)
 
     assert ideal_air_dict['economizer_type'] == 'DifferentialEnthalpy'
-    assert ideal_air_dict['demand_controlled_ventilation'] == True
+    assert ideal_air_dict['demand_controlled_ventilation']
     assert ideal_air_dict['sensible_heat_recovery'] == 0.75
     assert ideal_air_dict['latent_heat_recovery'] == 0.6
     assert ideal_air_dict['heating_air_temperature'] == 40


### PR DESCRIPTION
This commit adds modules and classes for the ~120 HVAC templates that are available in the OpenStudio standards gem.

The classes don't do much computation but they serve the following purposes:

* Organizing/ classifying the 120 templates (grouping them into 16 classes)
* Providing documentation in the form of docstrings
* Handling serialization to dict
* Storing a few optional ECMs like heat recovery and economizers.

They way they are implemented it a bit like the Radiance modifiers in that most of the current functionality is handled by base classes from which everything inherits. But breaking down everything into 16 classes is useful as it means that we can extend the properties of ECMs that are available in the future.