### PR TITLE
Added greenroof material

### DIFF
--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -871,6 +871,13 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
 
     @classmethod
     def from_idf(cls, idf_string):
+        """Create an EnergyMaterial from an EnergyPlus text string.
+
+        Args:
+            idf_string: A text string fully describing an EnergyPlus material.
+        """
+        ep_strs = parse_idf_string(idf_string, 'Material:RoofVegetation,')
+
         pass
 
     @classmethod
@@ -928,8 +935,8 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
             in data and data['res_vol_moist_cont'] is not None else 0.01
         ivmc = data['init_vol_moist_cont'] if 'init_vol_moist_cont' \
             in data and data['init_vol_moist_cont'] is not None else 0.1
-        mdc = data['moisture_dif_calculation'] if 'moisture_dif_calculation' in data and \
-            data['moisture_dif_calculation'] is not None else 'Simple'
+        mdc = data['moist_dif_calc'] if 'moist_dif_calc' in data and \
+            data['moist_dif_calc'] is not None else 'Simple'
 
         new_mat = cls(rough, thick, t_abs, s_abs, v_abs, dense, sp_ht, p_h, lai,
                       l_r, l_e, msr, sln, svmc, rvmc, ivmc, mdc)
@@ -942,4 +949,19 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
 
     def to_idf(self):
         """Get an EnergyPlus string representation of the material."""
-        pass
+        values = (self.identifier, self.plant_height, self.leaf_area_ind,
+                  self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
+                  self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
+                  self.density, self.specific_heat, self.thermal_absorptance,
+                  self.solar_absorptance, self.visible_absorptance,
+                  self.sat_vol_moist_cont, self.res_vol_moist_cont, self.init_vol_moist_cont,
+                  self.moist_dif_calc)
+        comments = ('name', 'height of plants', 'leaf area index', 'leaf reflectivity',
+                    'leaf emissivity', 'minimum stomatal resistance', 'soil layer name',
+                    'roughness', 'thickness', 'conductivity of dry soil', 'density of dry soil',
+                    'specific heat of dry soil', 'thermal absorptance', 'solar absorptance',
+                    'visible absorptance', 'saturation volumetric moisture content of the soil layer',
+                    'residual volumetric moisture content of the soil layer',
+                    'initial volumetric moisture content of the soil layer',
+                    'moisture diffusion calculation method')
+        return generate_idf_string('Material:RoofVegetation', values, comments)

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -653,10 +653,10 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
     """Green Roof Material
     https://bigladdersoftware.com/epx/docs/9-5/input-output-reference/group-surface-construction-elements.html#materialroofvegetation
     """
-    __slots__ = ('_plant_height', '_leaf_area_ind', '_leaf_reflectivity',
+    __slots__ = ('_thickness', '_conductivity', '_density', '_specific_heat', '_roughness',
+                 '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance',
+                 '_plant_height', '_leaf_area_ind', '_leaf_reflectivity',
                  '_leaf_emissivity', '_min_stomatal_res', '_soil_layer_name',
-                 '_roughness', '_thickness', '_conductivity', '_density',
-                 '_specific_heat', '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance',
                  '_sat_vol_moist_cont', '_res_vol_moist_cont', '_init_vol_moist_cont',
                  '_moist_dif_calc')
 
@@ -1037,11 +1037,11 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
 
     def __copy__(self):
         new_material = self.__class__(
-            self.identifier, self.plant_height, self.leaf_area_ind,
-            self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
-            self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
-            self.density, self.specific_heat, self.thermal_absorptance,
-            self.solar_absorptance, self.visible_absorptance, self.sat_vol_moist_cont,
+            self.identifier, self.thickness, self.conductivity, self.density,
+            self.specific_heat, self.roughness, self.thermal_absorptance,
+            self.solar_absorptance, self.visible_absorptance, self.plant_height,
+            self.leaf_area_ind, self.leaf_reflectivity, self.leaf_emissivity,
+            self.min_stomatal_res, self.soil_layer_name, self.sat_vol_moist_cont,
             self.res_vol_moist_cont, self.init_vol_moist_cont, self.moist_dif_calc)
         new_material._display_name = self._display_name
         return new_material

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -84,7 +84,8 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
     @roughness.setter
     def roughness(self, rough):
         assert rough in self.ROUGHTYPES, 'Invalid input "{}" for material roughness.' \
-            ' Roughness must be one of the following:\n'.format(rough, self.ROUGHTYPES)
+            ' Roughness must be one of the following:\n'.format(
+                rough, self.ROUGHTYPES)
         self._roughness = rough
 
     @property
@@ -198,7 +199,8 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
 
     @r_value.setter
     def r_value(self, r_val):
-        _new_conductivity = self.thickness / float_positive(r_val, 'material r-value')
+        _new_conductivity = self.thickness / \
+            float_positive(r_val, 'material r-value')
         self._conductivity = _new_conductivity
 
     @property
@@ -300,7 +302,8 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
             raise ImportError('honeybee_radiance library must be installed to use '
                               'to_radiance_solar() method. {}'.format(e))
         return Plastic.from_single_reflectance(
-            clean_rad_string(self.identifier), 1 - self.solar_absorptance, specularity,
+            clean_rad_string(self.identifier), 1 -
+            self.solar_absorptance, specularity,
             self.RADIANCEROUGHTYPES[self.roughness])
 
     def to_radiance_visible(self, specularity=0.0):
@@ -311,7 +314,8 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
             raise ImportError('honeybee_radiance library must be installed to use '
                               'to_radiance_solar() method. {}'.format(e))
         return Plastic.from_single_reflectance(
-            clean_rad_string(self.identifier), 1 - self.visible_absorptance, specularity,
+            clean_rad_string(self.identifier), 1 -
+            self.visible_absorptance, specularity,
             self.RADIANCEROUGHTYPES[self.roughness])
 
     def to_dict(self):
@@ -438,7 +442,8 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
     @roughness.setter
     def roughness(self, rough):
         assert rough in self.ROUGHTYPES, 'Invalid input "{}" for material roughness.' \
-            ' Roughness must be one of the following:\n'.format(rough, self.ROUGHTYPES)
+            ' Roughness must be one of the following:\n'.format(
+                rough, self.ROUGHTYPES)
         self._roughness = rough
 
     @property
@@ -559,7 +564,8 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
             data['solar_absorptance'] is not None else 0.7
         v_abs = data['visible_absorptance'] if 'visible_absorptance' in data else None
 
-        new_mat = cls(data['identifier'], data['r_value'], rough, t_abs, s_abs, v_abs)
+        new_mat = cls(data['identifier'], data['r_value'],
+                      rough, t_abs, s_abs, v_abs)
         if 'display_name' in data and data['display_name'] is not None:
             new_mat.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
@@ -584,7 +590,8 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
             raise ImportError('honeybee_radiance library must be installed to use '
                               'to_radiance_solar() method. {}'.format(e))
         return Plastic.from_single_reflectance(
-            clean_rad_string(self.identifier), 1 - self.solar_absorptance, specularity,
+            clean_rad_string(self.identifier), 1 -
+            self.solar_absorptance, specularity,
             self.RADIANCEROUGHTYPES[self.roughness])
 
     def to_radiance_visible(self, specularity=0.0):
@@ -595,7 +602,8 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
             raise ImportError('honeybee_radiance library must be installed to use '
                               'to_radiance_solar() method. {}'.format(e))
         return Plastic.from_single_reflectance(
-            clean_rad_string(self.identifier), 1 - self.visible_absorptance, specularity,
+            clean_rad_string(self.identifier), 1 -
+            self.visible_absorptance, specularity,
             self.RADIANCEROUGHTYPES[self.roughness])
 
     def to_dict(self):
@@ -638,3 +646,124 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
             self.solar_absorptance, self._visible_absorptance)
         new_material._display_name = self._display_name
         return new_material
