### PR TITLE
feat(radiance): Add methods to assign modifiers based on constructions

### DIFF
--- a/honeybee_energy/cli/__init__.py
+++ b/honeybee_energy/cli/__init__.py
@@ -8,6 +8,7 @@ from honeybee.cli import main
 from ..config import folders
 from .lib import lib
 from .translate import translate
+from .edit import edit
 from .settings import settings
 from .simulate import simulate
 from .result import result
@@ -58,6 +59,7 @@ def config(output_file):
 # add sub-commands to energy
 energy.add_command(lib)
 energy.add_command(translate)
+energy.add_command(edit)
 energy.add_command(settings)
 energy.add_command(simulate)
 energy.add_command(result)

--- a/honeybee_energy/cli/edit.py
+++ b/honeybee_energy/cli/edit.py
@@ -1,0 +1,69 @@
+"""honeybee energy commands for editing model energy properties."""
+import click
+import sys
+import logging
+import json
+
+from honeybee.model import Model
+
+_logger = logging.getLogger(__name__)
+
+
+@click.group(help='Commands for editing model energy properties.')
+def edit():
+    pass
+
+
+@edit.command('radiance-from-energy')
+@click.argument('model-json', type=click.Path(
+    exists=True, file_okay=True, dir_okay=False, resolve_path=True))
+@click.option('--solar/--visible', ' /-v', help='Flag to note whether the assigned '
+              'radiance modifiers should follow the solar properties of the '
+              'constructions or the visible properties.', default=True)
+@click.option('--exterior-offset', '-o', help='A number for the distance at which the '
+              'exterior Faces should be offset in meters. This is used to account for '
+              'the fact that the exterior material layer of the construction usually '
+              'needs a different modifier from the interior. If set to 0, no offset '
+              'will occur and all modifiers will be interior.',
+              type=float, default=0, show_default=True)
+@click.option('--output-file', '-f', help='Optional hbjson file to output the JSON '
+              'string of the converted model. By default this will be printed out to '
+              'stdout', type=click.File('w'), default='-', show_default=True)
+def radiance_from_energy(model_json, solar, exterior_offset, output_file):
+    """Assign honeybee Radiance modifiers based on energy construction properties.
+
+    Note that the honeybee-radiance extension must be installed in order for this
+    command to be run successfully.
+
+    \b
+    Args:
+        model_json: Full path to a Honeybee Model (HBJSON) file.
+    """
+    try:
+        # re-serialize the Model to Python
+        with open(model_json) as json_file:
+            data = json.load(json_file)
+        model = Model.from_dict(data)
+        # assign the radiance properties based on the interior energy constructions
+        if solar:
+            model.properties.energy.assign_radiance_solar_interior()
+        else:
+            model.properties.energy.assign_radiance_visible_interior()
+        # offset the exterior faces and 
+        if exterior_offset is not None and exterior_offset > 0:
+            exterior_offset = exterior_offset if model.units == 'Meters' else \
+                exterior_offset / model.conversion_factor_to_meters(model.units)
+            ref_type = 'Solar' if solar else 'Visible'
+            model.properties.energy.offset_and_assign_exterior_face_modifiers(
+                reflectance_type=ref_type, offset=exterior_offset
+            )
+        # write the Model JSON string
+        output_file.write(json.dumps(model.to_dict()))
+    except Exception as e:
+        _logger.exception(
+            'Assignment of model radiance modifiers from energy construction '
+            'failed.\n{}'.format(e)
+        )
+        sys.exit(1)
+    else:
+        sys.exit(0)

--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -200,6 +200,24 @@ class AirBoundaryConstruction(object):
             base['display_name'] = self.display_name
         return base
 
+    def to_radiance_solar(self):
+        """Honeybee Radiance completely transparent material."""
+        return self._transparent_radiance_material()
+
+    def to_radiance_visible(self):
+        """Honeybee Radiance completely transparent material."""
+        return self._transparent_radiance_material()
+
+    @staticmethod
+    def _transparent_radiance_material():
+        """Get a transparent radiance material for the air boundary."""
+        try:
+            from honeybee_radiance.modifier.material import Glass
+        except ImportError as e:
+            raise ImportError('honeybee_radiance library must be installed to use '
+                              'to_radiance() method. {}'.format(e))
+        return Glass('air_boundary', 1, 1, 1)
+
     def duplicate(self):
         """Get a copy of this construction."""
         return self.__copy__()

