### PR TITLE
fix(afn): Refactor methods for VentilationSimulationControl geometry

### DIFF
--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -16,7 +16,7 @@ class FaceEnergyProperties(object):
         construction: An optional Honeybee OpaqueConstruction object for
             the face. If None, it will be set by the parent Room ConstructionSet
             or the the Honeybee default generic ConstructionSet.
-        vent_crack: An optional AFNCrack to specify an air leakage crack for
+        vent_crack: An optional AFNCrack to specify the air leakage crack for
             the Face. (Default: None).
 
     Properties:
@@ -74,7 +74,12 @@ class FaceEnergyProperties(object):
 
     @property
     def vent_crack(self):
-        """Get or set a AFNCrack object to specify Airflow Network air leakage."""
+        """Get or set a AFNCrack object to specify Airflow Network air leakage.
+
+        Note that anything assigned here has no bearing on the simulation unless
+        the Model that the Face is a part of has its ventilation_simulation_control
+        set for MultiZone air flow, thereby triggering the use of the AirflowNetwork.
+        """
         return self._vent_crack
 
     @vent_crack.setter

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -293,6 +293,16 @@ class ModelEnergyProperties(object):
                 'VentilationSimulationControl object. Got: {}.'.format(value)
         self._ventilation_simulation_control = value
 
+    def autocalculate_ventilation_simulation_control(self):
+        """Set geometry properties of ventilation_simulation_control with Model's rooms.
+
+        The room geometry of the host Model will be used to assign the aspect_ratio,
+        long_axis_angle, and the building_type. Note that these properties are only
+        meaningful for simulations using the AirflowNetwork.
+        """
+        self.ventilation_simulation_control.assign_geometry_properties_from_rooms(
+            self.host.rooms)
+
     def check_duplicate_material_identifiers(self, raise_exception=True):
         """Check that there are no duplicate Material identifiers in the model."""
         material_identifiers = set()

--- a/honeybee_energy/ventcool/afn.py
+++ b/honeybee_energy/ventcool/afn.py
@@ -1,141 +1,10 @@
 # coding=utf-8
 """Functions to generate an Airflow Network for a list of rooms."""
 from __future__ import division
-import math
 
 from .crack import AFNCrack
 from .opening import VentilationOpening
 from ._crack_data import CRACK_TEMPLATE_DATA
