### PR TITLE
fix(lighting): Add baseline_watts_per_area to Lighting class

### DIFF
--- a/honeybee_energy/cli/__init__.py
+++ b/honeybee_energy/cli/__init__.py
@@ -13,6 +13,7 @@ from .translate import translate
 from .settings import settings
 from .simulate import simulate
 from .result import result
+from .baseline import baseline
 
 # command group for all energy extension commands.
 @click.group(help='honeybee energy commands.')
@@ -26,6 +27,7 @@ energy.add_command(translate)
 energy.add_command(settings)
 energy.add_command(simulate)
 energy.add_command(result)
+energy.add_command(baseline)
 
 # add energy sub-commands to honeybee CLI
 main.add_command(energy)

--- a/honeybee_energy/cli/baseline.py
+++ b/honeybee_energy/cli/baseline.py
@@ -1,0 +1,72 @@
+"""honeybee energy commands for creating baseline buildings conforming to standards."""
+
+try:
+    import click
+except ImportError:
+    raise ImportError(
+        'click is not installed. Try `pip install . [cli]` command.'
+    )
+
+from honeybee.model import Model
+from honeybee.boundarycondition import Outdoors
+from honeybee.facetype import RoofCeiling
+
+import sys
+import logging
+import json
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for creating baseline buildings conforming to standards.')
+def baseline():
+    pass
+
+
+@baseline.command('geometry-2004')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.option('--output-file', help='Optional hbjson file to output the JSON string '
+              'of the converted model. By default this will be printed out to stdout',
+              type=click.File('w'), default='-', show_default=True)
+def geometry_2004(model_json, output_file):
+    """Convert a Model's geometry to be conformant with ASHRAE 90.1-2004 appendix G.
+    \n
+    This includes stripping out all child shades (leaving orphaned shade), reducing
+    the vertical glazing ratio to 40% it it's above this value, and reducing the
+    skylight ratio to 5% of it's above this value.
+    \n
+    Args:
+        model_json: Full path to a Model JSON file.
+    """
+    try:
+        # re-serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        model = Model.from_dict(data)
+        model.remove_assigned_shades()  # remove all of the child shades
+        w_area = model.exterior_wall_area
+        r_area = model.exterior_roof_area
+        wr = model.exterior_wall_aperture_area / w_area if w_area != 0 else 0
+        sr = model.exterior_skylight_aperture_area / r_area if r_area != 0 else 0
+
+        # if the window or skylight ratio is greater than max permitted, set it to max
+        if wr > 0.4:  # set all walls to have 40% ratio
+            model.wall_apertures_by_ratio(0.4)
+        if sr > 0.05:  # reduce all skylights by the amount needed for 5%
+            red_fract = 0.05 / sr  # scale factor for all of the skylights
+            for room in model.rooms:
+                for face in room.faces:
+                    if isinstance(face.boundary_condition, Outdoors) and \
+                            isinstance(face.type, RoofCeiling) and \
+                            len(face._apertures) > 0:
+                        new_ratio = face.aperture_ratio * red_fract
+                        face.apertures_by_ratio(new_ratio)
+
+        # write the Model JSON string
+        output_file.write(json.dumps(model.to_dict()))
+    except Exception as e:
+        _logger.exception('Model baseline geometry creation failed.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/honeybee_energy/cli/translate.py
+++ b/honeybee_energy/cli/translate.py
@@ -114,8 +114,8 @@ def model_to_osm(model_json, sim_par_json, folder, check_model, log_file):
 def model_to_idf(model_json, sim_par_json, additional_str, output_file):
     """Translate a Model JSON file to an IDF using direct-to-idf translators.
     \n
-    The resulting IDF should be simulate-able but not all Model properties might
-    make it into the IDF given that the direct-to-idf translators are used.
+    If the model contains a feature that is not translate-able through direct-to-idf
+    translators, an exception will be raised.
     \n
     Args:
         model_json: Full path to a Model JSON file.
@@ -143,7 +143,7 @@ def model_to_idf(model_json, sim_par_json, additional_str, output_file):
 
         # create the strings for simulation paramters and model
         ver_str = energyplus_idf_version() if folders.energyplus_version \
-            is not None else energyplus_idf_version((9, 2, 0))
+            is not None else energyplus_idf_version((9, 3, 0))
         sim_par_str = sim_par.to_idf()
         model_str = model.to.idf(model, schedule_directory=sch_directory)
         idf_str = '\n\n'.join([ver_str, sim_par_str, model_str, additional_str])

--- a/tests/cli_baseline_test.py
+++ b/tests/cli_baseline_test.py
@@ -1,0 +1,22 @@
+"""Test cli translate module."""
+from click.testing import CliRunner
+from honeybee_energy.cli.baseline import geometry_2004
+from honeybee.model import Model
+
+import json
+
+
+def test_model_to_idf():
+    runner = CliRunner()
+    input_hb_model = './tests/json/ShoeBox.json'
+
+    result = runner.invoke(geometry_2004, [input_hb_model])
+    assert result.exit_code == 0
+    model_dict = json.loads(result.output)
+    new_model = Model.from_dict(model_dict)
+    w_area = new_model.exterior_wall_area
+    r_area = new_model.exterior_roof_area
+    wr = new_model.exterior_wall_aperture_area / w_area if w_area != 0 else 0
+    sr = new_model.exterior_skylight_aperture_area / r_area if r_area != 0 else 0
+    assert wr < 0.41
+    assert sr < 0.06

--- a/tests/load_lighting_test.py
+++ b/tests/load_lighting_test.py
@@ -28,6 +28,7 @@ def test_lighting_init():
     assert lighting.return_air_fraction == 0
     assert lighting.radiant_fraction == 0.32
     assert lighting.visible_fraction == 0.25
+    assert lighting.baseline_watts_per_area == 11.84029
 
 
 def test_lighting_setability():
@@ -53,6 +54,8 @@ def test_lighting_setability():
     assert lighting.radiant_fraction == 0.4
     lighting.visible_fraction = 0.2
     assert lighting.visible_fraction == 0.2
+    lighting.baseline_watts_per_area = 5.0
+    assert lighting.baseline_watts_per_area == 5.0
 
 
 def test_lighting_equality():


### PR DESCRIPTION
This new property will provide a user interface for setting the lighting power density in the baseline model creation workflows.  This property is really only relevant when users are creating their own ProgramTypes from scratch (as opposed to using the ProgramTypes that come with the honeybee-energy-standards package).

The plan is that the baseline model creation workflows will first look for an equivalent ProgramType in the ASHRAE-2004 standard and use the LPD there.  If an equivalent ProgramType in 2004 is not found, this baseline_watts_per_area property will be used instead.  The default value for this property is the ASHRAE 2004 baseline for an office, which is the recommended approach when a given program cannot be classified into any of the categories of the ASHRAE standard.