### PR TITLE
feat(docker): improve image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,41 +4,61 @@ LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
 
 ARG OPENSTUDIO_VERSION
 ARG OPENSTUDIO_FILENAME
+ARG HONEYBEE_GEM_FILENAME
 
 ENV HOME_PATH='/home/ladybugbot'
 ENV LBT_PATH="${HOME_PATH}/ladybug_tools"
+ENV LIBRARY_PATH="${HOME_PATH}/lib"
 ENV LOCAL_OPENSTUDIO_PATH="${LBT_PATH}/openstudio"
+ENV RUN_PATH="${HOME_PATH}/run"
+ENV SIM_PATH="${RUN_PATH}/simulation"
+ENV PATH="${HOME_PATH}/.local/bin:${PATH}"
 
 # Create non-root user
 RUN adduser ladybugbot --uid 1000 --disabled-password --gecos ""
 USER ladybugbot
 WORKDIR ${HOME_PATH}
-RUN mkdir -p ${LOCAL_OPENSTUDIO_PATH} && touch ${LBT_PATH}/config.json
+RUN mkdir -p ${LOCAL_OPENSTUDIO_PATH} \
+    && touch ${LBT_PATH}/config.json \
+    && mkdir -p ${SIM_PATH}
 
-# keep
+# Expects an untarred OpenStudio download in the build context
 COPY ${OPENSTUDIO_FILENAME}/usr/local/openstudio-${OPENSTUDIO_VERSION}/EnergyPlus \
     ${LOCAL_OPENSTUDIO_PATH}/EnergyPlus
 
 COPY ${OPENSTUDIO_FILENAME}/usr/local/openstudio-${OPENSTUDIO_VERSION}/bin \
     ${LOCAL_OPENSTUDIO_PATH}/bin
 
-
 # Add honeybee-openstudio-gem lib to ladybug_tools folder
-ENV HONEYBEE_OPENSTUDIO_GEM_VERSION=2.11.1
-RUN mkdir -p ladybug_tools/resources/measures/honeybee_openstudio_gem \
-    && curl -SL -o honeybee-openstudio-gem.tar.gz https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v$HONEYBEE_OPENSTUDIO_GEM_VERSION.tar.gz \
-    && tar zxvf honeybee-openstudio-gem.tar.gz \
-    && mv honeybee-openstudio-gem-$HONEYBEE_OPENSTUDIO_GEM_VERSION/lib ladybug_tools/resources/measures/honeybee_openstudio_gem \
-    && rm -r honeybee-openstudio-gem-$HONEYBEE_OPENSTUDIO_GEM_VERSION \
-    && rm honeybee-openstudio-gem.tar.gz
-
+# Expects an untarred honeybee-openstudio-gem in the build context
+# https://github.com/ladybug-tools/honeybee-openstudio-gem
+COPY ${HONEYBEE_GEM_FILENAME} \
+    ${LBT_PATH}/resources/measures/honeybee_openstudio_gem
 
 # Install honeybee-energy
-ENV PATH="/home/ladybugbot/.local/bin:${PATH}"
-COPY . honeybee-energy
-RUN pip3 install setuptools wheel\
-    && pip3 install ./honeybee-energy[standards]
+COPY honeybee_energy ${LIBRARY_PATH}/honeybee_energy
+COPY .git ${LIBRARY_PATH}/.git
+COPY setup.py ${LIBRARY_PATH}
+COPY setup.cfg ${LIBRARY_PATH}
+COPY requirements.txt ${LIBRARY_PATH}
+COPY README.md ${LIBRARY_PATH}
+COPY LICENSE ${LIBRARY_PATH}
 
-# Set up working directory
-RUN mkdir -p /home/ladybugbot/run/simulation
-WORKDIR /home/ladybugbot/run
+USER root
+RUN apt-get update \
+    && apt-get -y install --no-install-recommends git \
+    # EnergyPlus dynamically links to libx11
+    && apt-get -y install libx11-6 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip3 install --no-cache-dir setuptools wheel \
+    && pip3 install --no-cache-dir ${LIBRARY_PATH}[standards] \
+    && apt-get -y --purge remove git \
+    && apt-get -y clean \
+    && apt-get -y autoremove \
+    && rm -rf ${LIBRARY_PATH}/.git \
+    && chown -R ladybugbot ${HOME_PATH}
+
+USER ladybugbot
+# Set working directory
+WORKDIR ${RUN_PATH}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,26 @@
-FROM python:3.7
+FROM python:3.7-slim
 
 LABEL maintainer="Ladybug Tools" email="info@ladybug.tools"
 
