### PR TITLE
fix(simulate): Add support of OSM and IDF in "simulate model" command

### DIFF
--- a/tests/cli_simulate_test.py
+++ b/tests/cli_simulate_test.py
@@ -43,7 +43,7 @@ def test_simulate_model():
     result = runner.invoke(simulate_model, [input_model, input_epw])
     assert result.exit_code == 0
 
-    folder = os.path.join(folders.default_simulation_folder, 'ShoeBox')
-    output_sql = os.path.join(folder, 'OpenStudio', 'run', 'eplusout.sql')
+    folder = os.path.join(folders.default_simulation_folder, 'shoebox')
+    output_sql = os.path.join(folder, 'openstudio', 'run', 'eplusout.sql')
     assert os.path.isfile(output_sql)
     nukedir(folder)


### PR DESCRIPTION
The implementation is pretty hacky but this is just what we have to do if we don't want a separate recipe for each file type.