+
+
+@lockable
+class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
+    """Green Roof Material
+    https://bigladdersoftware.com/epx/docs/9-5/input-output-reference/group-surface-construction-elements.html#materialroofvegetation"""
+    __slots__ = ('_plant_height', '_leaf_area_ind', '_leaf_reflectivity',
+                 '_leaf_emissivity', '_min_stomatal_res', '_soil_layer_name',
+                 '_roughness', '_thickness', '_conductivity', '_density',
+                 '_specific_heat', '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance',
+                 '_sat_vol_moist_cont', '_res_vol_moist_cont', '_init_vol_moist_cont',
+                 '_moist_dif_calc')
+
+    def __init__(self, identifier, thickness=0.1, conductivity=0.35, density=1100, specific_heat=800,
+                 roughness='MediumRough', thermal_absorptance=0.9,
+                 solar_absorptance=0.7, visible_absorptance=None, plant_height=0.2,
+                 leaf_area_ind=1.0, leaf_reflectivity=0.22, leaf_emissivity=0.95,
+                 min_stomatal_res=180, soil_layer_name='GreenRoofSoil',
+                 sat_vol_moist_cont=0.3, res_vol_moist_cont=0.01, init_vol_moist_cont=0.1,
+                 moist_dif_calc='Simple'):
+        self.thickness = thickness
+        self.conductivity = conductivity
+        self.density = density
+        self.specific_heat = specific_heat
+        self.roughness = roughness
+        self.thermal_absorptance = thermal_absorptance
+        self.solar_absorptance = solar_absorptance
+        self.visible_absorptance = visible_absorptance
+        self.plant_height = plant_height
+        self.leaf_area_ind = leaf_area_ind
+        self.leaf_reflectivity = leaf_reflectivity
+        self.leaf_emissivity = leaf_emissivity
+        self.min_stomatal_res = min_stomatal_res
+        self.soil_layer_name = soil_layer_name
+        self.sat_vol_moist_cont = sat_vol_moist_cont
+        self.res_vol_moist_cont = res_vol_moist_cont
+        self.init_vol_moist_cont = init_vol_moist_cont
+        self.moist_dif_calc = moist_dif_calc
+
+    @property
+    def roughness(self):
+        """Get or set the text describing the roughness of the material layer."""
+        return self._roughness
+
+    @roughness.setter
+    def roughness(self, rough):
+        assert rough in self.ROUGHTYPES, 'Invalid input "{}" for material roughness.' \
+            ' Roughness must be one of the following:\n'.format(
+                rough, self.ROUGHTYPES)
+        self._roughness = rough
+
+    @property
+    def thickness(self):
+        """Get or set the thickess of the material layer [m]."""
+        return self._thickness
+
+    @thickness.setter
+    def thickness(self, thick):
+        self._thickness = float_positive(thick, 'material thickness')
+        self._compare_thickness_conductivity()
+
+    @property
+    def conductivity(self):
+        """Get or set the conductivity of the material layer [W/m-K]."""
+        return self._conductivity
+
+    @conductivity.setter
+    def conductivity(self, cond):
+        self._conductivity = float_positive(cond, 'material conductivity')
+        self._compare_thickness_conductivity()
+
+    @property
+    def density(self):
+        """Get or set the density of the material layer [kg/m3]."""
+        return self._density
+
+    @density.setter
+    def density(self, dens):
+        self._density = float_positive(dens, 'material density')
+
+    @property
+    def specific_heat(self):
+        """Get or set the specific heat of the material layer [J/kg-K]."""
+        return self._specific_heat
+
+    @specific_heat.setter
+    def specific_heat(self, sp_ht):
+        self._specific_heat = float_in_range(
+            sp_ht, 100.0, input_name='material specific heat')
+
+    @property
+    def thermal_absorptance(self):
+        """Get or set the thermal absorptance of the material layer."""
+        return self._thermal_absorptance
+
+    @thermal_absorptance.setter
+    def thermal_absorptance(self, t_abs):
+        self._thermal_absorptance = float_in_range(
+            t_abs, 0.0, 1.0, 'material thermal absorptance')
+
+    @property
+    def solar_absorptance(self):
+        """Get or set the solar absorptance of the material layer."""
+        return self._solar_absorptance
+
+    @solar_absorptance.setter
+    def solar_absorptance(self, s_abs):
+        self._solar_absorptance = float_in_range(
+            s_abs, 0.0, 1.0, 'material solar absorptance')
+
+    @property
+    def visible_absorptance(self):
+        """Get or set the visible absorptance of the material layer."""
+        return self._visible_absorptance if self._visible_absorptance is not None \
+            else self._solar_absorptance
+
+    @visible_absorptance.setter
+    def visible_absorptance(self, v_abs):
+        self._visible_absorptance = float_in_range(
+            v_abs, 0.0, 1.0, 'material visible absorptance') if v_abs is not None \
+            else None

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -868,3 +868,78 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
             self._moist_dif_calc = mdc
         else:
             self._moist_dif_calc = 'Simple'