--- a/honeybee_energy/construction/shade.py
+++ b/honeybee_energy/construction/shade.py
@@ -165,7 +165,8 @@ class ShadeConstruction(object):
             host_shade_identifier: Text string for the identifier of a Shade object that
                 possesses this ShadeConstruction.
         """
-        values = [host_shade_identifier, self.solar_reflectance, self.visible_reflectance]
+        values = [host_shade_identifier, self.solar_reflectance,
+                  self.visible_reflectance]
         if self.is_specular:
             values.extend([1, self.identifier])
             comments = ('shading surface name', 'solar reflectance',

--- a/honeybee_energy/construction/window.py
+++ b/honeybee_energy/construction/window.py
@@ -191,7 +191,7 @@ class WindowConstruction(_ConstructionBase):
     def gap_count(self):
         """The number of gas gaps contained within the window construction."""
         count = 0
-        for i, mat in enumerate(self.materials):
+        for mat in self.materials:
             if isinstance(mat, _EnergyWindowMaterialGasBase):
                 count += 1
         return count

--- a/honeybee_energy/construction/windowshade.py
+++ b/honeybee_energy/construction/windowshade.py
@@ -120,7 +120,7 @@ class WindowConstructionShade(object):
             'Got {}.'.format(type(shade_material))
         assert shade_location in self.SHADE_LOCATIONS, \
             'Invalid input "{}" for shade location.  Must be one ' \
-            'of the following:\n'.format(shade_location, self.SHADE_LOCATIONS)
+            'of the following:\n{}'.format(shade_location, self.SHADE_LOCATIONS)
         if isinstance(shade_material, EnergyWindowMaterialGlazing):
             ext_pane = window_construction[0]
             assert not isinstance(ext_pane, EnergyWindowMaterialSimpleGlazSys), \
@@ -134,7 +134,8 @@ class WindowConstructionShade(object):
             if isinstance(shade_material, EnergyWindowMaterialBlind):
                 assert shade_material.slat_width < int_gap.thickness, \
                     'Blind slat_width must be less than the width of the gap in which ' \
-                    'it sits. {} > {}.'.format(shade_material.slat_width, int_gap.thickness)
+                    'it sits. {} > {}.'.format(
+                        shade_material.slat_width, int_gap.thickness)
             shd_thick = 0 if isinstance(shade_material, EnergyWindowMaterialBlind) \
                 else shade_material.thickness
             gap_thick = (int_gap.thickness - shd_thick) / 2
@@ -154,7 +155,7 @@ class WindowConstructionShade(object):
         # assign the control type, setpoint and schedule
         assert control_type in self.CONTROL_TYPES, \
             'Invalid input "{}" for shading control type.' \
-            ' Must be one of the following:\n'.format(control_type, self.CONTROL_TYPES)
+            ' Must be one of the following:\n{}'.format(control_type, self.CONTROL_TYPES)
         self._control_type = control_type
         self.setpoint = setpoint
         self.schedule = schedule
@@ -227,7 +228,7 @@ class WindowConstructionShade(object):
     def control_type(self, value):
         assert value in self.CONTROL_TYPES, \
             'Invalid input "{}" for shading control type.' \
-            ' Must be one of the following:\n'.format(value, self.CONTROL_TYPES)
+            ' Must be one of the following:\n{}'.format(value, self.CONTROL_TYPES)
         if value != 'AlwaysOn':
             assert self._setpoint is not None, 'Control setpoint must not ' \
                 'be None to use "{}" control type.'.format(value)
@@ -317,7 +318,8 @@ class WindowConstructionShade(object):
         layers if the consruction is a switchable glazing.
         """
         if self.is_switchable_glazing:
-            return list(set(self._window_construction.materials + (self.shade_material,)))
+            return list(set(
+                self._window_construction.materials + (self.shade_material,)))
         return list(set(self.materials))
 
     @property

--- a/honeybee_energy/material/_base.py
+++ b/honeybee_energy/material/_base.py
@@ -75,7 +75,7 @@ class _EnergyMaterialOpaqueBase(_EnergyMaterialBase):
     """Base energy material for all opaque material types."""
     ROUGHTYPES = ('VeryRough', 'Rough', 'MediumRough',
                   'MediumSmooth', 'Smooth', 'VerySmooth')
-    RADIANCEROUGHTYPES = {'VeryRough': 0.3, 'Rough': 0.2, 'MediumRough': 0.15,
+    RADIANCEROUGHTYPES = {'VeryRough': 0.2, 'Rough': 0.2, 'MediumRough': 0.15,
                           'MediumSmooth': 0.1, 'Smooth': 0.05, 'VerySmooth': 0}
     __slots__ = ()
 

--- a/honeybee_energy/material/glazing.py
+++ b/honeybee_energy/material/glazing.py
@@ -161,8 +161,8 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
     def solar_reflectance_back(self, s_ref):
         if s_ref is not None:
             s_ref = float_in_range(s_ref, 0.0, 1.0, 'glazing material solar reflectance')
-            assert s_ref + self._solar_transmittance <= 1, 'Sum of window transmittance ' \
-                'and reflectance ({}) is greater than 1.'.format(
+            assert s_ref + self._solar_transmittance <= 1, 'Sum of window ' \
+                'transmittance and reflectance ({}) is greater than 1.'.format(
                     s_ref + self._solar_transmittance)
         self._solar_reflectance_back = s_ref
 
@@ -518,7 +518,7 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
 
     @u_factor.setter
     def u_factor(self, u_fac):
-        # NOTE: u-values above 5.8 are not usually realistic but 12 is used as a hard limit
+        # NOTE: u-values above 5.8 are not realistic but 12 is the absolute hard limit
         self._u_factor = float_in_range(u_fac, 0.0, 12, 'glazing material u-factor')
 
     @property


### PR DESCRIPTION
This commit adds a command to assign all radiance modifiers based on energy properties.  This will be particularly useful in comfort mapping workflows.