### PR TITLE
fix(scheudle): Ensure that activity and mixing schedules can be None

### DIFF
--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -122,7 +122,7 @@ class AirBoundaryConstruction(object):
         assert data['type'] == 'AirBoundaryConstruction', \
             'Expected AirBoundaryConstruction. Got {}.'.format(data['type'])
         a_mix = data['air_mixing_per_area'] if 'air_mixing_per_area' in data else 0.1
-        if 'air_mixing_schedule' in data:
+        if 'air_mixing_schedule' in data and data['air_mixing_schedule'] is not None:
             a_sch = dict_to_schedule(data['air_mixing_schedule'])
         else:
             a_sch = always_on
@@ -154,7 +154,8 @@ class AirBoundaryConstruction(object):
             'Expected AirBoundaryConstructionAbridged. Got {}.'.format(data['type'])
         a_mix = data['air_mixing_per_area'] if 'air_mixing_per_area' in data else 0.1
         a_sch = schedule_dict[data['air_mixing_schedule']] if \
-            'air_mixing_schedule' in data else always_on
+            'air_mixing_schedule' in data and data['air_mixing_schedule'] is not None \
+            else always_on
         new_obj = cls(data['identifier'], a_mix, a_sch)
         if 'display_name' in data and data['display_name'] is not None:
             new_obj.display_name = data['display_name']

--- a/honeybee_energy/load/people.py
+++ b/honeybee_energy/load/people.py
@@ -33,7 +33,7 @@ class People(_LoadBase):
             activity of the occupants over the course of the year. The type of
             this schedule should be ActivityLevel and the values of the schedule equal
             to the number of Watts given off by an individual person in the room.
-            If None, it will a default constant schedule with 120 Watts per person
+            If None, a default constant schedule with 120 Watts per person
             will be used, which is typical of awake, adult humans who are seated.
         radiant_fraction: A number between 0 and 1 for the fraction of the
             sensible heat given off by people that is radiant (as opposed to
@@ -256,7 +256,8 @@ class People(_LoadBase):
             'Expected People dictionary. Got {}.'.format(data['type'])
         occ_sched = cls._get_schedule_from_dict(data['occupancy_schedule'])
         act_sched = cls._get_schedule_from_dict(data['activity_schedule']) if \
-            'activity_schedule' in data and data['activity_schedule'] is not None else None
+            'activity_schedule' in data and data['activity_schedule'] is not None \
+            else None
         rad_fract, lat_fract = cls._optional_dict_keys(data)
         new_obj = cls(data['identifier'], data['people_per_area'], occ_sched, act_sched,
                       rad_fract, lat_fract)
@@ -424,7 +425,7 @@ class People(_LoadBase):
             occ_sched = schedule_dict[occ_sch_id]
         except KeyError as e:
             raise ValueError('Failed to find {} in the schedule_dict.'.format(e))
-        if act_sch_id.lower() == 'seated adult activity':
+        if act_sch_id == '' or act_sch_id.lower() == 'seated adult activity':
             activity_sched = None
         else:
             try:


### PR DESCRIPTION
This will make it easier for people to build these objects when they are ok with accepting a standard "always on" type of default.