### PR TITLE
fix(load): Ensure Setpoint schedules are shifted

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN mkdir ladybug_tools/openstudio/ \
 
 
 # Add honeybee-openstudio-gem lib to ladybug_tools folder
-ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.9.0
+ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.11.1
 RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
     && curl -SL -o honeybee-openstudio-gem.tar.gz https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v$HONEYBEE_OPENSTUDIO_GEM_VERSION.tar.gz \
     && tar zxvf honeybee-openstudio-gem.tar.gz \

--- a/honeybee_energy/load/_base.py
+++ b/honeybee_energy/load/_base.py
@@ -113,13 +113,12 @@ class _LoadBase(object):
     @staticmethod
     def _shift_schedule(schedule, schedule_offset, timestep):
         """Take a schedule and shift it behind and then ahead."""
-        if isinstance(schedule, ScheduleRuleset):
+        if schedule_offset == 0 or not isinstance(schedule, ScheduleRuleset):
+            return [schedule] * 3
+        else:
             behind = schedule.shift_by_step(-schedule_offset, timestep)
             ahead = schedule.shift_by_step(schedule_offset, timestep)
-            shifted_schs = [behind, schedule, ahead]
-        else:  # schedule FixedInterval; not worth it to shift
-            shifted_schs = [schedule] * 3
-        return shifted_schs
+            return [behind, schedule, ahead]
 
     @staticmethod
     def _gaussian_values(count, load_value, load_stdev):

--- a/honeybee_energy/load/equipment.py
+++ b/honeybee_energy/load/equipment.py
@@ -156,12 +156,12 @@ class _EquipmentBase(_LoadBase):
         # generate shifted schedules and a gaussian distribution of watts_per_area
         usage_schs = self._shift_schedule(self.schedule, schedule_offset, timestep)
         stdev = self.watts_per_area * (watts_stdev / 100)
-        new_loads, sch_int = self._gaussian_values(count, self.watts_per_area, stdev)
-        sch_int = sch_int if schedule_indices is None else schedule_indices
+        new_loads, sch_ints = self._gaussian_values(count, self.watts_per_area, stdev)
+        sch_ints = sch_ints if schedule_indices is None else schedule_indices
 
         # generate the new objects and return them
         new_objects = []
-        for load_val, sch_int in zip(new_loads, sch_int):
+        for load_val, sch_int in zip(new_loads, sch_ints):
             new_obj = self.duplicate()
             new_obj.identifier = clean_and_id_ep_string(self.identifier)
             new_obj.watts_per_area = load_val

--- a/honeybee_energy/load/hotwater.py
+++ b/honeybee_energy/load/hotwater.py
@@ -177,12 +177,12 @@ class ServiceHotWater(_LoadBase):
         # generate shifted schedules and a gaussian distribution of flow_per_area
         usage_schs = self._shift_schedule(self.schedule, schedule_offset, timestep)
         stdev = self.flow_per_area * (flow_stdev / 100)
-        new_loads, sch_int = self._gaussian_values(count, self.flow_per_area, stdev)
-        sch_int = sch_int if schedule_indices is None else schedule_indices
+        new_loads, sch_ints = self._gaussian_values(count, self.flow_per_area, stdev)
+        sch_ints = sch_ints if schedule_indices is None else schedule_indices
 
         # generate the new objects and return them
         new_objects = []
-        for load_val, sch_int in zip(new_loads, sch_int):
+        for load_val, sch_int in zip(new_loads, sch_ints):
             new_obj = self.duplicate()
             new_obj.identifier = clean_and_id_ep_string(self.identifier)
             new_obj.flow_per_area = load_val

--- a/honeybee_energy/load/infiltration.py
+++ b/honeybee_energy/load/infiltration.py
@@ -164,13 +164,13 @@ class Infiltration(_LoadBase):
         # generate shifted schedules and gaussian distribution of flow_per_exterior_area
         usage_schs = self._shift_schedule(self.schedule, schedule_offset, timestep)
         stdev = self.flow_per_exterior_area * (flow_stdev / 100)