+
+    @classmethod
+    def from_idf(cls, idf_string):
+        pass
+
+    @classmethod
+    def from_dict(cls, data):
+        """Create an EnergyMaterialGreenRoof from a dictionary.
+
+        Args:
+            data: A python dictionary in the following format
+
+        .. code-block:: python
+
+            {
+            "type": 'EnergyMaterialGreenRoof',
+            "identifier": 'My_New_Green_Roof_040_110_5834_654',
+            "display_name": 'My green roof',
+            "thickness"
+
+            }
+
+        """
+        assert data['type'] == 'EnergyMaterialGreenRoof', \
+            'Expectend EnergyMaterialGreenRoof. Got {}'.format(data['type'])
+        # Use .setter arg_names
+        # For setting default values from dict to obj:
+        rough = data['roughness'] if 'roughness' in data and \
+            data['roughness'] is not None else 'MediumRough'
+        thick = data['thickness'] if 'thickness' in data and \
+            data['thickness'] is not None else 0.1
+        t_abs = data['thermal_absorptance'] if 'thermal_absorptance' in data and \
+            data['thermal_absorptance'] is not None else 0.9
+        s_abs = data['solar_absorptance'] if 'solar_absorptance' in data and \
+            data['solar_absorptance'] is not None else 0.7
+        v_abs = data['visible_absorptance'] if 'visible_absorptance' in data else None
+        cond = data['conductivity'] if 'conductivity' in data and \
+            data['conductivity'] is not None else 0.35
+        dens = data['density'] if 'density' in data and \
+            data['density'] is not None else 1100
+        sp_ht = data['specific_heat'] if 'specific_heat' in data and \
+            data['specific_heat'] is not None else 800
+        p_h = data['plant_height'] if 'plant_height' in data and \
+            data['plant_height'] is not None else 0.2
+        lai = data['leaf_area_index'] if 'leaf_area_index' in data and \
+            data['leaf_area_index'] is not None else 1.0
+        l_r = data['leaf_reflectivity'] if 'leaf_reflectivity' in data and \
+            data['leaf_reflectivity'] is not None else 0.22
+        l_e = data['leaf_emissivity'] if 'leaf_emissivity' in data and \
+            data['leaf_emissivity'] is not None else 0.95
+        msr = data['min_stomatal_res'] if 'min_stomatal_res' in data and \
+            data['min_stomatal_res'] is not None else 180
+        sln = data['soil_layer_name'] if 'soil_layer_name' in data and \
+            data['soil_layer_name'] is not None else 'GreenRoofSoil'
+        svmc = data['sat_vol_moist_cont'] if 'sat_vol_moist_cont' \
+            in data and data['sat_vol_moist_cont'] is not None else 0.3
+        rvmc = data['res_vol_moist_cont'] if 'res_vol_moist_cont' \
+            in data and data['res_vol_moist_cont'] is not None else 0.01
+        ivmc = data['init_vol_moist_cont'] if 'init_vol_moist_cont' \
+            in data and data['init_vol_moist_cont'] is not None else 0.1
+        mdc = data['moisture_dif_calculation'] if 'moisture_dif_calculation' in data and \
+            data['moisture_dif_calculation'] is not None else 'Simple'
+
+        new_mat = cls(rough, thick, t_abs, s_abs, v_abs, dense, sp_ht, p_h, lai,
+                      l_r, l_e, msr, sln, svmc, rvmc, ivmc, mdc)
+        if 'display_name' in data and data['display_name'] is not None:
+            new_mat.display_name = data['display_name']
+        if 'user_data' in data and data['user_data'] is not None:
+            new_mat.user_data = data['user_data']
+
+        return new_mat
+
+    def to_idf(self):
+        """Get an EnergyPlus string representation of the material."""
+        pass

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -889,11 +889,26 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         .. code-block:: python
 
             {
-            "type": 'EnergyMaterialGreenRoof',
-            "identifier": 'My_New_Green_Roof_040_110_5834_654',
-            "display_name": 'My green roof',
-            "thickness"
-
+            'type': 'EnergyMaterialGreenRoof',
+            'identifier': 'Green_Roof_040_110_7868_987',
+            'plant_height': 0.9,
+            'leaf_area_ind': 1.0,
+            'leaf_reflectivity': 0.22,
+            'leaf_emissivity': 0.95,
+            'min_stomatal_res': 180,
+            'soil_layer_name': 'GreenRoofSoil,
+            'roughness': 'MediumRough,
+            'thickness':0.1,
+            'conductivity': 0.35,
+            'density': 1100,
+            'specific_heat': 800,
+            'thermal_absorptance': 0.9,
+            'solar_absorptance': 0.7,
+            'visible_absorptance':0.7,
+            'sat_vol_moist_cont': 0.3,
+            'res_vol_moist_cont': 0.01,
+            'init_vol_moist_cont': 0.1,
+            'moist_dif_calc': 'Simple'
             }
 
         """
@@ -1012,6 +1027,9 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __repr__(self):
+        return self.to_idf()
 
     def __copy__(self):
         new_material = self.__class__(self.identifier, self.plant_height, self.leaf_area_ind,

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -651,7 +651,8 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
 @lockable
 class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
     """Green Roof Material
-    https://bigladdersoftware.com/epx/docs/9-5/input-output-reference/group-surface-construction-elements.html#materialroofvegetation"""
+    https://bigladdersoftware.com/epx/docs/9-5/input-output-reference/group-surface-construction-elements.html#materialroofvegetation
+    """
     __slots__ = ('_plant_height', '_leaf_area_ind', '_leaf_reflectivity',
                  '_leaf_emissivity', '_min_stomatal_res', '_soil_layer_name',
                  '_roughness', '_thickness', '_conductivity', '_density',

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -767,3 +767,104 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         self._visible_absorptance = float_in_range(
             v_abs, 0.0, 1.0, 'material visible absorptance') if v_abs is not None \
             else None
+
+    @property
+    def plant_height(self):
+        return(self._plant_height)
+
+    @plant_height.setter
+    def plant_height(self, p_h):
+        self._plant_height = float_in_range(
+            p_h, 0.005, 1.000, 'plant height') if p_h is not None \
+            else None
+
+    @property
+    def leaf_area_ind(self):
+        return(self._leaf_area_ind)
+
+    @leaf_area_ind.setter
+    def leaf_area_ind(self, lai):
+        self._leaf_area_ind = float_in_range(
+            lai, 0.001, 5.00, 'leaf area index') if lai is not None \
+            else None
+
+    @property
+    def leaf_reflectivity(self):
+        return(self._leaf_reflectivity)
+
+    @leaf_reflectivity.setter
+    def leaf_reflectivity(self, l_r):
+        self._leaf_reflectivity = float_in_range(
+            l_r, 0.05, 0.50, 'leaf reflectivity') if l_r is not None \
+            else None
+
+    @property
+    def leaf_emissivity(self):
+        return(self._leaf_emissivity)
+
+    @leaf_emissivity.setter
+    def leaf_emissivity(self, l_e):
+        self._leaf_emissivity = float_in_range(
+            l_e, 0.8, 1.0) if l_e is not None \
+            else None
+
+    @property
+    def min_stomatal_res(self):
+        return(self._min_stomatal_res)
+
+    @min_stomatal_res.setter
+    def min_stomatal_res(self, msr):
+        self._min_stomatal_res = float_in_range(
+            msr, 50.0, 300.0, 'minimum stomatal resistance') if msr is not None \
+            else None
+
+    @property
+    def soil_layer_name(self):
+        return(self._soil_layer_name)
+
+    @soil_layer_name.setter
+    def soil_layer_name(self, sln):
+        self._soil_layer_name = sln if sln is not None \
+            else None
+
+    @property
+    def sat_vol_moist_cont(self):
+        return(self._sat_vol_moist_cont)
+
+    @sat_vol_moist_cont.setter
+    def sat_vol_moist_cont(self, svmc):
+        self._sat_vol_moist_cont = float_in_range(
+            svmc, 0.1, 0.5, 'saturation volumetric moisture content of soil layer') \
+            if svmc is not None \
+            else None
+
+    @property
+    def res_vol_moist_cont(self):
+        return(self._res_vol_moist_cont)
+
+    @res_vol_moist_cont.setter
+    def res_vol_moist_cont(self, rvmc):
+        self._res_vol_moist_cont = float_in_range(
+            rvmc, 0.01, 0.1) if rvmc is not None \
+            else None
+
+    @property
+    def init_vol_moist_cont(self):
+        return(self._init_vol_moist_cont)
+
+    @init_vol_moist_cont.setter
+    def init_vol_moist_cont(self, ivmc):
+        self._init_vol_moist_cont = float_in_range(
+            ivmc, 0.05, 0.50) if ivmc is not None \
+            else None
+
+    @property
+    def moist_dif_calc(self):
+        return(self._moist_dif_calc)
+
+    @moist_dif_calc.setter
+    def moist_dif_calc(self, mdc):
+        if mdc == 'Simple':
+            self._moist_dif_calc = mdc
+        else:
+            self._moist_dif_calc = 'Simple'

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -877,8 +877,7 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
             idf_string: A text string fully describing an EnergyPlus material.
         """
         ep_strs = parse_idf_string(idf_string, 'Material:RoofVegetation,')