-
-
-# TODO: Move to ladybug_geometry
-def _compute_bounding_box_x(geometries):
-    """Calculate minimum and maximum x coordinates of multiple geometries.
-
-    Note this function returns the coordinate extents relative to the standard
-    basis. If extents relative to a rotated bounding box is required, the geometries
-    need to be rotated to the standard basis before running this function.
-    """
-
-    geoms = geometries
-    min_x, max_x = geoms[0].min.x, geoms[0].max.x
-
-    for geom in geoms[1:]:
-        if geom.min.x < min_x:
-            min_x = geom.min.x
-        if geom.max.x > max_x:
-            max_x = geom.max.x
-
-    return min_x, max_x
-
-
-# TODO: Move to ladybug_geometry
-def _compute_bounding_box_y(geometries):
-    """Calculate minimum and maximum y coordinates of multiple geometries.
-
-    Note this function returns the coordinate extents relative to the standard
-    basis. If extents relative to a rotated bounding box is required, the geometries
-    need to be rotated to the standard basis before running this function.
-    """
-
-    geoms = geometries
-    min_y, max_y = geoms[0].min.y, geoms[0].max.y
-
-    for geom in geoms[1:]:
-        if geom.min.y < min_y:
-            min_y = geom.min.y
-        if geom.max.y > max_y:
-            max_y = geom.max.y
-
-    return min_y, max_y
-
-
-# TODO: Move to ladybug_geometry
-def _compute_bounding_box_z(geometries):
-    """Calculate minimum and maximum z coordinates of multiple geometries.
-
-    Note this function returns the coordinate extents relative to the standard
-    basis. If extents relative to a rotated bounding box is required, the geometries
-    need to be rotated to the standard basis before running this function.
-    """
-
-    geoms = geometries
-    min_z, max_z = geoms[0].min.z, geoms[0].max.z
-
-    for geom in geometries:
-        if geom.max.z > max_z:
-            max_z = geom.max.z
-        if geom.min.z < min_z:
-            min_z = geom.min.z
-
-    return min_z, max_z
-
-
-# TODO: Move to ladybug_geometry
-def _compute_bounding_box_extents(geometries, axis_angle=0):
-    """Calculate the extents of an oriented bounding box from an array of 3D geometry objects.
-
-    Args:
-        geometries: An array of 3D geometry objects.
-        axis_angle: The counter-clockwise rotation angle in radians in the xy plane
-            to represent the orientation of the bounding box extents. (Default: 0).
-    Returns:
-        The distances associated with the width, length and height of the bounding box.
-    """
-
-    geoms = geometries
-    theta = -axis_angle / 180.0 * math.pi
-    cpt = geoms[0].vertices[0]
-
-    if abs(axis_angle) > 1e-10:
-        geoms = [geom.rotate_xy(theta, cpt) for geom in geoms]
-
-    xx = _compute_bounding_box_x(geoms)
-    yy = _compute_bounding_box_y(geoms)
-    zz = _compute_bounding_box_z(geoms)
-
-    return xx[1] - xx[0], yy[1] - yy[0], zz[1] - zz[0]
-
-
-def _compute_building_type(bounding_box_extents):
-    """Compute the relationship between building footprint and height for AirflowNetwork.
-
-    Args:
-        bounding_box_extents: A tuple with three numbers representing the distance of
-            the bounding box width, length, and height.
-        rooms: List of Honeybee Room objects.
-    Returns:
-        Either a 'LowRise' text string if the bounding box height is less then three
-        times the width and length of the footprint, or a 'HighRise' text string
-        if the bounding box height is more than three times the width and length of
-        the footprint.
-    """
-
-    xx, yy, zz = bounding_box_extents
-
-    hdist = 3 * max(xx, yy)
-    zdist = zz
-
-    return 'LowRise' if zdist <= hdist else 'HighRise'
-
-
-def _compute_aspect_ratio(bounding_box_extents):
-    """Compute the AirflowNetwork aspect ratio of a building.
-
-    Args:
-        bounding_box_extents: A tuple with three numbers representing the distance of
-            the bounding box width, length, and height.
-    Returns:
-        A number representing the ratio of length of the short axis divided by the
-        length of the long axis.
-    """
-
-    xx, yy, _ = bounding_box_extents
-
-    if xx < yy:
-        return xx / yy
-    else:
-        return yy / xx
 
 
 def _air_density_from_pressure(atmospheric_pressure=101325, air_temperature=20.0):
@@ -370,7 +239,6 @@ def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
         atmospheric_pressure: Optional number to define the atmospheric pressure
             measurement in Pascals used to calculate dry air density. (Default: 101325).
     """
-
     # simplify parameters
     if leakage_type == 'Excellent':
         int_cracks = CRACK_TEMPLATE_DATA['internal_excellent_cracks']
@@ -384,21 +252,16 @@ def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
     else:
         raise AssertionError('leakage_type must be "Excellent", "Medium", '
                              'or "VeryPoor". Got: {}.'.format(leakage_type))
-    air_density = _air_density_from_pressure(atmospheric_pressure)
 
-    # generate
+    # generate the airflow newtwork
     for room in rooms:
-
         # get grouped faces by type that experience air flow leakage
         ext_faces, int_faces = room.properties.energy.envelope_components_by_type()
 
-        has_room_infiltration = room.properties.energy.infiltration is not None
-
         # mutate surfaces with AFN flow parameters
-        if use_room_infiltration and has_room_infiltration:
-            room.properties.energy.exterior_afn_from_infiltration_load(
-                ext_faces, air_density)
+        if use_room_infiltration and room.properties.energy.infiltration is not None:
+            rho = _air_density_from_pressure(atmospheric_pressure)
+            room.properties.energy.exterior_afn_from_infiltration_load(ext_faces, rho)
         else:
             _exterior_afn(ext_faces, ext_cracks)
-
         _interior_afn(int_faces, int_cracks)

--- a/honeybee_energy/ventcool/crack.py
+++ b/honeybee_energy/ventcool/crack.py
@@ -10,6 +10,10 @@ from honeybee.typing import float_in_range, float_positive
 class AFNCrack(object):
     """Airflow leakage through surface due to cracks or porous surface material.
 
