### PR TITLE
fix(cli): Expose north angle on all simulation setting commands

### DIFF
--- a/honeybee_energy/cli/_helper.py
+++ b/honeybee_energy/cli/_helper.py
@@ -1,0 +1,23 @@
+"""A collection of helper functions used throughout the CLI.
+
+Most functions assist with the serialization of objects to/from JSON.
+"""
+import json
+
+from ladybug.analysisperiod import AnalysisPeriod
+from honeybee_energy.simulation.runperiod import RunPeriod
+
+
+def _load_run_period_json(run_period_json):
+    """Load a RunPeriod from a JSON file with a run period or analysis period.
+    
+    Args:
+        run_period_json: A JSON file of a RunPeriod or AnalysisPeriod to be loaded.
+    """
+    if run_period_json is not None and run_period_json != 'None':
+        with open(run_period_json) as json_file:
+            data = json.load(json_file)
+        if data['type'] == 'AnalysisPeriod':
+            return RunPeriod.from_analysis_period(AnalysisPeriod.from_dict(data))
+        elif data['type'] == 'RunPeriod':
+            return RunPeriod.from_dict(data)

--- a/honeybee_energy/cli/lib.py
+++ b/honeybee_energy/cli/lib.py
@@ -206,7 +206,7 @@ def window_material_by_id(material_id, output_file):
 @lib.command('opaque-construction-by-id')
 @click.argument('construction-id', type=str)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'defintion should be returned.', type=bool, default=True)
+              'defintion should be returned.', default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -232,7 +232,7 @@ def opaque_construction_by_id(construction_id, complete, output_file):
 @lib.command('window-construction-by-id')
 @click.argument('construction-id', type=str)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'defintion should be returned.', type=bool, default=True)
+              'defintion should be returned.', default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -282,10 +282,9 @@ def shade_construction_by_id(construction_id, output_file):
 @click.argument('construction-set-id', type=str)
 @click.option('--none-defaults/--include-defaults', ' /-d', help='Flag to note whether '
               'default constructions in the set should be included in or should be '
-              'None.', type=bool, default=True, show_default=True)
+              'None.', default=True, show_default=True)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -335,8 +334,7 @@ def schedule_type_limit_by_id(schedule_type_limit_id, output_file):
 @lib.command('schedule-by-id')
 @click.argument('schedule-id', type=str)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -361,8 +359,7 @@ def schedule_by_id(schedule_id, complete, output_file):
 @lib.command('program-type-by-id')
 @click.argument('program-type-id', type=str)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -416,8 +413,7 @@ def materials_by_id(material_ids, output_file):
 @lib.command('constructions-by-id')
 @click.argument('construction-ids', nargs=-1)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON strings of '
               'the objects. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -455,10 +451,10 @@ def constructions_by_id(construction_ids, complete, output_file):
 @click.argument('construction-set-ids', nargs=-1)
 @click.option('--none-defaults/--include-defaults', ' /-d', help='Flag to note whether '
               'default constructions in the set should be included in detail or should '
-              'be None.', type=bool, default=True, show_default=True)
+              'be None.', default=True, show_default=True)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
               'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON string of '
               'the object. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -514,8 +510,7 @@ def schedule_type_limits_by_id(schedule_type_limit_ids, output_file):
 @lib.command('schedules-by-id')
 @click.argument('schedule-ids', nargs=-1)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON strings of '
               'the objects. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)
@@ -543,8 +538,7 @@ def schedules_by_id(schedule_ids, complete, output_file):
 @lib.command('program-types-by-id')
 @click.argument('program-type-ids', nargs=-1)
 @click.option('--complete/--abridged', ' /-a', help='Flag to note wether an abridged '
-              'definition should be returned.',
-              type=bool, default=True, show_default=True)
+              'definition should be returned.', default=True, show_default=True)
 @click.option('--output-file', '-f', help='Optional file to output the JSON strings of '
               'the objects. By default, it will be printed out to stdout',
               type=click.File('w'), default='-', show_default=True)

--- a/tests/cli_settings_test.py
+++ b/tests/cli_settings_test.py
@@ -85,7 +85,8 @@ def test_orientation_sim_pars():
     runner = CliRunner()
     ddy_path = './tests/ddy/chicago.ddy'
 
-    result = runner.invoke(orientation_sim_pars, [ddy_path, '0', '90', '180', '270'])
+    result = runner.invoke(orientation_sim_pars,
+                           [ddy_path, '0', '90', '180', '270', '-n', '100'])
     assert result.exit_code == 0
     simpar_list = json.loads(result.output)
     for sp_json in simpar_list:


### PR DESCRIPTION
I realized how annoying it is for people to be unable to change the north angle of their recipes.

I am also adding in some workarounds to that I can expose the run period for comfort maps, which I think will get used a lot.