-# Create non-root user
-RUN adduser ladybugbot --uid 1000
-USER ladybugbot
-WORKDIR /home/ladybugbot
-RUN mkdir ladybug_tools && touch ladybug_tools/config.json
+ARG OPENSTUDIO_VERSION
+ARG OPENSTUDIO_FILENAME
 
-# Install Open Studio
-ENV OPENSTUDIO_VERSION=3.1.0
-ENV OPENSTUDIO_FILENAME=OpenStudio-3.1.0+e165090621-Linux
-ENV OPENSTUDIO_DOWNLOAD_URL=https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz
-RUN mkdir ladybug_tools/openstudio/ \
-    && curl -SL -o openstudio.tar.gz $OPENSTUDIO_DOWNLOAD_URL \
-    && tar zxvf openstudio.tar.gz \
-    && mv $OPENSTUDIO_FILENAME/usr/local/openstudio-$OPENSTUDIO_VERSION/EnergyPlus ladybug_tools/openstudio/EnergyPlus \
-    && mv $OPENSTUDIO_FILENAME/usr/local/openstudio-$OPENSTUDIO_VERSION/bin ladybug_tools/openstudio/bin \
-    && rm -r $OPENSTUDIO_FILENAME \
-    && rm openstudio.tar.gz
+ENV HOME_PATH='/home/ladybugbot'
+ENV LBT_PATH="${HOME_PATH}/ladybug_tools"
+ENV LOCAL_OPENSTUDIO_PATH="${LBT_PATH}/openstudio"
+
+# Create non-root user
+RUN adduser ladybugbot --uid 1000 --disabled-password --gecos ""
+USER ladybugbot
+WORKDIR ${HOME_PATH}
+RUN mkdir -p ${LOCAL_OPENSTUDIO_PATH} && touch ${LBT_PATH}/config.json
+
+# keep
+COPY ${OPENSTUDIO_FILENAME}/usr/local/openstudio-${OPENSTUDIO_VERSION}/EnergyPlus \
+    ${LOCAL_OPENSTUDIO_PATH}/EnergyPlus
+
+COPY ${OPENSTUDIO_FILENAME}/usr/local/openstudio-${OPENSTUDIO_VERSION}/bin \
+    ${LOCAL_OPENSTUDIO_PATH}/bin
 
 
 # Add honeybee-openstudio-gem lib to ladybug_tools folder

--- a/build_image.sh
+++ b/build_image.sh
@@ -4,7 +4,7 @@ set -e
 error_help="Usage: $0 CONTAINER_NAME TAG [REMOVE_DOWNLOADS=false|true]"
 
 export CONTAINER_NAME="${1:?$error_help}"
-export NEXT_RELEASE_VERSION="${2:?$error_help}"
+export TAG="${2:?$error_help}"
 
 # Get OpenStudio
 
@@ -29,7 +29,7 @@ tar zxvf ${HONEYBEE_OPENSTUDIO_GEM_TAR}
 mv honeybee-openstudio-gem-*/ ${HONEYBEE_GEM_FILENAME}
 
 docker build . \
-  -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION \
+  -t $CONTAINER_NAME:$TAG \
   --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
   --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME} \
   --build-arg HONEYBEE_GEM_FILENAME=${HONEYBEE_GEM_FILENAME}

--- a/build_image.sh
+++ b/build_image.sh
@@ -1,0 +1,39 @@
+#! /usr/bin/env sh
+set -e
+
+error_help="Usage: $0 CONTAINER_NAME TAG [REMOVE_DOWNLOADS=false|true]"
+
+export CONTAINER_NAME="${1:?$error_help}"
+export NEXT_RELEASE_VERSION="${2:?$error_help}"
+
+# Get OpenStudio
+
+export OPENSTUDIO_VERSION='3.1.0'
+export OPENSTUDIO_DOWNLOAD_URL='https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz'
+export OPENSTUDIO_TAR_FILENAME='openstudio.tar.gz'
+export OPENSTUDIO_FILENAME='openstudio'
+
+curl -SL -o ${OPENSTUDIO_TAR_FILENAME} ${OPENSTUDIO_DOWNLOAD_URL}
+tar zxvf ${OPENSTUDIO_TAR_FILENAME}
+mv OpenStudio-*-Linux/ ${OPENSTUDIO_FILENAME}
+
+# Get the gem
+
+export HONEYBEE_OPENSTUDIO_GEM_VERSION='2.11.1'
+export HONEYBEE_OPENSTUDIO_GEM_URL="https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v${HONEYBEE_OPENSTUDIO_GEM_VERSION}.tar.gz"
+export HONEYBEE_OPENSTUDIO_GEM_TAR='honeybee-openstudio-gem.tar.gz'
+export HONEYBEE_GEM_FILENAME='honeybee-gem'
+
+curl -SL -o ${HONEYBEE_OPENSTUDIO_GEM_TAR} ${HONEYBEE_OPENSTUDIO_GEM_URL}
+tar zxvf ${HONEYBEE_OPENSTUDIO_GEM_TAR}
+mv honeybee-openstudio-gem-*/ ${HONEYBEE_GEM_FILENAME}
+
+docker build . \
+  -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION \
+  --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
+  --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME} \
+  --build-arg HONEYBEE_GEM_FILENAME=${HONEYBEE_GEM_FILENAME}
+
+if [[ "${3}" == 'true' ]]; then
+    rm -rf openstudio* honeybee-*
+fi

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,28 +1,46 @@
 #!/bin/sh
 