+    Note that this whole class only has bearing on the simulation when the Model
+    that the AFNCrack is a part of has its ventilation_simulation_control set for
+    MultiZone air flow, thereby triggering the use of the AirflowNetwork.
+
     Args:
         flow_coefficient: A number in kg/s-m at 1 Pa per meter of
             crack length at the conditions defined in the ReferenceCrack condition;

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -123,9 +123,9 @@ class VentilationOpening(object):
     def wind_cross_vent(self):
         """Get or set a boolean for whether there is cross ventilation from the window.
 
-        Note that this property only has significance for simulations with simple
-        ZoneVentilation objects and has no bearing on simulations with the
-        Airflow Network.
+        Note that this property only has significance for simulations using SingleZone
+        ventilation_simulation_control and has no bearing on multizone simulations
+        with the Airflow Network.
 
         This should be True if there is an opening of roughly equal area on the
         opposite side of the Room such that wind-driven cross ventilation will
@@ -140,13 +140,11 @@ class VentilationOpening(object):
 
     @property
     def flow_coefficient_closed(self):
-        """Get or set coefficient for the mass flow rate when opening is closed.
+        """Get or set a number for the mass flow coefficient when opening is closed [kg/s-m].
 
-        Note that while the default for this value is zero, it only indicates that this
-        VentilationOpening object is not participating in the AirflowNetwork simulation,
-        and thus does not actually inform any simulation. Values greater than (but not
-        equal) to zero indicate participation in the AirflowNetwork simulation,
-        consistent with the expected EnergyPlus range for flow_coefficient_closed values.
+        Note that anything assigned here has no bearing on the simulation unless
+        the Model that this object is a part of has its ventilation_simulation_control
+        set for MultiZone air flow, thereby triggering the use of the AirflowNetwork.
         """
         return self._flow_coefficient_closed
 
@@ -156,7 +154,12 @@ class VentilationOpening(object):
 
     @property
     def flow_exponent_closed(self):
-        """Get or set exponent for deriving the mass flow rate when opening is closed."""
+        """Get or set the exponent for deriving the mass flow rate when opening is closed.
+
+        Note that anything assigned here has no bearing on the simulation unless
+        the Model that this object is a part of has its ventilation_simulation_control
+        set for MultiZone air flow, thereby triggering the use of the AirflowNetwork.
+        """
         return self._flow_exponent_closed
 
     @flow_exponent_closed.setter
@@ -166,7 +169,12 @@ class VentilationOpening(object):
 
     @property
     def two_way_threshold(self):
-        """Get or set minimum density difference above which two-way flow occurs."""
+        """Get or set minimum density difference above which two-way flow occurs [kg/m3].
+
+        Note that anything assigned here has no bearing on the simulation unless
+        the Model that this object is a part of has its ventilation_simulation_control
+        set for MultiZone air flow, thereby triggering the use of the AirflowNetwork.
+        """
         return self._two_way_threshold
 
     @two_way_threshold.setter


### PR DESCRIPTION
Now that the bounding box methods have been moved to ladybug_geometry, this commit refactors these functions out of honeybee_energy.  It also moves all of the aspect ratio methods not in ladybug_geometry onto the VentilationSimulationControl class instead of having everything as hidden methods within the afn module.

Lastly, a method was added to the ModelEnergyProperties to automatically compute building_type, long_axis_angle, and aspect_ratio from the Model's room geometry.

And I updated some of the docstrings to make it clear which properties have a bearing on the simulation in different situations.