### PR TITLE
fix(hvac): Re-make all HVAC  Enumerations

### DIFF
--- a/honeybee_energy/cli/baseline.py
+++ b/honeybee_energy/cli/baseline.py
@@ -278,7 +278,7 @@ def hvac_2004(model_json, climate_zone, nonresidential, fuel, floor_area,
         model = Model.from_dict(data)
 
         # determine the HVAC template from the input criteria
-        std = '90.1-2004'
+        std = 'ASHRAE_2004'
         if len(climate_zone) == 1:
             climate_zone = '{}A'.format(climate_zone)
         if nonresidential:
@@ -294,21 +294,21 @@ def hvac_2004(model_json, climate_zone, nonresidential, fuel, floor_area,
             hvac_id = 'Baseline 2004 {} HVAC'
             if story_count > 5 or floor_area > 13935.5:  # more than 150,000 ft2
                 hvac_id = hvac_id.format('VAV')
-                hvac_sys = VAV(hvac_id, std, 'VAV chiller with gas boiler reheat') \
-                    if fuel else VAV(hvac_id, std, 'VAV chiller with PFP boxes')
+                hvac_sys = VAV(hvac_id, std, 'VAV_Chiller_Boiler') \
+                    if fuel else VAV(hvac_id, std, 'VAV_Chiller_PFP')
             elif story_count > 3 or floor_area > 6967.7:  # more than 75,000 ft2
                 hvac_id = hvac_id.format('PVAV')
-                hvac_sys = PVAV(hvac_id, std, 'PVAV with gas boiler reheat') \
-                    if fuel else PVAV(hvac_id, std, 'PVAV with PFP boxes')
+                hvac_sys = PVAV(hvac_id, std, 'PVAV_Boiler') \
+                    if fuel else PVAV(hvac_id, std, 'PVAV_PFP')
             else:
                 hvac_id = hvac_id.format('PSZ')
-                hvac_sys = PSZ(hvac_id, std, 'PSZ-AC with gas boiler') \
-                    if fuel else PSZ(hvac_id, std, 'PSZ-HP')
+                hvac_sys = PSZ(hvac_id, std, 'PSZAC_Boiler') \
+                    if fuel else PSZ(hvac_id, std, 'PSZHP')
             if climate_zone not in ('1A', '1B', '2A', '3A', '4A'):
                 hvac_sys.economizer_type = 'DifferentialDryBulb'
         else:
             hvac_id = 'Baseline 2004 PT Residential HVAC'
-            hvac_sys = PTAC(hvac_id, std, 'PTAC with baseboard gas boiler') \
+            hvac_sys = PTAC(hvac_id, std, 'PTAC_BoilerBaseboard') \
                 if fuel else PTAC(hvac_id, std, 'PTHP')
 
         # apply the HVAC template to all conditioned rooms in the model

--- a/honeybee_energy/construction/_base.py
+++ b/honeybee_energy/construction/_base.py
@@ -298,5 +298,5 @@ class _ConstructionBase(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Construction,\n {},\n {}'.format(
-            self.identifier, '\n '.join(tuple(mat.identifier for mat in self.materials)))
+        return 'Construction: {}, [{} materials]'.format(
+            self.display_name, len(self.materials))

--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -230,6 +230,6 @@ class AirBoundaryConstruction(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'AirBoundaryConstruction,\n identifier: {}\n mixing per area: {}\n ' \
-            'schedule: {}'.format(
-                self.identifier, self.air_mixing_per_area, self.air_mixing_schedule)
+        return 'AirBoundaryConstruction: {} [{} m3/s-m2] [schedule: {}]'.format(
+                self.display_name, round(self.air_mixing_per_area, 4),
+                self.air_mixing_schedule.display_name)

--- a/honeybee_energy/construction/shade.py
+++ b/honeybee_energy/construction/shade.py
@@ -240,6 +240,5 @@ class ShadeConstruction(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'ShadeConstruction,\n identifier: {}\n solar_ref: {}\n vis_ref: {}' \
-            '\n specular: {}'.format(self.identifier, self.solar_reflectance,
-                                     self.visible_reflectance, self.is_specular)
+        return 'ShadeConstruction: {} [solar_ref: {}]'.format(
+            self.display_name, self.solar_reflectance)

--- a/honeybee_energy/constructionset.py
+++ b/honeybee_energy/constructionset.py
@@ -623,7 +623,7 @@ class ConstructionSet(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Energy Construction Set: {}'.format(self.identifier)
+        return 'Energy Construction Set: {}'.format(self.display_name)
 
 
 @lockable
@@ -848,10 +848,10 @@ class WallConstructionSet(_FaceSetBase):
         self._ground_construction = value
 
     def __repr__(self):
-        return 'Wall Construction Set:\n Exterior: {}\n Interior: {}' \
-            '\n Ground: {}'.format(self.exterior_construction.identifier,
-                                   self.interior_construction.identifier,
-                                   self.ground_construction.identifier)
+        return 'Wall Construction Set: [Exterior: {}] [Interior: {}]' \
+            ' [Ground: {}]'.format(self.exterior_construction.display_name,
+                                   self.interior_construction.display_name,
+                                   self.ground_construction.display_name)
 
 
 @lockable
@@ -908,10 +908,10 @@ class FloorConstructionSet(_FaceSetBase):
         self._ground_construction = value
 
     def __repr__(self):
-        return 'Floor Construction Set:\n Exterior: {}\n Interior: {}' \
-            '\n Ground: {}'.format(self.exterior_construction.identifier,
-                                   self.interior_construction.identifier,
-                                   self.ground_construction.identifier)
+        return 'Floor Construction Set: [Exterior: {}] [Interior: {}]' \
+            ' [Ground: {}]'.format(self.exterior_construction.display_name,
+                                   self.interior_construction.display_name,
+                                   self.ground_construction.display_name)
 
 
 @lockable
@@ -968,10 +968,10 @@ class RoofCeilingConstructionSet(_FaceSetBase):
         self._ground_construction = value
 
     def __repr__(self):
-        return 'RoofCeiling Construction Set:\n Exterior: {}\n Interior: {}' \
-            '\n Ground: {}'.format(self.exterior_construction.identifier,
-                                   self.interior_construction.identifier,
-                                   self.ground_construction.identifier)
+        return 'RoofCeiling Construction Set: [Exterior: {}] [Interior: {}]' \
+            ' [Ground: {}]'.format(self.exterior_construction.display_name,
+                                   self.interior_construction.display_name,
+                                   self.ground_construction.display_name)
 
 
 @lockable
@@ -1190,12 +1190,12 @@ class ApertureConstructionSet(object):
             self._skylight_construction, self._operable_construction)
 
     def __repr__(self):
-        return 'Aperture Construction Set:\n Window: {}\n Interior: {}' \
-            '\n Skylight: {}\n Operable: {}'.format(
-                self.window_construction.identifier,
-                self.interior_construction.identifier,
-                self.skylight_construction.identifier,
-                self.operable_construction.identifier)
+        return 'Aperture Construction Set: [Window: {}] [Interior: {}]' \
+            ' [Skylight: {}] [Operable: {}]'.format(
+                self.window_construction.display_name,
+                self.interior_construction.display_name,
+                self.skylight_construction.display_name,
+                self.operable_construction.display_name)
 
 
 @lockable
@@ -1457,10 +1457,10 @@ class DoorConstructionSet(object):
             self._overhead_construction)
 
     def __repr__(self):
-        return 'Door Construction Set:\n Exterior: {}\n Interior: {}' \
-            '\n Exterior Glass: {}\n Interior Glass: {}\n Overhead: {}'.format(
-                self.exterior_construction.identifier,
-                self.interior_construction.identifier,
-                self.exterior_glass_construction.identifier,
-                self.interior_glass_construction.identifier,
-                self.overhead_construction.identifier)
+        return 'Door Construction Set: [Exterior: {}] [Interior: {}]' \
+            ' [Exterior Glass: {}] [Interior Glass: {}] [Overhead: {}]'.format(
+                self.exterior_construction.display_name,
+                self.interior_construction.display_name,
+                self.exterior_glass_construction.display_name,
+                self.interior_glass_construction.display_name,
+                self.overhead_construction.display_name)

--- a/honeybee_energy/hvac/_base.py
+++ b/honeybee_energy/hvac/_base.py
@@ -99,4 +99,4 @@ class _HVACSystem(object):
         return new_obj
 
     def __repr__(self):
-        return 'HVACSystem: {}'.format(self.identifier)
+        return 'HVACSystem: {}'.format(self.display_name)

--- a/honeybee_energy/hvac/_template.py
+++ b/honeybee_energy/hvac/_template.py
@@ -23,12 +23,12 @@ class _TemplateSystem(_HVACSystem):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment.
             For example, 'VAV chiller with gas boiler reheat'.
@@ -42,11 +42,11 @@ class _TemplateSystem(_HVACSystem):
     """
     __slots__ = ('_vintage', '_equipment_type')
 
-    VINTAGES = ('DOE Ref Pre-1980', 'DOE Ref 1980-2004', '90.1-2004', '90.1-2007',
-                '90.1-2010', '90.1-2013')
+    VINTAGES = ('DOE_Ref_Pre_1980', 'DOE_Ref_1980_2004', 'ASHRAE_2004', 'ASHRAE_2007',
+                'ASHRAE_2010', 'ASHRAE_2013')
     EQUIPMENT_TYPES = ('Inferred',)
 
-    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None):
+    def __init__(self, identifier, vintage='ASHRAE_2013', equipment_type=None):
         """Initialize HVACSystem."""
         # initialize base HVAC system properties
         _HVACSystem.__init__(self, identifier)
@@ -59,12 +59,12 @@ class _TemplateSystem(_HVACSystem):
 
         Choose from the following options:
 
-        * DOE Ref Pre-1980
-        * DOE Ref 1980-2004
-        * 90.1-2004
-        * 90.1-2007
-        * 90.1-2010
-        * 90.1-2013
+        * DOE_Ref_Pre_1980
+        * DOE_Ref_1980_2004
+        * ASHRAE_2004
+        * ASHRAE_2007
+        * ASHRAE_2010
+        * ASHRAE_2013
         """
         return self._vintage
 
@@ -119,7 +119,7 @@ class _TemplateSystem(_HVACSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": ""  # text for the HVAC equipment type
             }
         """
@@ -147,7 +147,7 @@ class _TemplateSystem(_HVACSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": ""  # text for the HVAC equipment type
             }
         """
@@ -190,8 +190,9 @@ class _TemplateSystem(_HVACSystem):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return '{}: {}\n type: {}\n vintage: {}'.format(
-            self.__class__.__name__, self.identifier, self.equipment_type, self.vintage)
+        return '{}: {} [type: {}] [vintage: {}]'.format(
+            self.__class__.__name__, self.display_name,
+            self.equipment_type, self.vintage)
 
 
 class _EnumerationBase(object):

--- a/honeybee_energy/hvac/allair/_base.py
+++ b/honeybee_energy/hvac/allair/_base.py
@@ -23,12 +23,12 @@ class _AllAirBase(_TemplateSystem):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment.
             For example, 'VAV chiller with gas boiler reheat'.
@@ -57,7 +57,7 @@ class _AllAirBase(_TemplateSystem):
                         'DifferentialEnthalpy')
     _has_air_loop = True
 
-    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None,
+    def __init__(self, identifier, vintage='ASHRAE_2013', equipment_type=None,
                  economizer_type='Inferred',
                  sensible_heat_recovery=autosize, latent_heat_recovery=autosize):
         """Initialize HVACSystem."""
@@ -147,7 +147,7 @@ class _AllAirBase(_TemplateSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": "",  # text for the HVAC equipment type
             "economizer_type": 'DifferentialDryBulb',  # Economizer type
             "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
@@ -190,7 +190,7 @@ class _AllAirBase(_TemplateSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": "",  # text for the HVAC equipment type
             "economizer_type": 'DifferentialDryBulb',  # Economizer type
             "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
@@ -244,13 +244,6 @@ class _AllAirBase(_TemplateSystem):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    def __repr__(self):
-        return '{}: {}\n type: {}\n vintage: {}\n economizer: {}\n sensible recovery:' \
-            ' {} \n latent recovery: {}'.format(
-                self.__class__.__name__, self.identifier, self.equipment_type,
-                self.vintage, self.economizer_type, self.sensible_heat_recovery,
-                self.latent_heat_recovery)
 
 
 class _AllAirEnumeration(_EnumerationBase):

--- a/honeybee_energy/hvac/allair/furnace.py
+++ b/honeybee_energy/hvac/allair/furnace.py
@@ -19,17 +19,17 @@ class ForcedAirFurnace(_AllAirBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Forced air furnace
+            * Furnace
 
         economizer_type: Text to indicate the type of air-side economizer used on
             the system. If Inferred, the economizer will be set to whatever is
@@ -58,4 +58,4 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
     """
     __slots__ = ()
 
-    EQUIPMENT_TYPES = ('Forced air furnace',)
+    EQUIPMENT_TYPES = ('Furnace',)

--- a/honeybee_energy/hvac/allair/psz.py
+++ b/honeybee_energy/hvac/allair/psz.py
@@ -19,36 +19,36 @@ class PSZ(_AllAirBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * PSZ-AC with baseboard electric
-            * PSZ-AC with baseboard gas boiler
-            * PSZ-AC with baseboard district hot water
-            * PSZ-AC with gas unit heaters
-            * PSZ-AC with electric coil
-            * PSZ-AC with gas coil
-            * PSZ-AC with gas boiler
-            * PSZ-AC with central air source heat pump
-            * PSZ-AC with district hot water
-            * PSZ-AC with no heat
-            * PSZ-AC district chilled water with baseboard electric
-            * PSZ-AC district chilled water with baseboard gas boiler
-            * PSZ-AC district chilled water with gas unit heaters
-            * PSZ-AC district chilled water with electric coil
-            * PSZ-AC district chilled water with gas coil
-            * PSZ-AC district chilled water with gas boiler
-            * PSZ-AC district chilled water with central air source heat pump
-            * PSZ-AC district chilled water with district hot water
-            * PSZ-AC district chilled water with no heat
-            * PSZ-HP
+            * PSZAC_ElectricBaseboard
+            * PSZAC_BoilerBaseboard
+            * PSZAC_DHWBaseboard
+            * PSZAC_GasHeaters
+            * PSZAC_ElectricCoil
+            * PSZAC_GasCoil
+            * PSZAC_Boiler
+            * PSZAC_ASHP
+            * PSZAC_DHW
+            * PSZAC
+            * PSZAC_DCW_ElectricBaseboard
+            * PSZAC_DCW_BoilerBaseboard
+            * PSZAC_DCW_GasHeaters
+            * PSZAC_DCW_ElectricCoil
+            * PSZAC_DCW_GasCoil
+            * PSZAC_DCW_Boiler
+            * PSZAC_DCW_ASHP
+            * PSZAC_DCW_DHW
+            * PSZAC_DCW
+            * PSZHP
 
         economizer_type: Text to indicate the type of air-side economizer used on
             the system. If Inferred, the economizer will be set to whatever is
@@ -78,24 +78,24 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'PSZ-AC with baseboard electric',
-        'PSZ-AC with baseboard gas boiler',
-        'PSZ-AC with baseboard district hot water',
-        'PSZ-AC with gas unit heaters',
-        'PSZ-AC with electric coil',
-        'PSZ-AC with gas coil',
-        'PSZ-AC with gas boiler',
-        'PSZ-AC with central air source heat pump',
-        'PSZ-AC with district hot water',
-        'PSZ-AC with no heat',
-        'PSZ-AC district chilled water with baseboard electric',
-        'PSZ-AC district chilled water with baseboard gas boiler',
-        'PSZ-AC district chilled water with gas unit heaters',
-        'PSZ-AC district chilled water with electric coil',
-        'PSZ-AC district chilled water with gas coil',
-        'PSZ-AC district chilled water with gas boiler',
-        'PSZ-AC district chilled water with central air source heat pump',
-        'PSZ-AC district chilled water with district hot water',
-        'PSZ-AC district chilled water with no heat',
-        'PSZ-HP'
+        'PSZAC_ElectricBaseboard',
+        'PSZAC_BoilerBaseboard',
+        'PSZAC_DHWBaseboard',
+        'PSZAC_GasHeaters',
+        'PSZAC_ElectricCoil',
+        'PSZAC_GasCoil',
+        'PSZAC_Boiler',
+        'PSZAC_ASHP',
+        'PSZAC_DHW',
+        'PSZAC',
+        'PSZAC_DCW_ElectricBaseboard',
+        'PSZAC_DCW_BoilerBaseboard',
+        'PSZAC_DCW_GasHeaters',
+        'PSZAC_DCW_ElectricCoil',
+        'PSZAC_DCW_GasCoil',
+        'PSZAC_DCW_Boiler',
+        'PSZAC_DCW_ASHP',
+        'PSZAC_DCW_DHW',
+        'PSZAC_DCW',
+        'PSZHP'
     )

--- a/honeybee_energy/hvac/allair/ptac.py
+++ b/honeybee_energy/hvac/allair/ptac.py
@@ -19,26 +19,26 @@ class PTAC(_AllAirBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * PTAC with baseboard electric
-            * PTAC with baseboard gas boiler
-            * PTAC with baseboard district hot water
-            * PTAC with gas unit heaters
-            * PTAC with electric coil
-            * PTAC with gas coil
-            * PTAC with gas boiler
-            * PTAC with central air source heat pump
-            * PTAC with district hot water
-            * PTAC with no heat
+            * PTAC_ElectricBaseboard
+            * PTAC_BoilerBaseboard
+            * PTAC_DHWBaseboard
+            * PTAC_GasHeaters
+            * PTAC_ElectricCoil
+            * PTAC_GasCoil
+            * PTAC_Boiler
+            * PTAC_ASHP
+            * PTAC_DHW
+            * PTAC
             * PTHP
 
     Properties:
@@ -56,16 +56,16 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'PTAC with baseboard electric',
-        'PTAC with baseboard gas boiler',
-        'PTAC with baseboard district hot water',
-        'PTAC with gas unit heaters',
-        'PTAC with electric coil',
-        'PTAC with gas coil',
-        'PTAC with gas boiler',
-        'PTAC with central air source heat pump',
-        'PTAC with district hot water',
-        'PTAC with no heat',
+        'PTAC_ElectricBaseboard',
+        'PTAC_BoilerBaseboard',
+        'PTAC_DHWBaseboard',
+        'PTAC_GasHeaters',
+        'PTAC_ElectricCoil',
+        'PTAC_GasCoil',
+        'PTAC_Boiler',
+        'PTAC_ASHP',
+        'PTAC_DHW',
+        'PTAC',
         'PTHP'
     )
     _has_air_loop = False

--- a/honeybee_energy/hvac/allair/pvav.py
+++ b/honeybee_energy/hvac/allair/pvav.py
@@ -19,21 +19,21 @@ class PVAV(_AllAirBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * PVAV with gas boiler reheat
-            * PVAV with central air source heat pump reheat
-            * PVAV with district hot water reheat
-            * PVAV with PFP boxes
-            * PVAV with gas heat with electric reheat
+            * PVAV_Boiler
+            * PVAV_ASHP
+            * PVAV_DHW
+            * PVAV_PFP
+            * PVAV_BoilerElectricReheat
 
         economizer_type: Text to indicate the type of air-side economizer used on
             the system. If Inferred, the economizer will be set to whatever is
@@ -63,9 +63,9 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'PVAV with gas boiler reheat',
-        'PVAV with central air source heat pump reheat',
-        'PVAV with district hot water reheat',
-        'PVAV with PFP boxes',
-        'PVAV with gas heat with electric reheat'
+        'PVAV_Boiler',
+        'PVAV_ASHP',
+        'PVAV_DHW',
+        'PVAV_PFP',
+        'PVAV_BoilerElectricReheat'
     )

--- a/honeybee_energy/hvac/allair/vav.py
+++ b/honeybee_energy/hvac/allair/vav.py
@@ -19,31 +19,31 @@ class VAV(_AllAirBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * VAV chiller with gas boiler reheat
-            * VAV chiller with central air source heat pump reheat
-            * VAV chiller with district hot water reheat
-            * VAV chiller with PFP boxes
-            * VAV chiller with gas coil reheat
-            * VAV air-cooled chiller with gas boiler reheat
-            * VAV air-cooled chiller with central air source heat pump reheat
-            * VAV air-cooled chiller with district hot water reheat
-            * VAV air-cooled chiller with PFP boxes
-            * VAV air-cooled chiller with gas coil reheat
-            * VAV district chilled water with gas boiler reheat
-            * VAV district chilled water with central air source heat pump reheat
-            * VAV district chilled water with district hot water reheat
-            * VAV district chilled water with PFP boxes
-            * VAV district chilled water with gas coil reheat
+            * VAV_Chiller_Boiler
+            * VAV_Chiller_ASHP
+            * VAV_Chiller_DHW
+            * VAV_Chiller_PFP
+            * VAV_Chiller_GasCoil
+            * VAV_ACChiller_Boiler
+            * VAV_ACChiller_ASHP
+            * VAV_ACChiller_DHW
+            * VAV_ACChiller_PFP
+            * VAV_ACChiller_GasCoil
+            * VAV_DCW_Boiler
+            * VAV_DCW_ASHP
+            * VAV_DCW_DHW
+            * VAV_DCW_PFP
+            * VAV_DCW_GasCoil
 
         economizer_type: Text to indicate the type of air-side economizer used on
             the system. If Inferred, the economizer will be set to whatever is
@@ -73,19 +73,19 @@ technical-resources/standards-and-guidelines/read-only-versions-of-ashrae-standa
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'VAV chiller with gas boiler reheat',
-        'VAV chiller with central air source heat pump reheat',
-        'VAV chiller with district hot water reheat',
-        'VAV chiller with PFP boxes',
-        'VAV chiller with gas coil reheat',
-        'VAV air-cooled chiller with gas boiler reheat',
-        'VAV air-cooled chiller with central air source heat pump reheat',
-        'VAV air-cooled chiller with district hot water reheat',
-        'VAV air-cooled chiller with PFP boxes',
-        'VAV air-cooled chiller with gas coil reheat',
-        'VAV district chilled water with gas boiler reheat',
-        'VAV district chilled water with central air source heat pump reheat',
-        'VAV district chilled water with district hot water reheat',
-        'VAV district chilled water with PFP boxes',
-        'VAV district chilled water with gas coil reheat'
+        'VAV_Chiller_Boiler',
+        'VAV_Chiller_ASHP',
+        'VAV_Chiller_DHW',
+        'VAV_Chiller_PFP',
+        'VAV_Chiller_GasCoil',
+        'VAV_ACChiller_Boiler',
+        'VAV_ACChiller_ASHP',
+        'VAV_ACChiller_DHW',
+        'VAV_ACChiller_PFP',
+        'VAV_ACChiller_GasCoil',
+        'VAV_DCW_Boiler',
+        'VAV_DCW_ASHP',
+        'VAV_DCW_DHW',
+        'VAV_DCW_PFP',
+        'VAV_DCW_GasCoil'
     )

--- a/honeybee_energy/hvac/doas/_base.py
+++ b/honeybee_energy/hvac/doas/_base.py
@@ -23,12 +23,12 @@ class _DOASBase(_TemplateSystem):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment.
             For example, 'DOAS with fan coil chiller with boiler'.
@@ -50,7 +50,7 @@ class _DOASBase(_TemplateSystem):
     """
     __slots__ = ('_sensible_heat_recovery', '_latent_heat_recovery')
 
-    def __init__(self, identifier, vintage='90.1-2013', equipment_type=None,
+    def __init__(self, identifier, vintage='ASHRAE_2013', equipment_type=None,
                  sensible_heat_recovery=autosize, latent_heat_recovery=autosize):
         """Initialize HVACSystem."""
         # initialize base HVAC system properties
@@ -105,7 +105,7 @@ class _DOASBase(_TemplateSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": "",  # text for the HVAC equipment type
             "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
             "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
@@ -145,7 +145,7 @@ class _DOASBase(_TemplateSystem):
             "type": "",  # text for the class name of the HVAC
             "identifier": "Classroom1_System",  # identifier for the HVAC
             "display_name": "Standard System",  # name for the HVAC
-            "vintage": "90.1-2013",  # text for the vintage of the template
+            "vintage": "ASHRAE_2013",  # text for the vintage of the template
             "equipment_type": "",  # text for the HVAC equipment type
             "sensible_heat_recovery": 0.75,  # Sensible heat recovery effectiveness
             "latent_heat_recovery": 0.7,  # Latent heat recovery effectiveness
@@ -195,12 +195,6 @@ class _DOASBase(_TemplateSystem):
 
     def __ne__(self, other):
         return not self.__eq__(other)
-
-    def __repr__(self):
-        return '{}: {}\n type: {}\n vintage: {}\n sensible recovery:' \
-            ' {} \n latent recovery: {}'.format(
-                self.__class__.__name__, self.identifier, self.equipment_type,
-                self.vintage, self.sensible_heat_recovery, self.latent_heat_recovery)
 
 
 class _DOASEnumeration(_EnumerationBase):

--- a/honeybee_energy/hvac/doas/fcu.py
+++ b/honeybee_energy/hvac/doas/fcu.py
@@ -22,34 +22,34 @@ class FCUwithDOAS(_DOASBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * DOAS with fan coil chiller with boiler
-            * DOAS with fan coil chiller with central air source heat pump
-            * DOAS with fan coil chiller with district hot water
-            * DOAS with fan coil chiller with baseboard electric
-            * DOAS with fan coil chiller with gas unit heaters
-            * DOAS with fan coil chiller with no heat
-            * DOAS with fan coil air-cooled chiller with boiler
-            * DOAS with fan coil air-cooled chiller with central air source heat pump
-            * DOAS with fan coil air-cooled chiller with district hot water
-            * DOAS with fan coil air-cooled chiller with baseboard electric
-            * DOAS with fan coil air-cooled chiller with gas unit heaters
-            * DOAS with fan coil air-cooled chiller with no heat
-            * DOAS with fan coil district chilled water with boiler
-            * DOAS with fan coil district chilled water with central air source heat pump
-            * DOAS with fan coil district chilled water with district hot water
-            * DOAS with fan coil district chilled water with baseboard electric
-            * DOAS with fan coil district chilled water with gas unit heaters
-            * DOAS with fan coil district chilled water with no heat
+            * DOAS_FCU_Chiller_Boiler
+            * DOAS_FCU_Chiller_ASHP
+            * DOAS_FCU_Chiller_DHW
+            * DOAS_FCU_Chiller_ElectricBaseboard
+            * DOAS_FCU_Chiller_GasHeaters
+            * DOAS_FCU_Chiller
+            * DOAS_FCU_ACChiller_Boiler
+            * DOAS_FCU_ACChiller_ASHP
+            * DOAS_FCU_ACChiller_DHW
+            * DOAS_FCU_ACChiller_ElectricBaseboard
+            * DOAS_FCU_ACChiller_GasHeaters
+            * DOAS_FCU_ACChiller
+            * DOAS_FCU_DCW_Boiler
+            * DOAS_FCU_DCW_ASHP
+            * DOAS_FCU_DCW_DHW
+            * DOAS_FCU_DCW_ElectricBaseboard
+            * DOAS_FCU_DCW_GasHeaters
+            * DOAS_FCU_DCW
 
         sensible_heat_recovery: A number between 0 and 1 for the effectiveness
             of sensible heat recovery within the system. If None, it will be
@@ -70,22 +70,22 @@ class FCUwithDOAS(_DOASBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'DOAS with fan coil chiller with boiler',
-        'DOAS with fan coil chiller with central air source heat pump',
-        'DOAS with fan coil chiller with district hot water',
-        'DOAS with fan coil chiller with baseboard electric',
-        'DOAS with fan coil chiller with gas unit heaters',
-        'DOAS with fan coil chiller with no heat',
-        'DOAS with fan coil air-cooled chiller with boiler',
-        'DOAS with fan coil air-cooled chiller with central air source heat pump',
-        'DOAS with fan coil air-cooled chiller with district hot water',
-        'DOAS with fan coil air-cooled chiller with baseboard electric',
-        'DOAS with fan coil air-cooled chiller with gas unit heaters',
-        'DOAS with fan coil air-cooled chiller with no heat',
-        'DOAS with fan coil district chilled water with boiler',
-        'DOAS with fan coil district chilled water with central air source heat pump',
-        'DOAS with fan coil district chilled water with district hot water',
-        'DOAS with fan coil district chilled water with baseboard electric',
-        'DOAS with fan coil district chilled water with gas unit heaters',
-        'DOAS with fan coil district chilled water with no heat'
+        'DOAS_FCU_Chiller_Boiler',
+        'DOAS_FCU_Chiller_ASHP',
+        'DOAS_FCU_Chiller_DHW',
+        'DOAS_FCU_Chiller_ElectricBaseboard',
+        'DOAS_FCU_Chiller_GasHeaters',
+        'DOAS_FCU_Chiller',
+        'DOAS_FCU_ACChiller_Boiler',
+        'DOAS_FCU_ACChiller_ASHP',
+        'DOAS_FCU_ACChiller_DHW',
+        'DOAS_FCU_ACChiller_ElectricBaseboard',
+        'DOAS_FCU_ACChiller_GasHeaters',
+        'DOAS_FCU_ACChiller',
+        'DOAS_FCU_DCW_Boiler',
+        'DOAS_FCU_DCW_ASHP',
+        'DOAS_FCU_DCW_DHW',
+        'DOAS_FCU_DCW_ElectricBaseboard',
+        'DOAS_FCU_DCW_GasHeaters',
+        'DOAS_FCU_DCW'
     )

--- a/honeybee_energy/hvac/doas/vrf.py
+++ b/honeybee_energy/hvac/doas/vrf.py
@@ -19,17 +19,17 @@ class VRFwithDOAS(_DOASBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * DOAS with VRF
+            * DOAS_VRF
 
         sensible_heat_recovery: A number between 0 and 1 for the effectiveness
             of sensible heat recovery within the system. If None, it will be
@@ -49,4 +49,4 @@ class VRFwithDOAS(_DOASBase):
     """
     __slots__ = ()
 
-    EQUIPMENT_TYPES = ('DOAS with VRF',)
+    EQUIPMENT_TYPES = ('DOAS_VRF',)

--- a/honeybee_energy/hvac/doas/wshp.py
+++ b/honeybee_energy/hvac/doas/wshp.py
@@ -19,20 +19,20 @@ class WSHPwithDOAS(_DOASBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * DOAS with water source heat pumps fluid cooler with boiler
-            * DOAS with water source heat pumps cooling tower with boiler
-            * DOAS with water source heat pumps with ground source heat pump
-            * DOAS with water source heat pumps district chilled water with district hot water
+            * DOAS_WSHP_FluidCooler_Boiler
+            * DOAS_WSHP_CoolingTower_Boiler
+            * DOAS_WSHP_GSHP
+            * DOAS_WSHP_DCW_DHW
 
         sensible_heat_recovery: A number between 0 and 1 for the effectiveness
             of sensible heat recovery within the system. If None, it will be
@@ -53,8 +53,8 @@ class WSHPwithDOAS(_DOASBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'DOAS with water source heat pumps fluid cooler with boiler',
-        'DOAS with water source heat pumps cooling tower with boiler',
-        'DOAS with water source heat pumps with ground source heat pump',
-        'DOAS with water source heat pumps district chilled water with district hot water'
+        'DOAS_WSHP_FluidCooler_Boiler',
+        'DOAS_WSHP_CoolingTower_Boiler',
+        'DOAS_WSHP_GSHP',
+        'DOAS_WSHP_DCW_DHW'
     )

--- a/honeybee_energy/hvac/heatcool/_base.py
+++ b/honeybee_energy/hvac/heatcool/_base.py
@@ -21,12 +21,12 @@ class _HeatCoolBase(_TemplateSystem):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment.
             For example, 'Baseboard gas boiler'.

--- a/honeybee_energy/hvac/heatcool/baseboard.py
+++ b/honeybee_energy/hvac/heatcool/baseboard.py
@@ -19,20 +19,20 @@ class Baseboard(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Baseboard electric
-            * Baseboard gas boiler
-            * Baseboard central air source heat pump
-            * Baseboard district hot water
+            * ElectricBaseboard
+            * BoilerBaseboard
+            * ASHPBaseboard
+            * DHWBaseboard
 
     Properties:
         * identifier
@@ -44,8 +44,8 @@ class Baseboard(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Baseboard electric',
-        'Baseboard gas boiler',
-        'Baseboard central air source heat pump',
-        'Baseboard district hot water'
+        'ElectricBaseboard',
+        'BoilerBaseboard',
+        'ASHPBaseboard',
+        'DHWBaseboard'
     )

--- a/honeybee_energy/hvac/heatcool/evapcool.py
+++ b/honeybee_energy/hvac/heatcool/evapcool.py
@@ -19,23 +19,23 @@ class EvaporativeCooler(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Direct evap coolers with baseboard electric
-            * Direct evap coolers with baseboard gas boiler
-            * Direct evap coolers with baseboard central air source heat pump
-            * Direct evap coolers with baseboard district hot water
-            * Direct evap coolers with forced air furnace
-            * Direct evap coolers with gas unit heaters
-            * Direct evap coolers with no heat
+            * EvapCoolers_ElectricBaseboard
+            * EvapCoolers_BoilerBaseboard
+            * EvapCoolers_ASHPBaseboard
+            * EvapCoolers_DHWBaseboard
+            * EvapCoolers_Furnace
+            * EvapCoolers_UnitHeaters
+            * EvapCoolers
 
     Properties:
         * identifier
@@ -47,11 +47,11 @@ class EvaporativeCooler(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Direct evap coolers with baseboard electric',
-        'Direct evap coolers with baseboard gas boiler',
-        'Direct evap coolers with baseboard central air source heat pump',
-        'Direct evap coolers with baseboard district hot water',
-        'Direct evap coolers with forced air furnace',
-        'Direct evap coolers with gas unit heaters',
-        'Direct evap coolers with no heat'
+        'EvapCoolers_ElectricBaseboard',
+        'EvapCoolers_BoilerBaseboard',
+        'EvapCoolers_ASHPBaseboard',
+        'EvapCoolers_DHWBaseboard',
+        'EvapCoolers_Furnace',
+        'EvapCoolers_UnitHeaters',
+        'EvapCoolers'
     )

--- a/honeybee_energy/hvac/heatcool/fcu.py
+++ b/honeybee_energy/hvac/heatcool/fcu.py
@@ -19,34 +19,34 @@ class FCU(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Fan coil chiller with boiler
-            * Fan coil chiller with central air source heat pump
-            * Fan coil chiller with district hot water
-            * Fan coil chiller with baseboard electric
-            * Fan coil chiller with gas unit heaters
-            * Fan coil chiller with no heat
-            * Fan coil air-cooled chiller with boiler
-            * Fan coil air-cooled chiller with central air source heat pump
-            * Fan coil air-cooled chiller with district hot water
-            * Fan coil air-cooled chiller with baseboard electric
-            * Fan coil air-cooled chiller with gas unit heaters
-            * Fan coil air-cooled chiller with no heat
-            * Fan coil district chilled water with boiler
-            * Fan coil district chilled water with central air source heat pump
-            * Fan coil district chilled water with district hot water
-            * Fan coil district chilled water with baseboard electric
-            * Fan coil district chilled water with gas unit heaters
-            * Fan coil district chilled water with no heat
+            * FCU_Chiller_Boiler
+            * FCU_Chiller_ASHP
+            * FCU_Chiller_DHW
+            * FCU_Chiller_ElectricBaseboard
+            * FCU_Chiller_GasHeaters
+            * FCU_Chiller
+            * FCU_ACChiller_Boiler
+            * FCU_ACChiller_ASHP
+            * FCU_ACChiller_DHW
+            * FCU_ACChiller_ElectricBaseboard
+            * FCU_ACChiller_GasHeaters
+            * FCU_ACChiller
+            * FCU_DCW_Boiler
+            * FCU_DCW_ASHP
+            * FCU_DCW_DHW
+            * FCU_DCW_ElectricBaseboard
+            * FCU_DCW_GasHeaters
+            * FCU_DCW
 
     Properties:
         * identifier
@@ -58,22 +58,22 @@ class FCU(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Fan coil chiller with boiler',
-        'Fan coil chiller with central air source heat pump',
-        'Fan coil chiller with district hot water',
-        'Fan coil chiller with baseboard electric',
-        'Fan coil chiller with gas unit heaters',
-        'Fan coil chiller with no heat',
-        'Fan coil air-cooled chiller with boiler',
-        'Fan coil air-cooled chiller with central air source heat pump',
-        'Fan coil air-cooled chiller with district hot water',
-        'Fan coil air-cooled chiller with baseboard electric',
-        'Fan coil air-cooled chiller with gas unit heaters',
-        'Fan coil air-cooled chiller with no heat',
-        'Fan coil district chilled water with boiler',
-        'Fan coil district chilled water with central air source heat pump',
-        'Fan coil district chilled water with district hot water',
-        'Fan coil district chilled water with baseboard electric',
-        'Fan coil district chilled water with gas unit heaters',
-        'Fan coil district chilled water with no heat'
+        'FCU_Chiller_Boiler',
+        'FCU_Chiller_ASHP',
+        'FCU_Chiller_DHW',
+        'FCU_Chiller_ElectricBaseboard',
+        'FCU_Chiller_GasHeaters',
+        'FCU_Chiller',
+        'FCU_ACChiller_Boiler',
+        'FCU_ACChiller_ASHP',
+        'FCU_ACChiller_DHW',
+        'FCU_ACChiller_ElectricBaseboard',
+        'FCU_ACChiller_GasHeaters',
+        'FCU_ACChiller',
+        'FCU_DCW_Boiler',
+        'FCU_DCW_ASHP',
+        'FCU_DCW_DHW',
+        'FCU_DCW_ElectricBaseboard',
+        'FCU_DCW_GasHeaters',
+        'FCU_DCW'
     )

--- a/honeybee_energy/hvac/heatcool/gasunit.py
+++ b/honeybee_energy/hvac/heatcool/gasunit.py
@@ -19,17 +19,17 @@ class GasUnitHeater(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Gas unit heaters
+            * GasHeaters
 
     Properties:
         * identifier
@@ -40,4 +40,4 @@ class GasUnitHeater(_HeatCoolBase):
     """
     __slots__ = ()
 
-    EQUIPMENT_TYPES = ('Gas unit heaters',)
+    EQUIPMENT_TYPES = ('GasHeaters',)

--- a/honeybee_energy/hvac/heatcool/residential.py
+++ b/honeybee_energy/hvac/heatcool/residential.py
@@ -19,25 +19,25 @@ class Residential(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Residential AC with baseboard electric
-            * Residential AC with baseboard gas boiler
-            * Residential AC with baseboard central air source heat pump
-            * Residential AC with baseboard district hot water
-            * Residential AC with residential forced air furnace
-            * Residential AC with no heat
-            * Residential heat pump
-            * Residential heat pump with no cooling
-            * Residential forced air furnace
+            * ResidentialAC_ElectricBaseboard
+            * ResidentialAC_BoilerBaseboard
+            * ResidentialAC_ASHPBaseboard
+            * ResidentialAC_DHWBaseboard
+            * ResidentialAC_ResidentialFurnace
+            * ResidentialAC
+            * ResidentialHP
+            * ResidentialHPNoCool
+            * ResidentialFurnace
 
     Properties:
         * identifier
@@ -49,13 +49,13 @@ class Residential(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Residential AC with baseboard electric',
-        'Residential AC with baseboard gas boiler',
-        'Residential AC with baseboard central air source heat pump',
-        'Residential AC with baseboard district hot water',
-        'Residential AC with residential forced air furnace',
-        'Residential AC with no heat',
-        'Residential heat pump',
-        'Residential heat pump with no cooling',
-        'Residential forced air furnace'
+        'ResidentialAC_ElectricBaseboard',
+        'ResidentialAC_BoilerBaseboard',
+        'ResidentialAC_ASHPBaseboard',
+        'ResidentialAC_DHWBaseboard',
+        'ResidentialAC_ResidentialFurnace',
+        'ResidentialAC',
+        'ResidentialHP',
+        'ResidentialHPNoCool',
+        'ResidentialFurnace'
     )

--- a/honeybee_energy/hvac/heatcool/vrf.py
+++ b/honeybee_energy/hvac/heatcool/vrf.py
@@ -19,12 +19,12 @@ class VRF(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.

--- a/honeybee_energy/hvac/heatcool/windowac.py
+++ b/honeybee_energy/hvac/heatcool/windowac.py
@@ -19,23 +19,23 @@ class WindowAC(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Window AC with baseboard electric
-            * Window AC with baseboard gas boiler
-            * Window AC with baseboard central air source heat pump
-            * Window AC with baseboard district hot water
-            * Window AC with forced air furnace
-            * Window AC with unit heaters
-            * Window AC with no heat
+            * WindowAC_ElectricBaseboard
+            * WindowAC_BoilerBaseboard
+            * WindowAC_ASHPBaseboard
+            * WindowAC_DHWBaseboard
+            * WindowAC_Furnace
+            * WindowAC_GasHeaters
+            * WindowAC
 
     Properties:
         * identifier
@@ -47,11 +47,11 @@ class WindowAC(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Window AC with baseboard electric',
-        'Window AC with baseboard gas boiler',
-        'Window AC with baseboard central air source heat pump',
-        'Window AC with baseboard district hot water',
-        'Window AC with forced air furnace',
-        'Window AC with unit heaters',
-        'Window AC with no heat'
+        'WindowAC_ElectricBaseboard',
+        'WindowAC_BoilerBaseboard',
+        'WindowAC_ASHPBaseboard',
+        'WindowAC_DHWBaseboard',
+        'WindowAC_Furnace',
+        'WindowAC_GasHeaters',
+        'WindowAC'
     )

--- a/honeybee_energy/hvac/heatcool/wshp.py
+++ b/honeybee_energy/hvac/heatcool/wshp.py
@@ -19,20 +19,20 @@ class WSHP(_HeatCoolBase):
             to set efficiencies for various pieces of equipment within the system.
             Choose from the following.
 
-            * DOE Ref Pre-1980
-            * DOE Ref 1980-2004
-            * 90.1-2004
-            * 90.1-2007
-            * 90.1-2010
-            * 90.1-2013
+            * DOE_Ref_Pre_1980
+            * DOE_Ref_1980_2004
+            * ASHRAE_2004
+            * ASHRAE_2007
+            * ASHRAE_2010
+            * ASHRAE_2013
 
         equipment_type: Text for the specific type of the system and equipment. (Default:
             the first option below) Choose from.
 
-            * Water source heat pumps fluid cooler with boiler
-            * Water source heat pumps cooling tower with boiler
-            * Water source heat pumps with ground source heat pump
-            * Water source heat pumps district chilled water with district hot water
+            * WSHP_FluidCooler_Boiler
+            * WSHP_CoolingTower_Boiler
+            * WSHP_GSHP
+            * WSHP_DCW_DHW
 
     Properties:
         * identifier
@@ -44,8 +44,8 @@ class WSHP(_HeatCoolBase):
     __slots__ = ()
 
     EQUIPMENT_TYPES = (
-        'Water source heat pumps fluid cooler with boiler',
-        'Water source heat pumps cooling tower with boiler',
-        'Water source heat pumps with ground source heat pump',
-        'Water source heat pumps district chilled water with district hot water'
+        'WSHP_FluidCooler_Boiler',
+        'WSHP_CoolingTower_Boiler',
+        'WSHP_GSHP',
+        'WSHP_DCW_DHW'
     )

--- a/honeybee_energy/hvac/idealair.py
+++ b/honeybee_energy/hvac/idealair.py
@@ -620,7 +620,4 @@ class IdealAirSystem(_HVACSystem):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'IdealAirSystem: {}\n economizer: {}\n dcv: {}\n sensible recovery: {}' \
-            '\n latent recovery: {}'.format(
-                self.identifier, self.economizer_type, self.demand_controlled_ventilation,
-                self.sensible_heat_recovery, self.latent_heat_recovery)
+        return 'IdealAirSystem: {}'.format(self.display_name)

--- a/honeybee_energy/load/_base.py
+++ b/honeybee_energy/load/_base.py
@@ -119,4 +119,4 @@ class _LoadBase(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Load Base: {}'.format(self.identifier)
+        return 'Load Base: {}'.format(self.display_name)

--- a/honeybee_energy/load/equipment.py
+++ b/honeybee_energy/load/equipment.py
@@ -244,8 +244,9 @@ class _EquipmentBase(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'Equipment:\n name: {}\n watts per area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.watts_per_area, self.schedule.identifier)
+        return '{}: {} [{} W/m2] [schedule: {}]'.format(
+            self.__class__.__name__, self.display_name, round(self.watts_per_area, 1),
+            self.schedule.display_name)
 
 
 @lockable
@@ -455,10 +456,6 @@ class ElectricEquipment(_EquipmentBase):
         new_obj._display_name = self._display_name
         return new_obj
 
-    def __repr__(self):
-        return 'ElectricEquipment:\n name: {}\n watts per area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.watts_per_area, self.schedule.identifier)
-
 
 @lockable
 class GasEquipment(_EquipmentBase):
@@ -665,7 +662,3 @@ class GasEquipment(_EquipmentBase):
             self.radiant_fraction, self.latent_fraction, self.lost_fraction)
         new_obj._display_name = self._display_name
         return new_obj
-
-    def __repr__(self):
-        return 'GasEquipment:\n name: {}\n watts per area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.watts_per_area, self.schedule.identifier)

--- a/honeybee_energy/load/hotwater.py
+++ b/honeybee_energy/load/hotwater.py
@@ -465,5 +465,5 @@ class ServiceHotWater(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'ServiceHotWater:\n name: {}\n flow per area: {} L/h-m2\n schedule: ' \
-            '{}'.format(self.identifier, self.flow_per_area, self.schedule.identifier)
+        return 'ServiceHotWater: {} [{} L/h-m2] [schedule: {}]'.format(
+            self.identifier, self.flow_per_area, self.schedule.identifier)

--- a/honeybee_energy/load/infiltration.py
+++ b/honeybee_energy/load/infiltration.py
@@ -400,6 +400,6 @@ class Infiltration(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'Infiltration:\n name: {}\n flow per exterior area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.flow_per_exterior_area,
-                        self.schedule.identifier)
+        return 'Infiltration: {} [{} m3/s-m2] [schedule: {}]'.format(
+            self.display_name, round(self.flow_per_exterior_area, 6),
+            self.schedule.display_name)

--- a/honeybee_energy/load/lighting.py
+++ b/honeybee_energy/load/lighting.py
@@ -398,5 +398,6 @@ class Lighting(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'Lighting:\n name: {}\n watts per area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.watts_per_area, self.schedule.identifier)
+        return 'Lighting: {} [{} W/m2] [schedule: {}]'.format(
+            self.display_name, round(self.watts_per_area, 1),
+            self.schedule.display_name)

--- a/honeybee_energy/load/people.py
+++ b/honeybee_energy/load/people.py
@@ -413,6 +413,6 @@ class People(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'People:\n name: {}\n people per area: {}\n schedule: ' \
-            '{}'.format(self.identifier, self.people_per_area,
-                        self.occupancy_schedule.identifier)
+        return 'People: {} [{} people/m2] [schedule: {}]'.format(
+            self.display_name, round(self.people_per_area, 3),
+            self.occupancy_schedule.display_name)

--- a/honeybee_energy/load/setpoint.py
+++ b/honeybee_energy/load/setpoint.py
@@ -584,7 +584,6 @@ class Setpoint(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'Setpoint:\n name: {}\n heating: {}\n cooling: ' \
-            '{}\n humidifying: {}\n dehumidifying: {}'.format(
-                self.identifier, self.heating_setpoint, self.cooling_setpoint,
-                self.humidifying_setpoint, self.dehumidifying_setpoint)
+        return 'Setpoint: {} [heating: {}C] [cooling: {}C]'.format(
+            self.display_name, round(self.heating_setpoint, 1),
+            round(self.cooling_setpoint, 1))

--- a/honeybee_energy/load/ventilation.py
+++ b/honeybee_energy/load/ventilation.py
@@ -404,7 +404,6 @@ class Ventilation(_LoadBase):
         return new_obj
 
     def __repr__(self):
-        return 'Ventilation:\n name: {}\n flow per person: {}\n flow per area: ' \
-            '{}\n flow per zone: {}\n ACH: {}'.format(
-                self.identifier, self.flow_per_person, self.flow_per_area,
-                self.flow_per_zone, self.air_changes_per_hour)
+        return 'Ventilation: {} [{} m3/s-person] [{} m3/s-m2] [{} ACH]'.format(
+            self.display_name, round(self.flow_per_person, 4),
+            round(self.flow_per_area, 6), round(self.air_changes_per_hour, 2))

--- a/honeybee_energy/material/_base.py
+++ b/honeybee_energy/material/_base.py
@@ -67,7 +67,7 @@ class _EnergyMaterialBase(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Base Energy Material:\n{}'.format(self.identifier)
+        return 'Base Energy Material:\n{}'.format(self.display_name)
 
 
 @lockable
@@ -85,7 +85,7 @@ class _EnergyMaterialOpaqueBase(_EnergyMaterialBase):
         return False
 
     def __repr__(self):
-        return 'Base Opaque Energy Material:\n{}'.format(self.identifier)
+        return 'Base Opaque Energy Material:\n{}'.format(self.display_name)
 
 
 @lockable
@@ -114,4 +114,4 @@ class _EnergyMaterialWindowBase(_EnergyMaterialBase):
         return False
 
     def __repr__(self):
-        return 'Base Window Energy Material:\n{}'.format(self.identifier)
+        return 'Base Window Energy Material:\n{}'.format(self.display_name)

--- a/honeybee_energy/measure.py
+++ b/honeybee_energy/measure.py
@@ -278,7 +278,7 @@ class Measure(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Measure: {}'.format(self.identifier)
+        return 'Measure: {}'.format(self.display_name)
 
 
 class MeasureArgument(object):
@@ -448,4 +448,4 @@ class MeasureArgument(object):
         return self.__repr__()
 
     def __repr__(self):
-        return '{} <{}> value: {}'.format(self.identifier, self.type_text, self.value)
+        return '{} <{}> value: {}'.format(self.display_name, self.type_text, self.value)

--- a/honeybee_energy/programtype.py
+++ b/honeybee_energy/programtype.py
@@ -595,4 +595,4 @@ class ProgramType(object):
         return not self.__eq__(other)
 
     def __repr__(self):
-        return 'Program Type: {}'.format(self.identifier)
+        return 'Program Type: {}'.format(self.display_name)

--- a/honeybee_energy/properties/aperture.py
+++ b/honeybee_energy/properties/aperture.py
@@ -192,4 +192,4 @@ class ApertureEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Aperture Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Aperture Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/properties/door.py
+++ b/honeybee_energy/properties/door.py
@@ -199,4 +199,4 @@ class DoorEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Door Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Door Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -186,4 +186,4 @@ class FaceEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Face Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Face Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -691,4 +691,4 @@ class ModelEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Model Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Model Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -1014,4 +1014,4 @@ class RoomEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Room Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Room Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/properties/shade.py
+++ b/honeybee_energy/properties/shade.py
@@ -214,4 +214,4 @@ class ShadeEnergyProperties(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Shade Energy Properties:\n host: {}'.format(self.host.identifier)
+        return 'Shade Energy Properties: [host: {}]'.format(self.host.display_name)

--- a/honeybee_energy/result/colorobj.py
+++ b/honeybee_energy/result/colorobj.py
@@ -238,7 +238,7 @@ class _ColorObject(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'Color Object'
+        return 'Color Object:'
 
 
 class ColorRoom(_ColorObject):
@@ -427,7 +427,7 @@ class ColorRoom(_ColorObject):
 
     def __repr__(self):
         """Color Room representation."""
-        return 'Color Room:\n{} Rooms\n{}'.format(
+        return 'Color Room: [{} Rooms] [{}]'.format(
             len(self._matched_objects), self._base_collection.header)
 
 
@@ -604,5 +604,5 @@ class ColorFace(_ColorObject):
 
     def __repr__(self):
         """Color Face representation."""
-        return 'Color Face:\n{} Objects\n{}'.format(
+        return 'Color Face: [{} Objects] [{}]'.format(
             len(self._matched_objects), self._base_collection.header)

--- a/honeybee_energy/result/loadbalance.py
+++ b/honeybee_energy/result/loadbalance.py
@@ -644,4 +644,4 @@ class LoadBalance(object):
 
     def __repr__(self):
         """Load Balance representation."""
-        return 'Load Balance:\n{} Rooms'.format(len(self.rooms))
+        return 'Load Balance: [{} Rooms]'.format(len(self.rooms))

--- a/honeybee_energy/schedule/fixedinterval.py
+++ b/honeybee_energy/schedule/fixedinterval.py
@@ -833,6 +833,6 @@ class ScheduleFixedInterval(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'ScheduleFixedInterval:\n name: {}\n period: {} - {}\n timestep: ' \
-            '{}'.format(self.identifier, self.start_date, self.end_date_time.strftime('%d %b'),
-                        self.timestep)
+        return 'ScheduleFixedInterval: {} [{} - {}] [timestep: {}]'.format(
+            self.display_name, self.start_date,
+            self.end_date_time.strftime('%d %b'), self.timestep)

--- a/honeybee_energy/schedule/rule.py
+++ b/honeybee_energy/schedule/rule.py
@@ -605,6 +605,6 @@ class ScheduleRule(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'ScheduleRule:\n schedule_day: {}\n days applied: {}\n date_range: ' \
-            '{} - {}'.format(self.schedule_day.identifier, ', '.join(self.days_applied),
-                             self.start_date, self.end_date)
+        return 'ScheduleRule: {} [days applied: {}] [date range: {} - {}]'.format(
+            self.schedule_day.display_name, ', '.join(self.days_applied),
+            self.start_date, self.end_date)

--- a/honeybee_energy/schedule/ruleset.py
+++ b/honeybee_energy/schedule/ruleset.py
@@ -1400,7 +1400,6 @@ class ScheduleRuleset(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'ScheduleRuleset:\n name: {}\n default_day: {}\n' \
-            ' schedule_rules:\n  {}'.format(
-                self.identifier, self.default_day_schedule.identifier,
-                '\n  '.join([rule.schedule_day.identifier for rule in self._schedule_rules]))
+        return 'ScheduleRuleset: {} [default day: {}] [{} rules]'.format(
+            self.display_name, self.default_day_schedule.display_name,
+            len(self._schedule_rules))

--- a/honeybee_energy/simulation/sizing.py
+++ b/honeybee_energy/simulation/sizing.py
@@ -325,5 +325,5 @@ class SizingParameter(object):
         return item in self._design_days
 
     def __repr__(self):
-        return 'SizingParameter:\n {} design days\n heating: {}\n cooling: ' \
-            '{}'.format(len(self._design_days), self.heating_factor, self.cooling_factor)
+        return 'SizingParameter: [{} design days] [heating: {}] [cooling: {}]'.format(
+            len(self._design_days), self.heating_factor, self.cooling_factor)

--- a/honeybee_energy/ventcool/control.py
+++ b/honeybee_energy/ventcool/control.py
@@ -259,10 +259,8 @@ class VentilationControl(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'VentilationControl,\n min in temperature: {}\n ' \
-            'max in temperature: {}\n min out temperature: {}\n ' \
-            'max out temperature: {}\n delta temperature: {}\n' \
-            'schedule: {}'.format(
+        return 'VentilationControl, [min in: {}] [max in: {}] [min out: {}] ' \
+            '[max out: {}] [delta: {}]'.format(
                 self.min_indoor_temperature, self.max_indoor_temperature,
                 self.min_outdoor_temperature, self.max_outdoor_temperature,
-                self.delta_temperature, self.schedule.identifier)
+                self.delta_temperature)

--- a/honeybee_energy/ventcool/crack.py
+++ b/honeybee_energy/ventcool/crack.py
@@ -122,5 +122,5 @@ class AFNCrack(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'AFNCrack,\n flow_coefficient: {}\n ' \
-            'flow_exponent: {}'.format(self.flow_coefficient, self.flow_exponent)
+        return 'AFNCrack: [coefficient: {}] [exponent: {}]'.format(
+            self.flow_coefficient, self.flow_exponent)

--- a/honeybee_energy/ventcool/opening.py
+++ b/honeybee_energy/ventcool/opening.py
@@ -342,11 +342,7 @@ class VentilationOpening(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'VentilationOpening,\n fraction area: {}\n ' \
-            'fraction height: {}\n discharge coeff: {}\n ' \
-            'flow_coefficient_closed: {}\n flow_exponent_closed: ' \
-            '{}\n two_way_threshold: {}'.format(
+        return 'VentilationOpening: [fraction area: {}] ' \
+            '[fraction height: {}] [discharge: {}]'.format(
                 self.fraction_area_operable, self.fraction_height_operable,
-                self.discharge_coefficient, self.flow_coefficient_closed,
-                self.flow_exponent_closed,
-                self.two_way_threshold)
+                self.discharge_coefficient)

--- a/honeybee_energy/ventcool/simulation.py
+++ b/honeybee_energy/ventcool/simulation.py
@@ -308,10 +308,7 @@ class VentilationSimulationControl(object):
         return self.__repr__()
 
     def __repr__(self):
-        return 'VentilationSimulationControl,\n vent_control_type: {}\n ' \
-            'reference_temperature: {}\n reference_pressure: {}\n ' \
-            'reference_humidity_ratio: {}\n building_type: {}\n long_axis_angle: {}\n' \
-            ' aspect_ratio: {}' .format(
-                self.vent_control_type, self.reference_temperature,
-                self.reference_pressure, self.reference_humidity_ratio,
-                self.building_type, self.long_axis_angle, self.aspect_ratio)
+        return 'VentilationSimulationControl: [control type: {}] ' \
+            '[building_type: {}] [long axis: {}] [aspect_ratio: {}]' .format(
+                self.vent_control_type, self.building_type,
+                round(self.long_axis_angle), round(self.aspect_ratio, 2))

--- a/tests/cli_baseline_test.py
+++ b/tests/cli_baseline_test.py
@@ -47,8 +47,8 @@ def test_hvac_2004():
     new_model = Model.from_dict(model_dict)
     new_hvac = new_model.rooms[0].properties.energy.hvac
     assert isinstance(new_hvac, VAV)
-    assert new_hvac.vintage == '90.1-2004'
-    assert new_hvac.equipment_type == 'VAV chiller with gas boiler reheat'
+    assert new_hvac.vintage == 'ASHRAE_2004'
+    assert new_hvac.equipment_type == 'VAV_Chiller_Boiler'
     assert new_hvac.economizer_type == 'DifferentialDryBulb'
 
 

--- a/tests/hvac_allair_test.py
+++ b/tests/hvac_allair_test.py
@@ -20,19 +20,19 @@ def test_vav_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'VAV chiller with gas boiler reheat'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'VAV_Chiller_Boiler'
     assert hvac_sys.economizer_type == 'Inferred'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'VAV district chilled water with district hot water reheat'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'VAV_DCW_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'VAV district chilled water with district hot water reheat'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'VAV_DCW_DHW'
     assert hvac_sys.economizer_type == 'DifferentialDryBulb'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
@@ -75,8 +75,8 @@ def test_vav_multi_room():
 def test_vav_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = VAV('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'VAV district chilled water with district hot water reheat'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'VAV_DCW_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
@@ -93,19 +93,19 @@ def test_pvav_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'PVAV with gas boiler reheat'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'PVAV_Boiler'
     assert hvac_sys.economizer_type == 'Inferred'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PVAV with district hot water reheat'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PVAV_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'PVAV with district hot water reheat'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PVAV_DHW'
     assert hvac_sys.economizer_type == 'DifferentialDryBulb'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
@@ -148,8 +148,8 @@ def test_pvav_multi_room():
 def test_pvav_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = PVAV('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PVAV with district hot water reheat'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PVAV_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
@@ -166,19 +166,19 @@ def test_psz_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'PSZ-AC with baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'PSZAC_ElectricBaseboard'
     assert hvac_sys.economizer_type == 'Inferred'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PSZ-AC district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PSZAC_DCW_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'PSZ-AC district chilled water with district hot water'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PSZAC_DCW_DHW'
     assert hvac_sys.economizer_type == 'DifferentialDryBulb'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
@@ -221,8 +221,8 @@ def test_psz_multi_room():
 def test_psz_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = PSZ('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PSZ-AC district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PSZAC_DCW_DHW'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
@@ -239,22 +239,22 @@ def test_ptac_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'PTAC with baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'PTAC_ElectricBaseboard'
     assert hvac_sys.economizer_type == 'Inferred'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PTAC with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PTAC_DHW'
     with pytest.raises(AssertionError):
         hvac_sys.economizer_type = 'DifferentialDryBulb'
     with pytest.raises(AssertionError):
         hvac_sys.sensible_heat_recovery = 0.8
     with pytest.raises(AssertionError):
         hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'PTAC with district hot water'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PTAC_DHW'
 
 
 def test_ptac_equality():
@@ -262,12 +262,12 @@ def test_ptac_equality():
     hvac_sys = PTAC('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
     hvac_sys_alt = PTAC(
-        'Test System', equipment_type='PTAC with district hot water')
+        'Test System', equipment_type='PTAC_DHW')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys_dup.equipment_type = 'PTAC with gas coil'
+    hvac_sys_dup.equipment_type = 'PTAC_GasCoil'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -275,8 +275,8 @@ def test_ptac_equality():
 def test_ptac_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = PTAC('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'PTAC with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PTAC_DHW'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = PTAC.from_dict(hvac_dict)
@@ -290,19 +290,19 @@ def test_furnace_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Forced air furnace'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'Furnace'
     assert hvac_sys.economizer_type == 'Inferred'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     with pytest.raises(ValueError):
         hvac_sys.equipment_type = 'Air furnace'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
     assert hvac_sys.economizer_type == 'DifferentialDryBulb'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
@@ -326,7 +326,7 @@ def test_furnace_equality():
 def test_furnace_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = ForcedAirFurnace('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     hvac_sys.economizer_type = 'DifferentialDryBulb'
     hvac_sys.sensible_heat_recovery = 0.8
 

--- a/tests/hvac_doas_test.py
+++ b/tests/hvac_doas_test.py
@@ -18,17 +18,17 @@ def test_fcu_with_doas_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'DOAS with fan coil chiller with boiler'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'DOAS_FCU_Chiller_Boiler'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'DOAS with fan coil district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DOAS_FCU_DCW_DHW'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'DOAS with fan coil district chilled water with district hot water'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'DOAS_FCU_DCW_DHW'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
 
@@ -70,8 +70,8 @@ def test_fcu_with_doas_multi_room():
 def test_fcu_with_doas_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = FCUwithDOAS('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'DOAS with fan coil district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DOAS_FCU_DCW_DHW'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
 
@@ -87,17 +87,17 @@ def test_vrf_with_doas_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'DOAS with VRF'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'DOAS_VRF'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     with pytest.raises(ValueError):
         hvac_sys.equipment_type = 'DOAS with ground sourced VRF'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
 
@@ -120,7 +120,7 @@ def test_vrf_with_doas_equality():
 def test_vrf_with_doas_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = VRFwithDOAS('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
 
@@ -136,17 +136,17 @@ def test_wshp_with_doas_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'DOAS with water source heat pumps fluid cooler with boiler'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'DOAS_WSHP_FluidCooler_Boiler'
     assert hvac_sys.sensible_heat_recovery == autosize
     assert hvac_sys.latent_heat_recovery == autosize
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'DOAS with water source heat pumps with ground source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DOAS_WSHP_GSHP'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'DOAS with water source heat pumps with ground source heat pump'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'DOAS_WSHP_GSHP'
     assert hvac_sys.sensible_heat_recovery == 0.8
     assert hvac_sys.latent_heat_recovery == 0.65
 
@@ -169,8 +169,8 @@ def test_wshp_with_doas_equality():
 def test_wshp_with_doas_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = WSHPwithDOAS('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'DOAS with water source heat pumps with ground source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DOAS_WSHP_GSHP'
     hvac_sys.sensible_heat_recovery = 0.8
     hvac_sys.latent_heat_recovery = 0.65
 

--- a/tests/hvac_heatcool_test.py
+++ b/tests/hvac_heatcool_test.py
@@ -22,27 +22,25 @@ def test_fcu_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Fan coil chiller with boiler'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'FCU_Chiller_Boiler'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Fan coil district chilled water with district hot water'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Fan coil district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'FCU_DCW_DHW'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'FCU_DCW_DHW'
 
 
 def test_fcu_equality():
     """Test the equality of FCU objects."""
     hvac_sys = FCU('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
-    hvac_sys_alt = FCU(
-        'Test System',
-        equipment_type='Fan coil air-cooled chiller with central air source heat pump')
+    hvac_sys_alt = FCU('Test System', equipment_type='FCU_ACChiller_ASHP')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -69,8 +67,8 @@ def test_fcu_multi_room():
 def test_fcu_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = FCU('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Fan coil district chilled water with district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'FCU_DCW_DHW'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = FCU.from_dict(hvac_dict)
@@ -84,25 +82,25 @@ def test_vrf_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
     assert hvac_sys.equipment_type == 'VRF'
 
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     with pytest.raises(ValueError):
         hvac_sys.equipment_type = 'Ground sourced VRF'
-    assert hvac_sys.vintage == '90.1-2010'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
 
 
 def test_vrf_equality():
     """Test the equality of VRF objects."""
     hvac_sys = VRF('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
-    hvac_sys_alt = VRF('Test System', vintage='90.1-2010')
+    hvac_sys_alt = VRF('Test System', vintage='ASHRAE_2010')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys_dup.vintage = '90.1-2010'
+    hvac_sys_dup.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -110,7 +108,7 @@ def test_vrf_equality():
 def test_vrf_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = VRF('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = VRF.from_dict(hvac_dict)
@@ -124,27 +122,25 @@ def test_wshp_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Water source heat pumps fluid cooler with boiler'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'WSHP_FluidCooler_Boiler'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Water source heat pumps with ground source heat pump'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Water source heat pumps with ground source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'WSHP_GSHP'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'WSHP_GSHP'
 
 
 def test_wshp_equality():
     """Test the equality of WSHP objects."""
     hvac_sys = WSHP('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
-    hvac_sys_alt = WSHP(
-        'Test System',
-        equipment_type='Water source heat pumps with ground source heat pump')
+    hvac_sys_alt = WSHP('Test System', equipment_type='WSHP_GSHP')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys_dup.vintage = '90.1-2010'
+    hvac_sys_dup.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -152,8 +148,8 @@ def test_wshp_equality():
 def test_wshp_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = WSHP('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Water source heat pumps with ground source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'WSHP_GSHP'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = WSHP.from_dict(hvac_dict)
@@ -167,13 +163,13 @@ def test_baseboard_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'ElectricBaseboard'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Baseboard district hot water'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Baseboard district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DHWBaseboard'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'DHWBaseboard'
 
 
 def test_baseboard_equality():
@@ -181,12 +177,12 @@ def test_baseboard_equality():
     hvac_sys = Baseboard('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
     hvac_sys_alt = Baseboard(
-        'Test System', equipment_type='Baseboard district hot water')
+        'Test System', equipment_type='DHWBaseboard')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -213,8 +209,8 @@ def test_baseboard_multi_room():
 def test_baseboard_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = Baseboard('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Baseboard district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'DHWBaseboard'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = Baseboard.from_dict(hvac_dict)
@@ -228,13 +224,13 @@ def test_evap_cool_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Direct evap coolers with baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'EvapCoolers_ElectricBaseboard'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Direct evap coolers with baseboard district hot water'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Direct evap coolers with baseboard district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'EvapCoolers_DHWBaseboard'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'EvapCoolers_DHWBaseboard'
 
 
 def test_evap_cool_equality():
@@ -243,12 +239,12 @@ def test_evap_cool_equality():
     hvac_sys_dup = hvac_sys.duplicate()
     hvac_sys_alt = EvaporativeCooler(
         'Test System',
-        equipment_type='Direct evap coolers with baseboard district hot water')
+        equipment_type='EvapCoolers_DHWBaseboard')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -275,8 +271,8 @@ def test_evap_cool_multi_room():
 def test_evap_cool_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = EvaporativeCooler('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Direct evap coolers with baseboard district hot water'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'EvapCoolers_DHWBaseboard'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = EvaporativeCooler.from_dict(hvac_dict)
@@ -290,23 +286,23 @@ def test_gasunit_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Gas unit heaters'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'GasHeaters'
 
-    hvac_sys.vintage = '90.1-2010'
-    assert hvac_sys.vintage == '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
 
 
 def test_gasunit_equality():
     """Test the equality of GasUnitHeater objects."""
     hvac_sys = GasUnitHeater('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
-    hvac_sys_alt = GasUnitHeater('Test System', vintage='90.1-2010')
+    hvac_sys_alt = GasUnitHeater('Test System', vintage='ASHRAE_2010')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys_dup.vintage = '90.1-2010'
+    hvac_sys_dup.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -314,7 +310,7 @@ def test_gasunit_equality():
 def test_gasunit_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = GasUnitHeater('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = GasUnitHeater.from_dict(hvac_dict)
@@ -328,13 +324,13 @@ def test_residential_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Residential AC with baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'ResidentialAC_ElectricBaseboard'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Residential forced air furnace'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Residential forced air furnace'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'ResidentialFurnace'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'ResidentialFurnace'
 
 
 def test_residential_equality():
@@ -342,12 +338,12 @@ def test_residential_equality():
     hvac_sys = Residential('Test System')
     hvac_sys_dup = hvac_sys.duplicate()
     hvac_sys_alt = Residential(
-        'Test System', equipment_type='Residential forced air furnace')
+        'Test System', equipment_type='ResidentialFurnace')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -374,8 +370,8 @@ def test_residential_multi_room():
 def test_residential_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = Residential('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Residential forced air furnace'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'ResidentialFurnace'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = Residential.from_dict(hvac_dict)
@@ -389,13 +385,13 @@ def test_window_ac_init():
     str(hvac_sys)  # test the string representation
 
     assert hvac_sys.identifier == 'Test System'
-    assert hvac_sys.vintage == '90.1-2013'
-    assert hvac_sys.equipment_type == 'Window AC with baseboard electric'
+    assert hvac_sys.vintage == 'ASHRAE_2013'
+    assert hvac_sys.equipment_type == 'WindowAC_ElectricBaseboard'
 
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Window AC with baseboard central air source heat pump'
-    assert hvac_sys.vintage == '90.1-2010'
-    assert hvac_sys.equipment_type == 'Window AC with baseboard central air source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'WindowAC_ASHPBaseboard'
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'WindowAC_ASHPBaseboard'
 
 
 def test_window_ac_equality():
@@ -404,12 +400,12 @@ def test_window_ac_equality():
     hvac_sys_dup = hvac_sys.duplicate()
     hvac_sys_alt = WindowAC(
         'Test System',
-        equipment_type='Window AC with baseboard central air source heat pump')
+        equipment_type='WindowAC_ASHPBaseboard')
 
     assert hvac_sys is hvac_sys
     assert hvac_sys is not hvac_sys_dup
     assert hvac_sys == hvac_sys_dup
-    hvac_sys.vintage = '90.1-2010'
+    hvac_sys.vintage = 'ASHRAE_2010'
     assert hvac_sys != hvac_sys_dup
     assert hvac_sys != hvac_sys_alt
 
@@ -436,8 +432,8 @@ def test_window_ac_multi_room():
 def test_window_ac_dict_methods():
     """Test the to/from dict methods."""
     hvac_sys = WindowAC('High Efficiency HVAC System')
-    hvac_sys.vintage = '90.1-2010'
-    hvac_sys.equipment_type = 'Window AC with baseboard central air source heat pump'
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'WindowAC_ASHPBaseboard'
 
     hvac_dict = hvac_sys.to_dict()
     new_hvac_sys = WindowAC.from_dict(hvac_dict)


### PR DESCRIPTION
This commit also improves the __repr__ for many of the objects to be more human-readable (using display_name instead of identifier) and many of them are now 1 line in order to be more easily printable.