-if [ -n "$1" ]
-then
-  NEXT_RELEASE_VERSION=$1
-else
-  echo "A release version must be supplied"
-  exit 1
-fi
-
-CONTAINER_NAME="ladybugtools/honeybee-energy"
-
-echo "PyPi Deployment..."
-echo "Building distribution"
-python setup.py sdist bdist_wheel
-echo "Pushing new version to PyPi"
-twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD 
+# if [ -n "$1" ]
+# then
+#   NEXT_RELEASE_VERSION=$1
+# else
+#   echo "A release version must be supplied"
+#   exit 1
+# fi
 
 
-echo "Docker Deployment..."
-echo "Login to Docker"
-echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+# echo "PyPi Deployment..."
+# echo "Building distribution"
+# python setup.py sdist bdist_wheel
+# echo "Pushing new version to PyPi"
+# twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
-docker build . -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
-docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
 
-docker push $CONTAINER_NAME:latest
-docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION 
+# echo "Docker Deployment..."
+# echo "Login to Docker"
+# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+# CONTAINER_NAME="ladybugtools/honeybee-energy"
+CONTAINER_NAME='hbe'
+NEXT_RELEASE_VERSION='latest'
+
+export OPENSTUDIO_VERSION='3.1.0'
+export OPENSTUDIO_DOWNLOAD_URL='https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz'
+export OPENSTUDIO_TAR_FILENAME='openstudio.tar.gz'
+export OPENSTUDIO_FILENAME='openstudio'
+
+curl -SL -o ${OPENSTUDIO_TAR_FILENAME} ${OPENSTUDIO_DOWNLOAD_URL}
+tar zxvf ${OPENSTUDIO_TAR_FILENAME}
+mv OpenStudio-*-Linux ${OPENSTUDIO_FILENAME}
+
+export HONEYBEE_OPENSTUDIO_GEM_VERSION='2.11.1'
+
+docker build . \
+  -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION \
+  --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
+  --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME}
+
+
+# docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
+
+# docker push $CONTAINER_NAME:latest
+# docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,39 +15,12 @@ python setup.py sdist bdist_wheel
 echo "Pushing new version to PyPi"
 twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
-
 echo "Docker Deployment..."
 echo "Login to Docker"
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 CONTAINER_NAME="ladybugtools/honeybee-energy"
 
-# Get OpenStudio
-
-export OPENSTUDIO_VERSION='3.1.0'
-export OPENSTUDIO_DOWNLOAD_URL='https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz'
-export OPENSTUDIO_TAR_FILENAME='openstudio.tar.gz'
-export OPENSTUDIO_FILENAME='openstudio'
-
-curl -SL -o ${OPENSTUDIO_TAR_FILENAME} ${OPENSTUDIO_DOWNLOAD_URL}
-tar zxvf ${OPENSTUDIO_TAR_FILENAME}
-mv OpenStudio-*-Linux/ ${OPENSTUDIO_FILENAME}
-
-# Get the gem
-
-export HONEYBEE_OPENSTUDIO_GEM_VERSION='2.11.1'
-export HONEYBEE_OPENSTUDIO_GEM_URL="https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v${HONEYBEE_OPENSTUDIO_GEM_VERSION}.tar.gz"
-export HONEYBEE_OPENSTUDIO_GEM_TAR='honeybee-openstudio-gem.tar.gz'
-export HONEYBEE_GEM_FILENAME='honeybee-gem'
-
-curl -SL -o ${HONEYBEE_OPENSTUDIO_GEM_TAR} ${HONEYBEE_OPENSTUDIO_GEM_URL}
-tar zxvf ${HONEYBEE_OPENSTUDIO_GEM_TAR}
-mv honeybee-openstudio-gem-*/ ${HONEYBEE_GEM_FILENAME}
-
-docker build . \
-  -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION \
-  --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
-  --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME} \
-  --build-arg HONEYBEE_GEM_FILENAME=${HONEYBEE_GEM_FILENAME}
+./build_image.sh ${CONTAINER_NAME} ${NEXT_RELEASE_VERSION}
 
 docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,27 +1,27 @@
 #!/bin/sh
 
