### PR TITLE
fix(docker): Update docker image to OpenStudio 3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ WORKDIR /home/ladybugbot
 RUN mkdir ladybug_tools && touch ladybug_tools/config.json
 
 # Install Open Studio
-ENV OPENSTUDIO_VERSION=3.0.1
-ENV OPENSTUDIO_FILENAME=OpenStudio-3.0.1+09b7c8a554-Linux
-ENV OPENSTUDIO_DOWNLOAD_URL=https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.0.1/OpenStudio-3.0.1%2B09b7c8a554-Linux.tar.gz
+ENV OPENSTUDIO_VERSION=3.1.0
+ENV OPENSTUDIO_FILENAME=OpenStudio-3.1.0+e165090621-Linux
+ENV OPENSTUDIO_DOWNLOAD_URL=https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz
 RUN mkdir ladybug_tools/openstudio/ \
     && curl -SL -o openstudio.tar.gz $OPENSTUDIO_DOWNLOAD_URL \
     && tar zxvf openstudio.tar.gz \
@@ -34,7 +34,7 @@ RUN mkdir ladybug_tools/openstudio/ \
 
 
 # Add honeybee-openstudio-gem lib to ladybug_tools folder
-ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.6.5
+ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.9.0
 RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
     && curl -SL -o honeybee-openstudio-gem.tar.gz https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v$HONEYBEE_OPENSTUDIO_GEM_VERSION.tar.gz \
     && tar zxvf honeybee-openstudio-gem.tar.gz \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Honeybee](http://www.ladybug.tools/assets/img/honeybee.png)
 
-[![Build Status](https://travis-ci.com/ladybug-tools/honeybee-energy.svg?branch=master)](https://travis-ci.com/ladybug-tools/honeybee-energy)
+[![Build Status](https://github.com/ladybug-tools/honeybee-energy/workflows/CI/badge.svg)](https://github.com/ladybug-tools/honeybee-energy/actions)
 [![Coverage Status](https://coveralls.io/repos/github/ladybug-tools/honeybee-energy/badge.svg?branch=master)](https://coveralls.io/github/ladybug-tools/honeybee-energy)
 
 [![Python 2.7](https://img.shields.io/badge/python-2.7-green.svg)](https://www.python.org/downloads/release/python-270/) [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/) [![IronPython](https://img.shields.io/badge/ironpython-2.7-red.svg)](https://github.com/IronLanguages/ironpython2/releases/tag/ipy-2.7.8/)
@@ -15,6 +15,7 @@ SDK in order to add energy simulation properties and capabilities to
 [honeybee-core](https://github.com/ladybug-tools/honeybee-core).
 
 ## Installation
+
 `pip install -U honeybee-energy`
 
 If you want to also include the command line interface try:


### PR DESCRIPTION
This PR should not be merged until we put the dockerhub credentials into Github so that the CI workflow runs successfully.

CC: @mostaphaRoudsari FYI