-
-        pass
+        return cls(*ep_strs)
 
     @classmethod
     def from_dict(cls, data):
@@ -965,3 +964,62 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
                     'initial volumetric moisture content of the soil layer',
                     'moisture diffusion calculation method')
         return generate_idf_string('Material:RoofVegetation', values, comments)
+
+    def to_dict(self):
+        base = {
+            'type': 'EnergyMaterialGreenRoof',
+            'identifier': self.identifier,
+            'plant_height': self.plant_height,
+            'leaf_area_ind': self.leaf_area_ind,
+            'leaf_reflectivity': self.leaf_reflectivity,
+            'leaf_emissivity': self.leaf_emissivity,
+            'min_stomatal_res': self.min_stomatal_res,
+            'soil_layer_name': self.soil_layer_name,
+            'roughness': self.roughness,
+            'thickness': self.thickness,
+            'conductivity': self.conductivity,
+            'density': self.density,
+            'specific_heat': self.specific_heat,
+            'thermal_absorptance': self.thermal_absorptance,
+            'solar_absorptance': self.solar_absorptance,
+            'visible_absorptance': self.visible_absorptance,
+            'sat_vol_moist_cont': self.sat_vol_moist_cont,
+            'res_vol_moist_cont': self.res_vol_moist_cont,
+            'init_vol_moist_cont': self.init_vol_moist_cont,
+            'moist_dif_calc': self.moist_dif_calc
+        }
+        if self._display_name is not None:
+            base['display_name'] = self.display_name
+        if self._user_data is not None:
+            base['user_data'] = self.user_data
+        return base
+
+    def __key(self):
+        """A tuple based on the object properties, useful for hashing."""
+        return (self.identifier, self.plant_height, self.leaf_area_ind,
+                self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
+                self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
+                self.density, self.specific_heat, self.thermal_absorptance,
+                self.solar_absorptance, self.visible_absorptance,
+                self.sat_vol_moist_cont, self.res_vol_moist_cont, self.init_vol_moist_cont,
+                self.moist_dif_calc)
+
+    def __hash__(self):
+        return hash(self.__key())
+
+    def __eq__(self, other):
+        return isinstance(other, EnergyMaterialGreenRoof) and self.__key() == other.__key()
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __copy__(self):
+        new_material = self.__class__(self.identifier, self.plant_height, self.leaf_area_ind,
+                                      self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
+                                      self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
+                                      self.density, self.specific_heat, self.thermal_absorptance,
+                                      self.solar_absorptance, self.visible_absorptance,
+                                      self.sat_vol_moist_cont, self.res_vol_moist_cont, self.init_vol_moist_cont,
+                                      self.moist_dif_calc)
+        new_material._display_name = self._display_name
+        return new_material

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -955,8 +955,11 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         Args:
             idf_string: A text string fully describing an EnergyPlus material.
         """
-        ep_strs = parse_idf_string(idf_string, "Material:RoofVegetation, ")
-        return cls(*ep_strs)
+        ep_strs = parse_idf_string(idf_string, 'Material:RoofVegetation')
+        return cls(ep_strs[0], ep_strs[8], ep_strs[9], ep_strs[10], ep_strs[11],
+                   ep_strs[7], ep_strs[12], ep_strs[13], ep_strs[14], ep_strs[1],
+                   ep_strs[2], ep_strs[3], ep_strs[4], ep_strs[5], ep_strs[6],
+                   ep_strs[15], ep_strs[16], ep_strs[17], ep_strs[18])
 
     @classmethod
     def from_dict(cls, data):

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -650,8 +650,83 @@ class EnergyMaterialNoMass(_EnergyMaterialOpaqueBase):
 
 @lockable
 class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
-    """Green Roof Material
-    https://bigladdersoftware.com/epx/docs/9-5/input-output-reference/group-surface-construction-elements.html#materialroofvegetation
+    """EnergyPlus Material:RoofVegetation
+
+    Args:
+        identifier: Text string for a unique Material ID. Must be < 100 characters
+            and not contain any EnergyPlus special characters. This will be used to
+            identify the object across a model and in the exported IDF.
+        thickness: Number for the thickness of the soil layer [m].
+        conductivity: Number for the thermal conductivity of the dry soil [W/m-K].
+        density: Number for the density of the dry soil [kg/m3].
+        specific_heat: Number for the specific heat of the material [J/kg-K].
+        roughness: Text describing the relative roughness of the material.
+            Must be one of the following: 'VeryRough', 'Rough', 'MediumRough',
+            'MediumSmooth', 'Smooth', 'VerySmooth'. Default is 'MediumRough'.
+        thermal_absorptance: A number between 0 and 1 for the fraction of
+            incident long wavelength radiation that is absorbed by the material.
+            Default value is 0.9.
+        solar_absorptance: A number between 0 and 1 for the fraction of incident
+            solar radiation absorbed by the material. Default value is 0.7.
+        visible_absorptance: A number between 0 and 1 for the fraction of incident
+            visible wavelength radiation absorbed by the material.
+            Default is None, which will yield the same value as solar_absorptance.
+        plant_height: This field defines the height of plants in units of meters. 
+            This field is limited to values in the range 0.005 < Height < 1.00 m. 
+            Default is .2 m.
+        leaf_area_ind: This is the projected leaf area per unit area of soil surface.
+            This field is dimensionless and is limited to values in the range of
+            0.001 < LAI < 5.0. Default is 1.0. At the present time the fraction 
+            vegetation cover is calculated directly from LAI (Leaf Area Index) 
+            using an empirical relation.
+        leaf_reflectivity: This field represents the fraction of incident solar 
+            radiation that is reflected by the individual leaf surfaces (albedo). 
+            Solar radiation includes the visible spectrum as well as infrared 
+            and ultraviolet wavelengths. Values for this field must be between 
+            0.05 and 0.5. Default is .22. Typical values are .18 to .25.
+        leaf_emissivity: This field is the ratio of thermal radiation emitted from 
+            leaf surfaces to that emitted by an ideal black body at the same temperature. 
+            This parameter is used when calculating the long wavelength radiant exchange 
+            at the leaf surfaces. Values for this field must be between 
+            0.8 and 1.0 (with 1.0 representing “black body” conditions). Default is .95.
+        min_stomatal_res: This field represents the resistance of the plants to moisture 
+            transport. It has units of s/m. Plants with low values of stomatal resistance 
+            will result in higher evapotranspiration rates than plants with high resistance. 
+            Values for this field must be in the range of 50.0 to 300.0. Default is 180.
+        soil_layer_name: This field is a unique reference name that the user assigns to the 
+            soil layer for a particular ecoroof. This name can then be referred to by 
+            other input data. Default is Green Roof Soil.
+        sat_vol_moist_cont: The field allows for user input of the saturation moisture 
+            content of the soil layer. Maximum moisture content is typically less than 
+            0.5. Range is [.1,.5] with the default being .3.
+        res_vol_moist_cont: The field allows for user input of the residual moisture 
+            content of the soil layer. Default is .01, range is [.01,.1].
+        init_vol_moist_cont: The field allows for user input of the initial moisture 
+            content of the soil layer. Range is (.05, .5] with the default being .1.
+        moist_dif_calc: The field allows for two models to be selected: Simple or Advanced. 
+            EnergyPlus Currently supports only the Simple Moisture Diffusion Calculation Method.
+
+    Properties:
+        * identifier
+        * display_name
+        * roughness
+        * thickness
+        * conductivity
+        * density
+        * specific_heat
+        * thermal_absorptance
+        * solar_absorptance
+        * visible_absorptance
+        * plant_height
+        * leaf_area_ind
+        * leaf_reflectivity
+        * leaf_emissivity
+        * min_stomatal_res
+        * soil_layer_name
+        * sat_vol_moist_cont
+        * res_vol_moist_cont
+        * init_vol_moist_cont
+        * moist_dif_calc
     """
     __slots__ = ('_thickness', '_conductivity', '_density', '_specific_heat', '_roughness',
                  '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance',

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -880,7 +880,7 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         Args:
             idf_string: A text string fully describing an EnergyPlus material.
         """
-        ep_strs = parse_idf_string(idf_string, 'Material:RoofVegetation,')
+        ep_strs = parse_idf_string(idf_string, "Material:RoofVegetation, ")
         return cls(*ep_strs)
 
     @classmethod
@@ -937,8 +937,8 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
             data['specific_heat'] is not None else 800
         p_h = data['plant_height'] if 'plant_height' in data and \
             data['plant_height'] is not None else 0.2
-        lai = data['leaf_area_index'] if 'leaf_area_index' in data and \
-            data['leaf_area_index'] is not None else 1.0
+        lai = data['leaf_area_ind'] if 'leaf_area_ind' in data and \
+            data['leaf_area_ind'] is not None else 1.0
         l_r = data['leaf_reflectivity'] if 'leaf_reflectivity' in data and \
             data['leaf_reflectivity'] is not None else 0.22
         l_e = data['leaf_emissivity'] if 'leaf_emissivity' in data and \
@@ -956,8 +956,8 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         mdc = data['moist_dif_calc'] if 'moist_dif_calc' in data and \
             data['moist_dif_calc'] is not None else 'Simple'
 
-        new_mat = cls(rough, thick, t_abs, s_abs, v_abs, dense, sp_ht, p_h, lai,
-                      l_r, l_e, msr, sln, svmc, rvmc, ivmc, mdc)
+        new_mat = cls(data['identifier'], thick, cond, dens, sp_ht, rough, t_abs, s_abs, v_abs, p_h,
+                      lai, l_r, l_e, msr, sln, svmc, rvmc, ivmc, mdc)
         if 'display_name' in data and data['display_name'] is not None:
             new_mat.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -667,6 +667,7 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
                  min_stomatal_res=180, soil_layer_name='GreenRoofSoil',
                  sat_vol_moist_cont=0.3, res_vol_moist_cont=0.01, init_vol_moist_cont=0.1,
                  moist_dif_calc='Simple'):
+        _EnergyMaterialOpaqueBase.__init__(self, identifier)
         self.thickness = thickness
         self.conductivity = conductivity
         self.density = density
@@ -685,6 +686,7 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         self.res_vol_moist_cont = res_vol_moist_cont
         self.init_vol_moist_cont = init_vol_moist_cont
         self.moist_dif_calc = moist_dif_calc
+        self._locked = False
 
     @property
     def roughness(self):
@@ -735,7 +737,8 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
     @specific_heat.setter
     def specific_heat(self, sp_ht):
         self._specific_heat = float_in_range(
-            sp_ht, 100.0, input_name='material specific heat')
+            sp_ht, 100.0, input_name='material specific heat') if sp_ht is not None \
+            else None
 
     @property
     def thermal_absorptance(self):
@@ -1033,12 +1036,12 @@ class EnergyMaterialGreenRoof(_EnergyMaterialOpaqueBase):
         return self.to_idf()
 
     def __copy__(self):
-        new_material = self.__class__(self.identifier, self.plant_height, self.leaf_area_ind,
-                                      self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
-                                      self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
-                                      self.density, self.specific_heat, self.thermal_absorptance,
-                                      self.solar_absorptance, self.visible_absorptance,
-                                      self.sat_vol_moist_cont, self.res_vol_moist_cont, self.init_vol_moist_cont,
-                                      self.moist_dif_calc)
+        new_material = self.__class__(
+            self.identifier, self.plant_height, self.leaf_area_ind,
+            self.leaf_reflectivity, self.leaf_emissivity, self.min_stomatal_res,
+            self.soil_layer_name, self.roughness, self.thickness, self.conductivity,
+            self.density, self.specific_heat, self.thermal_absorptance,
+            self.solar_absorptance, self.visible_absorptance, self.sat_vol_moist_cont,
+            self.res_vol_moist_cont, self.init_vol_moist_cont, self.moist_dif_calc)
         new_material._display_name = self._display_name
         return new_material

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -1,8 +1,9 @@
 # coding=utf-8
-from honeybee_energy.material.opaque import EnergyMaterial, EnergyMaterialNoMass
+from honeybee_energy.material.opaque import EnergyMaterial, EnergyMaterialNoMass, EnergyMaterialGreenRoof
 
 import pytest
 from .fixtures.userdata_fixtures import userdatadict
+
 
 def test_material_init(userdatadict):
     """Test the initialization of EnergyMaterial objects and basic properties."""
@@ -38,7 +39,6 @@ def test_material_init(userdatadict):
         concrete.thickness = 0
     with pytest.raises(AssertionError):
         concrete.thickness = 0.000000001
-    
 
 
 def test_material_equivalency(userdatadict):
@@ -224,3 +224,15 @@ def test_material_nomass_dict_methods(userdatadict):
     material_dict = material.to_dict()
     new_material = EnergyMaterialNoMass.from_dict(material_dict)
     assert material_dict == new_material.to_dict()
+
+
+def test_greenroof_init(userdatadict):
+    """Test initialization of EnergyMaterialGreenRoof Object and basic properties"""
+    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.2, 0.45, 1200, 900, 'Rough', 0.91, 0.65,
+                                    0.7, 0.5, 2.0, 0.25, 0.89, 250, 'Greendirt', 0.4, 0.04,
+                                    0.2, 'Simple')
+    groof.user_data = userdatadict
+    str(groof)
+    groof_dup = groof.duplicate()
+
+    assert groof.identifier == groof_dup.identifier == 'roofmcroofface'

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -356,37 +356,48 @@ def test_greenroof_invalid():
         groof.init_vol_moist_cont = 5
 
 
-def test_greenroof_init_from_idf():
-    """Test the initialization of EnergyMaterialGreenRoof objects from strings."""
-    ep_str_1 = "Material:RoofVegetation,\n" \
-        "myroof,                   !- name\n"\
-        "0.5,                      !- height of plants\n"\
-        "2.0,                      !- leaf area index\n"\
-        "0.25,                     !- leaf reflectivity\n"\
-        "0.90,                     !- leaf emissivity\n"\
-        "350.0,                    !- minimum stomatal resistance\n"\
-        "GreenRoofDIRT,            !- soil layer name\n"\
-        "MediumRough,              !- roughness\n"\
-        "0.5,                      !- thickness\n"\
-        "0.45,                     !- conductivity of dry soil\n"\
-        "1250.0,                   !- density of dry soil\n"\
-        "950.0,                    !- specific heat of dry soil\n"\
-        "0.74,                      !- thermal absorptance\n"\
-        "0.6,                      !- solar absorptance\n"\
-        "0.5,                      !- visible absorptance\n"\
-        "0.4,                      !- saturation volumetric moisture content of the soil layer\n"\
-        "0.9,                     !- residual volumetric moisture content of the soil layer\n"\
-        "0.4,                      !- initial volumetric moisture content of the soil layer\n"\
-        "Simple;                   !- moisture diffusion calculation method"
-    mat_1 = EnergyMaterial.from_idf(ep_str_1)
+# def test_greenroof_init_from_idf():
+#    """Test the initialization of EnergyMaterialGreenRoof objects from strings."""
+#    ep_st_1 = "Material:RoofVegetation,\n" \
+#        " myroof,                   !- name\n"\
+#        " 0.5,                      !- height of plants\n"\
+#        " 2.0,                      !- leaf area index\n"\
+#        " 0.25,                     !- leaf reflectivity\n"\
+#        " 0.90,                     !- leaf emissivity\n"\
+#        " 350.0,                    !- minimum stomatal resistance\n"\
+#        " GreenRoofDIRT,            !- soil layer name\n"\
+#        " MediumRough,              !- roughness\n"\
+#        " 0.5,                      !- thickness\n"\
+#        " 0.45,                     !- conductivity of dry soil\n"\
+#        " 1250.0,                   !- density of dry soil\n"\
+#        " 950.0,                    !- specific heat of dry soil\n"\
+#        " 0.74,                     !- thermal absorptance\n"\
+#        " 0.6,                      !- solar absorptance\n"\
+#        " 0.5,                      !- visible absorptance\n"\
+#        " 0.4,                      !- saturation volumetric moisture content of the soil layer\n"\
+#        " 0.9,                      !- residual volumetric moisture content of the soil layer\n"\
+#        " 0.4,                      !- initial volumetric moisture content of the soil layer\n"\
+#        " Simple;                   !- moisture diffusion calculation method"
+#    matter_1 = EnergyMaterial.from_idf(ep_st_1)
+#
+#    ep_st_2 = "Material:RoofVegetation, myroof, 0.5, 2.0, 0.25, 0.90, 350.0, " \
+#        "GreenRoofDIRT, MediumRough, 0.5, 0.45, 1250.0, 950.0, 0.74, 0.6, " \
+#        "0.5, 0.4, 0.9, 0.4, Simple;"
+#    matter_2 = EnergyMaterialGreenRoof.from_idf(ep_str_2)
+#
+#    assert matter_1.identifier == matter_2.identifier
+#    assert matter_1 == matter_2
+#
+#    new_idfstr = matter_1.to_idf()
+#    new_matter = EnergyMaterialGreenRoof.from_idf(new_idfstr)
+#    assert new_idfstr == new_mat.to_idf()
 
-    ep_str_2 = "Material:RoofVegetation, myroof, 0.5, 2.0, 0.25, 0.90, 350.0, " \
-        "GreenRoofDIRT, MediumRough, 0.5, 0.45, 1250.0, 950.0, 0.74, 0.6, " \
-        "0.5, 0.4, 0.9, 0.4, Simple;"
-    mat_2 = EnergyMaterialGreenRoof.from_idf(ep_str_2)
-
-    assert mat_1.identifier == mat_2.identifier
-    assert mat_1 == mat_2
-
-    new_mat = EnergyMaterialGreenRoof.from_idf(mat_1.to_idf())
-    assert ep_str_1 == new_mat.to_idf()
+def test_greenroof_dict_methods(userdatadict):
+    """Test to/from dict methods"""
+    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.5, 0.45, 1250, 950, 'Rough',
+                                    0.89, 0.65, 0.7, 0.5, 2, 0.35, 0.9, 275,
+                                    'greendirt', 0.4, 0.02, 0.15, 'Simple')
+    groof.user_data = userdatadict
+    grr_dict = groof.to_dict()
+    new_grr = EnergyMaterialGreenRoof.from_dict(grr_dict)
+    assert grr_dict == new_grr.to_dict()

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -356,41 +356,42 @@ def test_greenroof_invalid():
         groof.init_vol_moist_cont = 5
 
 
-# def test_greenroof_init_from_idf():
-#    """Test the initialization of EnergyMaterialGreenRoof objects from strings."""
-#    ep_st_1 = "Material:RoofVegetation,\n" \
-#        " myroof,                   !- name\n"\
-#        " 0.5,                      !- height of plants\n"\
-#        " 2.0,                      !- leaf area index\n"\
-#        " 0.25,                     !- leaf reflectivity\n"\
-#        " 0.90,                     !- leaf emissivity\n"\
-#        " 350.0,                    !- minimum stomatal resistance\n"\
-#        " GreenRoofDIRT,            !- soil layer name\n"\
-#        " MediumRough,              !- roughness\n"\
-#        " 0.5,                      !- thickness\n"\
-#        " 0.45,                     !- conductivity of dry soil\n"\
-#        " 1250.0,                   !- density of dry soil\n"\
-#        " 950.0,                    !- specific heat of dry soil\n"\
-#        " 0.74,                     !- thermal absorptance\n"\
-#        " 0.6,                      !- solar absorptance\n"\
-#        " 0.5,                      !- visible absorptance\n"\
-#        " 0.4,                      !- saturation volumetric moisture content of the soil layer\n"\
-#        " 0.9,                      !- residual volumetric moisture content of the soil layer\n"\
-#        " 0.4,                      !- initial volumetric moisture content of the soil layer\n"\
-#        " Simple;                   !- moisture diffusion calculation method"
-#    matter_1 = EnergyMaterial.from_idf(ep_st_1)
-#
-#    ep_st_2 = "Material:RoofVegetation, myroof, 0.5, 2.0, 0.25, 0.90, 350.0, " \
-#        "GreenRoofDIRT, MediumRough, 0.5, 0.45, 1250.0, 950.0, 0.74, 0.6, " \
-#        "0.5, 0.4, 0.9, 0.4, Simple;"
-#    matter_2 = EnergyMaterialGreenRoof.from_idf(ep_str_2)
-#
-#    assert matter_1.identifier == matter_2.identifier
-#    assert matter_1 == matter_2
-#
-#    new_idfstr = matter_1.to_idf()
-#    new_matter = EnergyMaterialGreenRoof.from_idf(new_idfstr)
-#    assert new_idfstr == new_mat.to_idf()
+def test_greenroof_init_from_idf():
+    """Test the initialization of EnergyMaterialGreenRoof objects from strings."""
+    ep_st_1 = """Material:RoofVegetation,
+           myroof,                   !- name
+           0.5,                      !- height of plants
+           2.0,                      !- leaf area index
+           0.25,                     !- leaf reflectivity
+           0.90,                     !- leaf emissivity
+           250.0,                    !- minimum stomatal resistance
+           GreenRoofDIRT,            !- soil layer name
+           MediumRough,              !- roughness
+           0.5,                      !- thickness
+           0.45,                     !- conductivity of dry soil
+           1250.0,                   !- density of dry soil
+           950.0,                    !- specific heat of dry soil
+           0.74,                     !- thermal absorptance
+           0.6,                      !- solar absorptance
+           0.5,                      !- visible absorptance
+           0.4,                      !- saturation volumetric moisture content of the soil layer
+           0.1,                      !- residual volumetric moisture content of the soil layer
+           0.4,                      !- initial volumetric moisture content of the soil layer
+           Simple;                   !- moisture diffusion calculation method"""
+    matter_1 = EnergyMaterialGreenRoof.from_idf(ep_st_1)
+
+    ep_st_2 = "Material:RoofVegetation, myroof, 0.5, 2.0, 0.25, 0.90, 250.0, " \
+        "GreenRoofDIRT, MediumRough, 0.5, 0.45, 1250.0, 950.0, 0.74, 0.6, " \
+        "0.5, 0.4, 0.1, 0.4, Simple;"
+    matter_2 = EnergyMaterialGreenRoof.from_idf(ep_st_2)
+
+    assert matter_1.identifier == matter_2.identifier
+    assert matter_1 == matter_2
+
+    new_idfstr = matter_1.to_idf()
+    new_matter = EnergyMaterialGreenRoof.from_idf(new_idfstr)
+    assert new_idfstr == new_matter.to_idf()
+
 
 def test_greenroof_dict_methods(userdatadict):
     """Test to/from dict methods"""

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -291,6 +291,7 @@ def test_greenroof_lockability(userdatadict):
 
 
 def test_greenroof_defaults():
+    """Test the EnergyMaterialGreenRoof default properties."""
     groof = EnergyMaterialGreenRoof('myroof')
 
     assert groof.thickness == 0.1
@@ -315,3 +316,77 @@ def test_greenroof_defaults():
 
 def test_greenroof_invalid():
     """Test the initializaion of EnergyMaterialGreenRoof objects with invalid properties."""
+    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.5, 0.45, 1250, 950, 'Rough',
+                                    0.89, 0.65, 0.7, 0.5, 2, 0.35, 0.9, 275,
+                                    'greendirt', 0.4, 0.02, 0.15, 'Simple')
+
+    with pytest.raises(TypeError):
+        groof.identifier = ['test_identifier']
+    with pytest.raises(AssertionError):
+        groof.thickness = -1
+    with pytest.raises(AssertionError):
+        groof.roughness = 'Shmedium'
+    with pytest.raises(AssertionError):
+        groof.conductivity = -3.25
+    with pytest.raises(AssertionError):
+        groof.density = -15
+    with pytest.raises(AssertionError):
+        groof.specific_heat = 25
+    with pytest.raises(AssertionError):
+        groof.thermal_absorptance = 5
+    with pytest.raises(AssertionError):
+        groof.solar_absorptance = 5
+    with pytest.raises(AssertionError):
+        groof.visible_absorptance = 12.53
+    with pytest.raises(AssertionError):
+        groof.plant_height = 0.0001
+    with pytest.raises(AssertionError):
+        groof.leaf_area_ind = 10
+    with pytest.raises(AssertionError):
+        groof.leaf_reflectivity = 1
+    with pytest.raises(AssertionError):
+        groof.leaf_emissivity = 0.1
+    with pytest.raises(AssertionError):
+        groof.min_stomatal_res = 10
+    with pytest.raises(AssertionError):
+        groof.sat_vol_moist_cont = 1
+    with pytest.raises(AssertionError):
+        groof.res_vol_moist_cont = 0.4
+    with pytest.raises(AssertionError):
+        groof.init_vol_moist_cont = 5
+
+
+def test_greenroof_init_from_idf():
+    """Test the initialization of EnergyMaterialGreenRoof objects from strings."""
+    ep_str_1 = "Material:RoofVegetation,\n" \
+        "myroof,                   !- name\n"\
+        "0.5,                      !- height of plants\n"\
+        "2.0,                      !- leaf area index\n"\
+        "0.25,                     !- leaf reflectivity\n"\
+        "0.90,                     !- leaf emissivity\n"\
+        "350.0,                    !- minimum stomatal resistance\n"\
+        "GreenRoofDIRT,            !- soil layer name\n"\
+        "MediumRough,              !- roughness\n"\
+        "0.5,                      !- thickness\n"\
+        "0.45,                     !- conductivity of dry soil\n"\
+        "1250.0,                   !- density of dry soil\n"\
+        "950.0,                    !- specific heat of dry soil\n"\
+        "0.74,                      !- thermal absorptance\n"\
+        "0.6,                      !- solar absorptance\n"\
+        "0.5,                      !- visible absorptance\n"\
+        "0.4,                      !- saturation volumetric moisture content of the soil layer\n"\
+        "0.9,                     !- residual volumetric moisture content of the soil layer\n"\
+        "0.4,                      !- initial volumetric moisture content of the soil layer\n"\
+        "Simple;                   !- moisture diffusion calculation method"
+    mat_1 = EnergyMaterial.from_idf(ep_str_1)
+
+    ep_str_2 = "Material:RoofVegetation, myroof, 0.5, 2.0, 0.25, 0.90, 350.0, " \
+        "GreenRoofDIRT, MediumRough, 0.5, 0.45, 1250.0, 950.0, 0.74, 0.6, " \
+        "0.5, 0.4, 0.9, 0.4, Simple;"
+    mat_2 = EnergyMaterialGreenRoof.from_idf(ep_str_2)
+
+    assert mat_1.identifier == mat_2.identifier
+    assert mat_1 == mat_2
+
+    new_mat = EnergyMaterialGreenRoof.from_idf(mat_1.to_idf())
+    assert ep_str_1 == new_mat.to_idf()

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -228,11 +228,90 @@ def test_material_nomass_dict_methods(userdatadict):
 
 def test_greenroof_init(userdatadict):
     """Test initialization of EnergyMaterialGreenRoof Object and basic properties"""
-    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.2, 0.45, 1200, 900, 'Rough', 0.91, 0.65,
-                                    0.7, 0.5, 2.0, 0.25, 0.89, 250, 'Greendirt', 0.4, 0.04,
-                                    0.2, 'Simple')
+    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.5, 0.45, 1250, 950, 'Rough',
+                                    0.89, 0.65, 0.7, 0.5, 2, 0.35, 0.9, 275,
+                                    'greendirt', 0.4, 0.02, 0.15, 'Simple')
     groof.user_data = userdatadict
     str(groof)
     groof_dup = groof.duplicate()
 
     assert groof.identifier == groof_dup.identifier == 'roofmcroofface'
+    assert groof.thickness == groof_dup.thickness == 0.5
+    assert groof.conductivity == groof_dup.conductivity == 0.45
+    assert groof.density == groof_dup.density == 1250
+    assert groof.specific_heat == groof_dup.specific_heat == 950
+    assert groof.roughness == groof_dup.roughness == 'Rough'
+    assert groof.thermal_absorptance == groof_dup.thermal_absorptance == 0.89
+    assert groof.solar_absorptance == groof_dup.solar_absorptance == 0.65
+    assert groof.visible_absorptance == groof_dup.visible_absorptance == 0.7
+    assert groof.plant_height == groof_dup.plant_height == 0.5
+    assert groof.leaf_area_ind == groof_dup.leaf_area_ind == 2
+    assert groof.leaf_reflectivity == groof_dup.leaf_reflectivity == 0.35
+    assert groof.leaf_emissivity == groof_dup.leaf_emissivity == 0.9
+    assert groof.min_stomatal_res == groof_dup.min_stomatal_res == 275
+    assert groof.soil_layer_name == groof_dup.soil_layer_name == 'greendirt'
+    assert groof.sat_vol_moist_cont == groof_dup.sat_vol_moist_cont == 0.4
+    assert groof.res_vol_moist_cont == groof_dup.res_vol_moist_cont == 0.02
+    assert groof.init_vol_moist_cont == groof_dup.init_vol_moist_cont == 0.15
+    assert groof.moist_dif_calc == groof_dup.moist_dif_calc == 'Simple'
+    assert groof.user_data == userdatadict
+
+
+def test_greenroof_equivalency(userdatadict):
+    """Test the equality of a material to another EnergyMaterial."""
+    groof1 = EnergyMaterialGreenRoof('roofmcroofface', 0.5, 0.45, 1250, 950, 'Rough',
+                                     0.89, 0.65, 0.7, 0.5, 2, 0.35, 0.9, 275,
+                                     'greendirt', 0.4, 0.02, 0.15, 'Simple')
+    groof1.user_data = userdatadict
+    groof2 = groof1.duplicate()
+    insulation = EnergyMaterial('Insulation', 0.05, 0.049, 265, 836)
+
+    assert groof1 == groof2
+    assert groof1 != insulation
+    collection = [groof1, groof2, insulation]
+    assert len(set(collection)) == 2
+
+    groof2.soil_layer_name = 'plantydirt'
+    assert groof1 != groof2
+    assert len(set(collection)) == 3
+
+
+def test_greenroof_lockability(userdatadict):
+    """Test the lockability of the EnergyMaterial."""
+    groof = EnergyMaterialGreenRoof('roofmcroofface', 0.5, 0.45, 1250, 950, 'Rough',
+                                    0.89, 0.65, 0.7, 0.5, 2, 0.35, 0.9, 275,
+                                    'greendirt', 0.4, 0.02, 0.15, 'Simple')
+    groof.density = 1100
+    groof.user_data = userdatadict
+    groof.lock()
+    with pytest.raises(AttributeError):
+        groof.density = 1234
+    groof.unlock()
+    groof.density = 1234
+
+
+def test_greenroof_defaults():
+    groof = EnergyMaterialGreenRoof('myroof')
+
+    assert groof.thickness == 0.1
+    assert groof.conductivity == 0.35
+    assert groof.density == 1100.0
+    assert groof.specific_heat == 800.0
+    assert groof.roughness == 'MediumRough'
+    assert groof.thermal_absorptance == 0.9
+    assert groof.solar_absorptance == 0.7
+    assert groof.visible_absorptance == 0.7
+    assert groof.plant_height == 0.2
+    assert groof.leaf_area_ind == 1.0
+    assert groof.leaf_reflectivity == 0.22
+    assert groof.leaf_emissivity == 0.95
+    assert groof.min_stomatal_res == 180.0
+    assert groof.soil_layer_name == 'GreenRoofSoil'
+    assert groof.sat_vol_moist_cont == 0.3
+    assert groof.res_vol_moist_cont == 0.01
+    assert groof.init_vol_moist_cont == 0.1
+    assert groof.moist_dif_calc == 'Simple'
+
+
+def test_greenroof_invalid():
+    """Test the initializaion of EnergyMaterialGreenRoof objects with invalid properties."""


### PR DESCRIPTION
Added greenroof material:
  All tests pass except:
      ```def test_greenroof_init_from_idf():```
```
    def parse_idf_string(idf_string, expected_type=None):
        """Parse an EnergyPlus string of a single object into a list of values.

        Args:
            idf_string: An IDF string for a single EnergyPlus object.
            expected_type: Text representing the expected start of the IDF object.
                (ie. WindowMaterial:Glazing). If None, no type check will be performed.

        Returns:
            ep_fields -- A list of strings with each item in the list as a separate field.
            Note that this list does NOT include the string for the start of the IDF
            object. (ie. WindowMaterial:Glazing)
        """
        idf_string = idf_string.strip()
        if expected_type is not None:
>           assert idf_string.startswith(expected_type), 'Expected EnergyPlus {} ' \
                'but received a different object: {}'.format(expected_type, idf_string)
E           AssertionError: Expected EnergyPlus Material, but received a different object: Material:RoofVegetation,
E           myroof,                   !- name
E           0.5,                      !- height of plants
E           2.0,                      !- leaf area index
E           0.25,                     !- leaf reflectivity
E           0.90,                     !- leaf emissivity
E           350.0,                    !- minimum stomatal resistance
E           GreenRoofDIRT,            !- soil layer name
E           MediumRough,              !- roughness
E           0.5,                      !- thickness
E           0.45,                     !- conductivity of dry soil
E           1250.0,                   !- density of dry soil
E           950.0,                    !- specific heat of dry soil
E           0.74,                      !- thermal absorptance
E           0.6,                      !- solar absorptance
E           0.5,                      !- visible absorptance
E           0.4,                      !- saturation volumetric moisture content of the soil layer
E           0.9,                     !- residual volumetric moisture content of the soil layer
E           0.4,                      !- initial volumetric moisture content of the soil layer
E           Simple;                   !- moisture diffusion calculation method

honeybee_energy\reader.py:20: AssertionError
```
```
    @classmethod
    def from_idf(cls, idf_string):
        """Create an EnergyMaterial from an EnergyPlus text string.

        Args:
            idf_string: A text string fully describing an EnergyPlus material.
        """
        ep_strs = parse_idf_string(idf_string, 'Material:RoofVegetation,')
        return cls(*ep_strs)
```
not sure why it's expecting material when being given roof mat 