-# if [ -n "$1" ]
-# then
-#   NEXT_RELEASE_VERSION=$1
-# else
-#   echo "A release version must be supplied"
-#   exit 1
-# fi
+if [ -n "$1" ]
+then
+  NEXT_RELEASE_VERSION=$1
+else
+  echo "A release version must be supplied"
+  exit 1
+fi
 
 
-# echo "PyPi Deployment..."
-# echo "Building distribution"
-# python setup.py sdist bdist_wheel
-# echo "Pushing new version to PyPi"
-# twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
+echo "PyPi Deployment..."
+echo "Building distribution"
+python setup.py sdist bdist_wheel
+echo "Pushing new version to PyPi"
+twine upload dist/* -u $PYPI_USERNAME -p $PYPI_PASSWORD
 
 
-# echo "Docker Deployment..."
-# echo "Login to Docker"
-# echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-# CONTAINER_NAME="ladybugtools/honeybee-energy"
-CONTAINER_NAME='hbe'
-NEXT_RELEASE_VERSION='latest'
+echo "Docker Deployment..."
+echo "Login to Docker"
+echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+CONTAINER_NAME="ladybugtools/honeybee-energy"
+
+# Get OpenStudio
 
 export OPENSTUDIO_VERSION='3.1.0'
 export OPENSTUDIO_DOWNLOAD_URL='https://openstudio-ci-builds.s3-us-west-2.amazonaws.com/3.1.0/OpenStudio-3.1.0%2Be165090621-Linux.tar.gz'
@@ -30,17 +30,26 @@ export OPENSTUDIO_FILENAME='openstudio'
 
 curl -SL -o ${OPENSTUDIO_TAR_FILENAME} ${OPENSTUDIO_DOWNLOAD_URL}
 tar zxvf ${OPENSTUDIO_TAR_FILENAME}
-mv OpenStudio-*-Linux ${OPENSTUDIO_FILENAME}
+mv OpenStudio-*-Linux/ ${OPENSTUDIO_FILENAME}
+
+# Get the gem
 
 export HONEYBEE_OPENSTUDIO_GEM_VERSION='2.11.1'
+export HONEYBEE_OPENSTUDIO_GEM_URL="https://github.com/ladybug-tools/honeybee-openstudio-gem/archive/v${HONEYBEE_OPENSTUDIO_GEM_VERSION}.tar.gz"
+export HONEYBEE_OPENSTUDIO_GEM_TAR='honeybee-openstudio-gem.tar.gz'
+export HONEYBEE_GEM_FILENAME='honeybee-gem'
+
+curl -SL -o ${HONEYBEE_OPENSTUDIO_GEM_TAR} ${HONEYBEE_OPENSTUDIO_GEM_URL}
+tar zxvf ${HONEYBEE_OPENSTUDIO_GEM_TAR}
+mv honeybee-openstudio-gem-*/ ${HONEYBEE_GEM_FILENAME}
 
 docker build . \
   -t $CONTAINER_NAME:$NEXT_RELEASE_VERSION \
   --build-arg OPENSTUDIO_VERSION=${OPENSTUDIO_VERSION} \
-  --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME}
+  --build-arg OPENSTUDIO_FILENAME=${OPENSTUDIO_FILENAME} \
+  --build-arg HONEYBEE_GEM_FILENAME=${HONEYBEE_GEM_FILENAME}
 
+docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
 
-# docker tag $CONTAINER_NAME:$NEXT_RELEASE_VERSION $CONTAINER_NAME:latest
-
-# docker push $CONTAINER_NAME:latest
-# docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION
+docker push $CONTAINER_NAME:latest
+docker push $CONTAINER_NAME:$NEXT_RELEASE_VERSION


### PR DESCRIPTION
# What
- Reduce image size
- Refactor build into its own script for easier local testing

# Why
- To enable faster pulls

# How
- Move blob getting to `build_image.sh`
- Refactor `deploy.sh`
- Base on `python:3.7-slim`

Reduces image size `1.42GB` -> `1.06GB`. Not amazing, but slightly better.

# Testing
I tested this with:
1. `./build_image.sh hbe latest true`
2. `docker run -v $(realpath .)/tests:/home/ladybugbot/run/tests -it -v $(realpath .)/dev-requirements.txt:/home/ladybugbot/run/dev-requirements.txt hbe:latest bash`
3. (inside container now) `pip install -r dev-requirement.txt`
4. `python -m pytest tests/`

All tests should be passing.