-        new_loads, sch_int = self._gaussian_values(
+        new_loads, sch_ints = self._gaussian_values(
             count, self.flow_per_exterior_area, stdev)
-        sch_int = sch_int if schedule_indices is None else schedule_indices
+        sch_ints = sch_ints if schedule_indices is None else schedule_indices
 
         # generate the new objects and return them
         new_objects = []
-        for load_val, sch_int in zip(new_loads, sch_int):
+        for load_val, sch_int in zip(new_loads, sch_ints):
             new_obj = self.duplicate()
             new_obj.identifier = clean_and_id_ep_string(self.identifier)
             new_obj.flow_per_exterior_area = load_val

--- a/honeybee_energy/load/lighting.py
+++ b/honeybee_energy/load/lighting.py
@@ -182,12 +182,12 @@ class Lighting(_LoadBase):
         # generate shifted schedules and a gaussian distribution of watts_per_area
         usage_schs = self._shift_schedule(self.schedule, schedule_offset, timestep)
         stdev = self.watts_per_area * (watts_stdev / 100)
-        new_loads, sch_int = self._gaussian_values(count, self.watts_per_area, stdev)
-        sch_int = sch_int if schedule_indices is None else schedule_indices
+        new_loads, sch_ints = self._gaussian_values(count, self.watts_per_area, stdev)
+        sch_ints = sch_ints if schedule_indices is None else schedule_indices
 
         # generate the new objects and return them
         new_objects = []
-        for load_val, sch_int in zip(new_loads, sch_int):
+        for load_val, sch_int in zip(new_loads, sch_ints):
             new_obj = self.duplicate()
             new_obj.identifier = clean_and_id_ep_string(self.identifier)
             new_obj.watts_per_area = load_val

--- a/honeybee_energy/load/people.py
+++ b/honeybee_energy/load/people.py
@@ -173,12 +173,12 @@ class People(_LoadBase):
         occ_schs = self._shift_schedule(
             self.occupancy_schedule, schedule_offset, timestep)
         stdev = self.people_per_area * (occupancy_stdev / 100)
-        new_loads, sch_int = self._gaussian_values(count, self.people_per_area, stdev)
-        sch_int = sch_int if schedule_indices is None else schedule_indices
+        new_loads, sch_ints = self._gaussian_values(count, self.people_per_area, stdev)
+        sch_ints = sch_ints if schedule_indices is None else schedule_indices
 
         # generate the new objects and return them
         new_objects = []
-        for load_val, sch_int in zip(new_loads, sch_int):
+        for load_val, sch_int in zip(new_loads, sch_ints):
             new_obj = self.duplicate()
             new_obj.identifier = clean_and_id_ep_string(self.identifier)
             new_obj.people_per_area = load_val

--- a/honeybee_energy/programtype.py
+++ b/honeybee_energy/programtype.py
@@ -447,6 +447,11 @@ class ProgramType(object):
                 program_count, infiltration_stdev, schedule_offset, timestep, sch_int)
             for i, inf in enumerate(div_infiltration):
                 div_programs[i].infiltration = inf
+        if self.setpoint is not None and schedule_offset != 0:
+            div_setpoint = self.setpoint.diversify(
+                program_count, schedule_offset, timestep, sch_int)
+            for i, setpt in enumerate(div_setpoint):
+                div_programs[i].setpoint = setpt
         return div_programs
 
     @staticmethod

--- a/tests/programtype_test.py
+++ b/tests/programtype_test.py
@@ -252,6 +252,10 @@ def test_program_type_diversify():
         assert prog.infiltration.flow_per_exterior_area != \
             infiltration.flow_per_exterior_area
 
+    div_programs = office_program.diversify(10, schedule_offset=0)
+    for prog in div_programs:
+        assert prog.people.occupancy_schedule == people.occupancy_schedule
+
 
 def test_program_type_average():
     """Test the ProgramType.average method."""


### PR DESCRIPTION
I realized that we should shift the setpoint if all of the other schedules are being shifted.

I have also added a check that allows the user to not shift the schedules at all if they don't want to as part of the diversification process.