### PR TITLE
feat(config): Improve E+ and OS version check and add config command

### DIFF
--- a/honeybee_energy/cli/__init__.py
+++ b/honeybee_energy/cli/__init__.py
@@ -7,7 +7,12 @@ except ImportError:
         'click is not installed. Try `pip install . [cli]` command.'
     )
 
+import sys
+import logging
+import json
+
 from honeybee.cli import main
+from ..config import folders
 from .lib import lib
 from .translate import translate
 from .settings import settings
@@ -19,6 +24,40 @@ from .baseline import baseline
 @click.group(help='honeybee energy commands.')
 def energy():
     pass
+
+
+_logger = logging.getLogger(__name__)
+
+
+@energy.command('config')
+@click.option('--output-file', help='Optional file to output the JSON string of '
+              'the config object. By default, it will be printed out to stdout',
+              type=click.File('w'), default='-', show_default=True)
+def config(output_file):
+    """Get a JSON object with all configuration information"""
+    try:
+        config_dict = {
+            'openstudio_path': folders.openstudio_path,
+            'openstudio_exe': folders.openstudio_exe,
+            'openstudio_version': folders.openstudio_version_str,
+            'energyplus_path': folders.energyplus_path,
+            'energyplus_exe': folders.energyplus_exe,
+            'energyplus_version': folders.energyplus_version_str,
+            'honeybee_openstudio_gem_path': folders.honeybee_openstudio_gem_path,
+            'standards_data_folder': folders.standards_data_folder,
+            'construction_lib': folders.construction_lib,
+            'constructionset_lib': folders.constructionset_lib,
+            'schedule_lib': folders.schedule_lib,
+            'programtype_lib': folders.programtype_lib,
+            'defaults_file': folders.defaults_file,
+            'standards_extension_folders': folders.standards_extension_folders
+        }
+        output_file.write(json.dumps(config_dict, indent=4))
+    except Exception as e:
+        _logger.exception('Failed to retrieve configurations.\n{}'.format(e))
+        sys.exit(1)
+    else:
+        sys.exit(0)
 
 
 # add sub-commands to energy

--- a/tests/cli_main_test.py
+++ b/tests/cli_main_test.py
@@ -1,0 +1,15 @@
+"""Test cli lib module."""
+from click.testing import CliRunner
+from honeybee_energy.cli import config
+
+import json
+
+
+def test_config():
+    """Test the config command."""
+    runner = CliRunner()
+
+    result = runner.invoke(config)
+    assert result.exit_code == 0
+    config_dict = json.loads(result.output)
+    assert len(config_dict) >= 12


### PR DESCRIPTION
This commit changes the check for EnergyPlus and OpenStudio version to parse the output of the --version command from the respective CLIs.  This will be much more reliable into the future as it does not rely on any version numbers being in the installation path.

I also added a `honeybee-energy config` command that returns a full JSON of configuration variables, including the version.