### PR TITLE
fix(window): Account for inter-reflection in transmittance calculations

### DIFF
--- a/honeybee_energy/construction/dynamic.py
+++ b/honeybee_energy/construction/dynamic.py
@@ -193,6 +193,12 @@ class WindowConstructionDynamic(object):
         return self._constructions[0].solar_transmittance
 
     @property
+    def visible_transmittance(self):
+        """Visible transmittance of the first window construction at normal incidence.
+        """
+        return self._constructions[0].visible_transmittance
+
+    @property
     def shgc(self):
         """The solar heat gain coefficient (SHGC) of the first window construction."""
         return self._constructions[0].shgc

--- a/honeybee_energy/construction/windowshade.py
+++ b/honeybee_energy/construction/windowshade.py
@@ -365,6 +365,14 @@ class WindowConstructionShade(object):
         return self._window_construction.solar_transmittance
 
     @property
+    def visible_transmittance(self):
+        """The visible transmittance of the bare window construction at normal incidence.
+
+        Note that this excludes all effects of the shade layer.
+        """
+        return self._window_construction.visible_transmittance
+
+    @property
     def shgc(self):
         """The solar heat gain coefficient (SHGC) of the bare window construction.
 

--- a/tests/construction_test.py
+++ b/tests/construction_test.py
@@ -221,9 +221,9 @@ def test_window_construction_init():
     assert double_low_e.outside_emissivity == \
         double_low_e_dup.outside_emissivity == 0.84
     assert double_low_e.solar_transmittance == \
-        double_low_e_dup.solar_transmittance == 0.4517 * 0.770675
+        double_low_e_dup.solar_transmittance > 0.4517 * 0.770675
     assert double_low_e.visible_transmittance == \
-        double_low_e_dup.visible_transmittance == 0.714 * 0.8836
+        double_low_e_dup.visible_transmittance > 0.714 * 0.8836
     assert double_low_e.glazing_count == double_low_e_dup.glazing_count == 2
     assert double_low_e.gap_count == double_low_e_dup.gap_count == 1
 

--- a/tests/material_glazing_test.py
+++ b/tests/material_glazing_test.py
@@ -138,8 +138,8 @@ def test_simple_sys_init():
     assert lowe_sys.vt == lowe_sys_dup.vt == 0.55
 
     assert lowe_sys.r_factor == lowe_sys_dup.r_factor == pytest.approx(1 / 1.8, rel=1e-3)
-    assert lowe_sys.r_value == lowe_sys_dup.r_value == pytest.approx(0.387077, rel=1e-3)
-    assert lowe_sys.u_value == lowe_sys_dup.u_value == pytest.approx(2.58346333, rel=1e-3)
+    assert lowe_sys.r_value == lowe_sys_dup.r_value == pytest.approx(0.38167, rel=1e-3)
+    assert lowe_sys.u_value == lowe_sys_dup.u_value == pytest.approx(1 / 0.38167, rel=1e-3)
     assert lowe_sys.solar_transmittance < lowe_sys_dup.shgc
 
 


### PR DESCRIPTION
It seems that I was forgetting to account for back reflected solar in the calculation of solar transmittance. This commit fixes this issue and will make the SHGC ore accurate.