### PR TITLE
fix(afn): Ensure AirBoundary Faces are properly represented in AFN

### DIFF
--- a/honeybee_energy/hvac/allair/vav.py
+++ b/honeybee_energy/hvac/allair/vav.py
@@ -34,25 +34,16 @@ class VAV(_AllAirBase):
             * VAV chiller with district hot water reheat
             * VAV chiller with PFP boxes
             * VAV chiller with gas coil reheat
-            * VAV chiller with no reheat with baseboard electric
-            * VAV chiller with no reheat with gas unit heaters
-            * VAV chiller with no reheat with zone heat pump
             * VAV air-cooled chiller with gas boiler reheat
             * VAV air-cooled chiller with central air source heat pump reheat
             * VAV air-cooled chiller with district hot water reheat
             * VAV air-cooled chiller with PFP boxes
             * VAV air-cooled chiller with gas coil reheat
-            * VAV air-cooled chiller with no reheat with baseboard electric
-            * VAV air-cooled chiller with no reheat with gas unit heaters
-            * VAV air-cooled chiller with no reheat with zone heat pump
             * VAV district chilled water with gas boiler reheat
             * VAV district chilled water with central air source heat pump reheat
             * VAV district chilled water with district hot water reheat
             * VAV district chilled water with PFP boxes
             * VAV district chilled water with gas coil reheat
-            * VAV district chilled water with no reheat with baseboard electric
-            * VAV district chilled water with no reheat with gas unit heaters
-            * VAV district chilled water with no reheat with zone heat pump
 
         economizer_type: Text to indicate the type of air-side economizer used on
             the system. If Inferred, the economizer will be set to whatever is
@@ -88,23 +79,14 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
         'VAV chiller with district hot water reheat',
         'VAV chiller with PFP boxes',
         'VAV chiller with gas coil reheat',
-        'VAV chiller with no reheat with baseboard electric',
-        'VAV chiller with no reheat with gas unit heaters',
-        'VAV chiller with no reheat with zone heat pump',
         'VAV air-cooled chiller with gas boiler reheat',
         'VAV air-cooled chiller with central air source heat pump reheat',
         'VAV air-cooled chiller with district hot water reheat',
         'VAV air-cooled chiller with PFP boxes',
         'VAV air-cooled chiller with gas coil reheat',
-        'VAV air-cooled chiller with no reheat with baseboard electric',
-        'VAV air-cooled chiller with no reheat with gas unit heaters',
-        'VAV air-cooled chiller with no reheat with zone heat pump',
         'VAV district chilled water with gas boiler reheat',
         'VAV district chilled water with central air source heat pump reheat',
         'VAV district chilled water with district hot water reheat',
         'VAV district chilled water with PFP boxes',
-        'VAV district chilled water with gas coil reheat',
-        'VAV district chilled water with no reheat with baseboard electric',
-        'VAV district chilled water with no reheat with gas unit heaters',
-        'VAV district chilled water with no reheat with zone heat pump'
+        'VAV district chilled water with gas coil reheat'
     )

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -15,7 +15,7 @@ from ..ventcool.opening import VentilationOpening
 
 # import Honeybee-core modules
 from honeybee.boundarycondition import Outdoors, Surface
-from honeybee.facetype import Wall, RoofCeiling, Floor
+from honeybee.facetype import Wall, RoofCeiling, Floor, AirBoundary
 from honeybee.aperture import Aperture
 
 # import all hvac modules to ensure they are all re-serialize-able in Room.from_dict
@@ -414,9 +414,13 @@ class RoomEnergyProperties(object):
             - int_apertures: List of interior Aperture Face objects.
 
             - int_doors: List of interior Door Face objects.
+
+            - int_air: List of interior Faces with AirBoundary face type.
         """
-        ext_walls, ext_roofs, ext_floors, ext_apertures, ext_doors = [], [], [], [], []
-        int_walls, int_floorceilings, int_apertures, int_doors = [], [], [], []
+        ext_walls, ext_roofs, ext_floors, ext_apertures, ext_doors = \
+            [], [], [], [], []
+        int_walls, int_floorceilings, int_apertures, int_doors, int_air = \
+            [], [], [], [], []
 
         for face in self.host.faces:
             if isinstance(face.boundary_condition, Outdoors):
@@ -437,9 +441,11 @@ class RoomEnergyProperties(object):
                 elif isinstance(face.type, RoofCeiling) or isinstance(face.type, Floor):
                     int_floorceilings.append(face)
                     int_apertures.extend(face.apertures)  # interior skylights
+                elif isinstance(face.type, AirBoundary):
+                    int_air.append(face)
 
         ext_faces = (ext_walls, ext_roofs, ext_floors, ext_apertures, ext_doors)
-        int_faces = (int_walls, int_floorceilings, int_apertures, int_doors)
+        int_faces = (int_walls, int_floorceilings, int_apertures, int_doors, int_air)
 
         return ext_faces, int_faces
 

--- a/honeybee_energy/ventcool/crack.py
+++ b/honeybee_energy/ventcool/crack.py
@@ -20,10 +20,10 @@ class AFNCrack(object):
             required to run an AirflowNetwork simulation. Some common values for this
             coefficient from the DesignBuilder Cracks template include the following:
 
-                * 0.00001 - Tight low-leakage external wall
-                * 0.001 - Tight, low-leakage internal wall
-                * 0.0004 - Poor, high-leakage external wall
-                * 0.019 - Poor, high-leakage internal wall
+            * 0.00001 - Tight low-leakage external wall
+            * 0.001 - Tight, low-leakage internal wall
+            * 0.0004 - Poor, high-leakage external wall
+            * 0.019 - Poor, high-leakage internal wall
 
         flow_exponent: An optional dimensionless number between 0.5 and 1 used
             to calculate the crack mass flow rate; required to run an AirflowNetwork

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -25,9 +25,9 @@ class VentilationOpening(object):
             awning or casement type and not allowed to fully open. Some common
             values for this coefficient include the following.
 
-                * 0.0 - Completely discount stack ventilation from the calculation.
-                * 0.45 - For unobstructed windows with an insect screen.
-                * 0.65 - For unobstructed windows with NO insect screen.
+            * 0.0 - Completely discount stack ventilation from the calculation.
+            * 0.45 - For unobstructed windows with an insect screen.
+            * 0.65 - For unobstructed windows with NO insect screen.
 
         wind_cross_vent: Boolean to indicate if there is an opening of roughly
             equal area on the opposite side of the Room such that wind-driven
@@ -39,8 +39,8 @@ class VentilationOpening(object):
             only used in an AirflowNetwork simulation. Some common values for this
             coefficient (from the DesignBuilder Cracks template) include the following:
 
-                * 0.00001 - Tight, low-leakage closed external window
-                * 0.003 - Very poor, high-leakage closed external window
+            * 0.00001 - Tight, low-leakage closed external window
+            * 0.003 - Very poor, high-leakage closed external window
 
             (Default: 0, indicates the VentilationOpening object will not participate
             in the AirflowNetwork simulation).


### PR DESCRIPTION
This commit ensures that the afn.genrate method recognizes Faces with an AirBoundary type and assigns them a Crack object with a very large flow coefficient.  This flow coefficient is derived from the Orifice Equation, using a discharge coefficient of 0.65 for an unobstructed opening.