### PR TITLE
perf(ventcool): Only write schedule when it's not default

### DIFF
--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -296,7 +296,7 @@ class RoomEnergyProperties(object):
         Args:
             vent_opening: A VentilationOpening object to be duplicated and assigned
                 to all of the operable apertures of the Room.
-        
+
         Returns:
             A list of Apertures for which ventilation opening properties were set.
             This can be used to perform additional operations on the apertures, such

--- a/honeybee_energy/ventcool/control.py
+++ b/honeybee_energy/ventcool/control.py
@@ -209,8 +209,9 @@ class VentilationControl(object):
         base['min_outdoor_temperature'] = self.min_outdoor_temperature
         base['max_outdoor_temperature'] = self.max_outdoor_temperature
         base['delta_temperature'] = self.delta_temperature
-        base['schedule'] = self.schedule.identifier if abridged \
-            else self.schedule.to_dict()
+        if self.schedule is not always_on:
+            base['schedule'] = self.schedule.identifier if abridged \
+                else self.schedule.to_dict()
         return base
 
     def duplicate(self):


### PR DESCRIPTION
This will help with applying window ventilation to dragonfly objects if no schedule is specified.