### PR TITLE
fix(output): Add energy use outputs for all the HVAC equipment

### DIFF
--- a/honeybee_energy/simulation/output.py
+++ b/honeybee_energy/simulation/output.py
@@ -241,8 +241,16 @@ output-table-summaryreports.html#outputtablesummaryreports)
                    'Zone VRF Air Terminal Heating Electric Energy',
                    'VRF Heat Pump Cooling Electric Energy',
                    'VRF Heat Pump Heating Electric Energy',
+                   'VRF Heat Pump Defrost Electric Energy',
+                   'VRF Heat Pump Crankcase Heater Electric Energy',
                    'Chiller Heater System Cooling Electric Energy',
-                   'Chiller Heater System Heating Electric Energy']
+                   'Chiller Heater System Heating Electric Energy',
+                   'District Cooling Chilled Water Energy',
+                   'District Heating Hot Water Energy',
+                   'Baseboard Electric Energy',
+                   'Evaporative Cooler Electric Energy',
+                   'Energy Management System Metered Output Variable 1']
+        # NOTE: The EMS output is needed to catch the electric energy of ASHP
         for outp in outputs:
             self._outputs.add(outp)
 


### PR DESCRIPTION
This commit ensures that simulations that request energy use results get the energy usage of ALL pieces of equipment contained within the various HVAC templates.