### PR TITLE
fix(err): Ignore degenerate surfaces warning

### DIFF
--- a/honeybee_energy/result/err.py
+++ b/honeybee_energy/result/err.py
@@ -90,7 +90,8 @@ class Err(object):
             elif '**  Fatal  **' in line:
                 self._fatal_errors.append(line)
             elif '** Severe  **' in line:
-                self._severe_errors.append(line)
+                if 'Degenerate surfaces' not in line:
+                    self._severe_errors.append(line)
 
     def ToString(self):
         """Overwrite .NET ToString."""


### PR DESCRIPTION
We are already doing a check for this before we export the model and so this warning from EnergyPlus is meaningless. We should remove it so that people don't get confused.