### PR TITLE
fix(ventcool): Set default discharge coefficient to 0.45 for deltaHnpl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN mkdir ladybug_tools/openstudio/ \
 
 
 # Add honeybee-openstudio-gem lib to ladybug_tools folder
-ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.3.0
+ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.5.3
 RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
     && curl -SL -o honeybee-openstudio-gem.tar.gz https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v$HONEYBEE_OPENSTUDIO_GEM_VERSION.tar.gz \
     && tar zxvf honeybee-openstudio-gem.tar.gz \

--- a/honeybee_energy/simulation/output.py
+++ b/honeybee_energy/simulation/output.py
@@ -250,7 +250,7 @@ output-table-summaryreports.html#outputtablesummaryreports)
                    'Baseboard Electric Energy',
                    'Evaporative Cooler Electric Energy',
                    'Energy Management System Metered Output Variable 1']
-        # NOTE: The EMS output is needed to catch the electric energy of ASHP
+        # NOTE: The EMS output catches the electric energy of standards gem ASHP
         for outp in outputs:
             self._outputs.add(outp)
 

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -20,14 +20,14 @@ class VentilationOpening(object):
         discharge_coefficient: A number between 0.0 and 1.0 that will be multipled
             by the area of the window in the stack (buoyancy-driven) part of the
             equation to account for additional friction from window geometry,
-            insect screens, etc. (Default: 0.17, for unobstructed windows with
+            insect screens, etc. (Default: 0.45, for unobstructed windows with
             insect screens). This value should be lowered if windows are of an
             awning or casement type and not allowed to fully open. Some common
             values for this coefficient include the following.
 
                 * 0.0 - Completely discount stack ventilation from the calculation.
-                * 0.17 - For unobstructed windows with an insect screen.
-                * 0.25 - For unobstructed windows with NO insect screen.
+                * 0.45 - For unobstructed windows with an insect screen.
+                * 0.65 - For unobstructed windows with NO insect screen.
 
         wind_cross_vent: Boolean to indicate if there is an opening of roughly
             equal area on the opposite side of the Room such that wind-driven
@@ -47,7 +47,7 @@ class VentilationOpening(object):
                  '_discharge_coefficient', '_wind_cross_vent', '_parent')
 
     def __init__(self, fraction_area_operable=0.5, fraction_height_operable=1.0,
-                 discharge_coefficient=0.17, wind_cross_vent=False):
+                 discharge_coefficient=0.45, wind_cross_vent=False):
         """Initialize VentilationOpening."""
         self.fraction_area_operable = fraction_area_operable
         self.fraction_height_operable = fraction_height_operable
@@ -127,7 +127,7 @@ class VentilationOpening(object):
             "type": "VentilationOpening",
             "fraction_area_operable": 0.5,  # Fractional number for area operable
             "fraction_height_operable": 0.5,  # Fractional number for height operable
-            "discharge_coefficient": 0.17,  # Fractional number for discharge coefficient
+            "discharge_coefficient": 0.45,  # Fractional number for discharge coefficient
             "wind_cross_vent": True  # Wind-driven cross ventilation
             }
         """
@@ -139,7 +139,7 @@ class VentilationOpening(object):
         height_op = data['fraction_height_operable'] if 'fraction_height_operable' in data \
             and data['fraction_height_operable'] is not None else 1.0
         discharge = data['discharge_coefficient'] if 'discharge_coefficient' in data \
-            and data['discharge_coefficient'] is not None else 0.17
+            and data['discharge_coefficient'] is not None else 0.45
         cross_vent = data['wind_cross_vent'] if 'wind_cross_vent' in data \
             and data['wind_cross_vent'] is not None else False
 

--- a/tests/ventcool_opening_test.py
+++ b/tests/ventcool_opening_test.py
@@ -19,7 +19,7 @@ def test_ventilation_opening_init():
 
     assert ventilation.fraction_area_operable == 0.5
     assert ventilation.fraction_height_operable == 1.0
-    assert ventilation.discharge_coefficient == 0.17
+    assert ventilation.discharge_coefficient == 0.45
     assert not ventilation.wind_cross_vent
     assert not ventilation.has_parent
     assert ventilation.parent is None


### PR DESCRIPTION
If we want to use the discharge coefficient in both simple ventilation and the AFN, it seems we should follow the E+ guide and use a coefficient that corresponds to the height from midpoint of lower opening to the neutral pressure level (deltaHnpl) instead of using the full height of the window.