### PR TITLE
fix(dockerfile): Add honeybee-energy-standards into Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
 ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
 COPY . honeybee-energy
 RUN pip3 install setuptools wheel\
-    && pip3 install pydantic==1.5.1 honeybee-schema ./honeybee-energy[cli]
+    && pip3 install ./honeybee-energy[cli]
 
 # Set up working directory
 RUN mkdir -p /home/ladybugbot/run/simulation

--- a/honeybee_energy/cli/baseline.py
+++ b/honeybee_energy/cli/baseline.py
@@ -97,7 +97,7 @@ def constructions_2004(model_json, climate_zone, output_file):
     all rooms in the model.
     \n
     Args:
-        model_json: Full path to a Model JSON file.
+        model_json: Full path to a Model JSON file.\n
         climate_zone: Text indicating the ASHRAE climate zone. This can be a single
             integer (in which case it is interpreted as A) or it can include the
             A, B, or C qualifier (eg. 3C).
@@ -254,7 +254,7 @@ def hvac_2004(model_json, climate_zone, nonresidential, fuel, floor_area,
     the model.
     \n
     Args:
-        model_json: Full path to a Model JSON file.
+        model_json: Full path to a Model JSON file.\n
         climate_zone: Text indicating the ASHRAE climate zone. This can be a single
             integer (in which case it is interpreted as A) or it can include the
             A, B, or C qualifier (eg. 3C).

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'cli': ['click==7.1.2', 'honeybee-core[cli]==1.35.1']
+        'cli': ['click==7.1.2', 'honeybee-core[cli]==1.35.1', 'honeybee-energy-standards==2.0.2']
     },
     entry_points={
         "console_scripts": ["honeybee-energy = honeybee_energy.cli:energy"]


### PR DESCRIPTION
This commit adds the honeybee-energy-standards package into the docker file as it is required in order to run all of the new baseline model creation commands.

@mostaphaRoudsari  and @AntoineDao , please let me know if I am doing this correctly.  Also, adding in this package will likely increase the size of the docker image by 10 MBs so I am not totally sure this is worth it given that not all recipes will be using the honeybee-energy-standards package.  Let me know if you think we need to set up separate docker images depending on whether the standards package is needed.