### PR TITLE
feat(afn.py): Modify crack logic to match constant infiltration flow.

### DIFF
--- a/honeybee_energy/ventcool/afn.py
+++ b/honeybee_energy/ventcool/afn.py
@@ -253,11 +253,12 @@ def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
         atmospheric_pressure: Optional number to define the atmospheric pressure
             measurement in Pascals used to calculate dry air density. (Default: 101325).
         delta_pressure: Optional reference air pressure difference across the building
-            envelope orifice in Pascals, used to calculate infiltration crack flow
-            coefficients if use_room_infiltration is set to True. If attempting to
-            replicate the room infiltration rate per exterior area, this value should
-            approximate the average positive simulated pressure differences from the
-            exterior to the interior. Default 4 represents typical building pressures.
+            envelope orifice in Pascals. delta_pressure is used to calculate
+            infiltration crack flow coefficients if the use_room_infiltration argument
+            is True. See the exterior_afn_from_infiltration method in the
+            RoomEnergyProperties class for details on how to set this value if
+            attempting to replicate the room infiltration rate per exterior area.
+            Default 4 represents typical building pressures.
     """
     # simplify parameters
     if leakage_type == 'Excellent':

--- a/honeybee_energy/ventcool/afn.py
+++ b/honeybee_energy/ventcool/afn.py
@@ -202,7 +202,7 @@ def _exterior_afn(exterior_face_groups, ext_cracks):
 
 
 def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
-             atmospheric_pressure=101325):
+             atmospheric_pressure=101325, delta_pressure=4):
     """
     Mutate a list of Honeybee Room objects to represent an EnergyPlus AirflowNetwork.
 
@@ -252,6 +252,12 @@ def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
             leakage_type.
         atmospheric_pressure: Optional number to define the atmospheric pressure
             measurement in Pascals used to calculate dry air density. (Default: 101325).
+        delta_pressure: Optional reference air pressure difference across the building
+            envelope orifice in Pascals, used to calculate infiltration crack flow
+            coefficients if use_room_infiltration is set to True. If attempting to
+            replicate the room infiltration rate per exterior area, this value should
+            approximate the average positive simulated pressure differences from the
+            exterior to the interior. Default 4 represents typical building pressures.
     """
     # simplify parameters
     if leakage_type == 'Excellent':
@@ -275,7 +281,8 @@ def generate(rooms, leakage_type='Medium', use_room_infiltration=True,
         # mutate surfaces with AFN flow parameters
         rho = _air_density_from_pressure(atmospheric_pressure)
         if use_room_infiltration and room.properties.energy.infiltration is not None:
-            room.properties.energy.exterior_afn_from_infiltration_load(ext_faces, rho)
+            room.properties.energy.exterior_afn_from_infiltration_load(
+                ext_faces, air_density=rho, delta_pressure=delta_pressure)
         else:
             _exterior_afn(ext_faces, ext_cracks)
         _interior_afn(int_faces, int_cracks, rho)

--- a/tests/room_extend_test.py
+++ b/tests/room_extend_test.py
@@ -350,8 +350,8 @@ def test_solve_norm_area_flow_coefficient():
 def test_solve_norm_perimeter_flow_coefficient():
     """Test calculation of leakage parameters from infiltration for opening edges."""
 
-    L = 6  # 2 x 1 meter opening
-    A = 2  # m2
+    L = 6.0  # 2 x 1 meter opening
+    A = 2.0  # m2
     refn = 0.65
     rep = RoomEnergyProperties
     d = 1.204

--- a/tests/ventcool_afn_test.py
+++ b/tests/ventcool_afn_test.py
@@ -136,7 +136,7 @@ def test_afn_single_zone():
             v = vface.properties.energy.vent_opening
             _cq = v.flow_coefficient_closed
             _n = v.flow_exponent_closed
-            assert 1e-9 == pytest.approx(_cq, abs=1e-10)
+            assert 0.0 == pytest.approx(_cq, abs=1e-10)
             assert 0.5 == pytest.approx(_n, abs=1e-10)
 
         # check opaque areas
@@ -191,7 +191,6 @@ def test_afn_single_zone_delta_pressure():
 
     # Test flow coefficients and exponents
     for i in range(1, 6):
-        print(faces[i])
         # check opaque areas
         chk_cq = (qv * d) / (dP ** n) * faces[i].area
         cq = faces[i].properties.energy.vent_crack.flow_coefficient


### PR DESCRIPTION
@chriswmackey 

This PR includes changes to the AFN infiltration calculation, and updated tests to better match infiltration flow through exterior area, including:
1. Incorporate the door and aperture infiltration (from edge cracks) with the area crack flow in their parent face. This is done by adding door and aperture area with parent area when scaling the normalized flow coefficient. 
2. Exposing the delta_pressure parameter for flow coefficient calculations, and modifying docstring to indicate how it should match simulated negative building pressure (relative to EP air node 1 to 2 custom result) to match constant interior flow rate per exterior area.

Note that, removing the edge crack flow (like we discussed in the forums) didn't make a huge difference, but I'm including it here since simplifying the model without having a huge impact on infiltration rate makes this version better then the last.  

I did manage to figure out how to get the AFN infiltration to pretty much exactly match the infiltrate rate per exterior area, but it involves approximating the average pressure difference, (weighted to account for the nonlinear relationship between envelope area and mass flow) from the simulated building, since there was a large difference between the simulated building pressure and our 4 Pa assumption. This was the reason I also exposed the delta_pressure parameter in this PR.  I'll post more details on the forum. 
