### PR TITLE
fix(model): Use correct property to add vertices for faces with holes

### DIFF
--- a/honeybee_energy/constructionset.py
+++ b/honeybee_energy/constructionset.py
@@ -39,9 +39,9 @@ class ConstructionSet(object):
         shade_construction: An optional ShadeConstruction to set the reflectance
             properties of all outdoor shades to which this ConstructionSet is
             assigned. If None, it will be the honeybee generic shade construction.
-        air_boundary_construction: An optional AirBoundaryConstruction to set
-            the properties of Faces with an AirBoundary type. If None, it
-            will be the honeybee generic air boundary construction.
+        air_boundary_construction: An optional AirBoundaryConstruction or
+            OpaqueConstruction to set the properties of Faces with an AirBoundary
+            type. If None, it will be the honeybee generic air boundary construction.
 
     Properties:
         * identifier
@@ -203,8 +203,9 @@ class ConstructionSet(object):
     @air_boundary_construction.setter
     def air_boundary_construction(self, value):
         if value is not None:
-            assert isinstance(value, AirBoundaryConstruction), \
-                'Expected AirBoundaryConstruction. Got {}'.format(type(value))
+            assert isinstance(value, (AirBoundaryConstruction, OpaqueConstruction)), \
+                'Expected AirBoundaryConstruction or OpaqueConstruction. ' \
+                'Got {}'.format(type(value))
             value.lock()   # lock editing in case construction has multiple references
         self._air_boundary_construction = value
 
@@ -402,9 +403,14 @@ class ConstructionSet(object):
         shade_con = ShadeConstruction.from_dict(data['shade_construction']) if \
             'shade_construction' in data and data['shade_construction'] is not None \
             else None
-        air_con = AirBoundaryConstruction.from_dict(data['air_boundary_construction']) \
-            if 'air_boundary_construction' in data and \
-            data['air_boundary_construction'] is not None else None
+        air_con = None
+        if 'air_boundary_construction' in data and \
+                data['air_boundary_construction'] is not None:
+            if data['air_boundary_construction']['type'] == 'AirBoundaryConstruction':
+                air_con = AirBoundaryConstruction.from_dict(
+                    data['air_boundary_construction'])
+            else:
+                air_con = OpaqueConstruction.from_dict(data['air_boundary_construction'])
 
         new_obj = cls(data['identifier'], wall_set, floor_set, roof_ceiling_set,
                       aperture_set, door_set, shade_con, air_con)

--- a/honeybee_energy/properties/face.py
+++ b/honeybee_energy/properties/face.py
@@ -63,9 +63,9 @@ class FaceEnergyProperties(object):
     def construction(self, value):
         if value is not None:
             if isinstance(self.host.type, AirBoundary):
-                assert isinstance(value, AirBoundaryConstruction), 'Expected Air ' \
-                    'Boundary Construction for face with AirBoundary type. ' \
-                    'Got {}'.format(type(value))
+                assert isinstance(value, (AirBoundaryConstruction, OpaqueConstruction)), \
+                    'Expected Air Boundary or Opaque Construction for face with ' \
+                    'AirBoundary type. Got {}'.format(type(value))
             else:
                 assert isinstance(value, OpaqueConstruction), \
                     'Expected Opaque Construction for face. Got {}'.format(type(value))

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -504,7 +504,6 @@ class ModelEnergyProperties(object):
         msgs.append(self.check_duplicate_hvac_identifiers(False))
         msgs.append(self.check_duplicate_shw_identifiers(False))
         msgs.append(self.check_interior_constructions_reversed(False))
-        msgs.append(self.check_air_boundary_constructions(False))
         # output a final report of errors or raise an exception
         full_msgs = [msg for msg in msgs if msg != '']
         full_msg = '\n'.join(full_msgs)
@@ -579,29 +578,6 @@ class ModelEnergyProperties(object):
                     'matching in reversed order with its adjacent pair.'.format(
                         adj_f.full_id, adj_f.properties.energy.construction.identifier
                     )
-                )
-        full_msg = '\n'.join(full_msgs)
-        if raise_exception and len(full_msgs) != 0:
-            raise ValueError(full_msg)
-        return full_msg
-
-    def check_air_boundary_constructions(self, raise_exception=True):
-        """Check that air boundary constructions align with the air boundary face type.
-        """
-        full_msgs = []
-        for face in self.host.faces:
-            const = face.properties.energy.construction
-            if isinstance(face.type, AirBoundary) and not \
-                    isinstance(const, AirBoundaryConstruction):
-                full_msgs.append(
-                    'Face "{}" has an AirBoundary face type but does not have '
-                    'the AirBoundary construction.'.format(face.full_id)
-                )
-            elif isinstance(const, AirBoundaryConstruction) and not \
-                    isinstance(face.type, AirBoundary):
-                full_msgs.append(
-                    'Face "{}" has an AirBoundary construction but does not have '
-                    'the AirBoundary face type.'.format(face.full_id)
                 )
         full_msg = '\n'.join(full_msgs)
         if raise_exception and len(full_msgs) != 0:
@@ -696,7 +672,7 @@ class ModelEnergyProperties(object):
                 self._add_shade_vertices(face, face_dict)
                 if face.geometry.has_holes:
                     face_dict['geometry']['vertices'] = \
-                        [pt.to_array() for pt in face.upper_left_counter_clockwise_vertices]
+                        [pt.to_array() for pt in face.upper_left_vertices]
                 if len(face._apertures) != 0:
                     for ap, ap_dict in zip(face._apertures, face_dict['apertures']):
                         self._add_shade_vertices(ap, ap_dict)
@@ -707,7 +683,7 @@ class ModelEnergyProperties(object):
             for shd, shd_d in zip(self.host._orphaned_shades, data['orphaned_shades']):
                 if shd.geometry.has_holes:
                     shd_d['geometry']['vertices'] = \
-                        [pt.to_array() for pt in shd.upper_left_counter_clockwise_vertices]
+                        [pt.to_array() for pt in shd.upper_left_vertices]
         if len(self.host._orphaned_faces) != 0:
             for shd, shd_d in zip(self.host._orphaned_faces, data['orphaned_faces']):
                 shd_d['geometry']['vertices'] = \
@@ -719,7 +695,7 @@ class ModelEnergyProperties(object):
             for shd, shd_dict in zip(obj._outdoor_shades, obj_dict['outdoor_shades']):
                 if shd.geometry.has_holes:
                     shd_dict['geometry']['vertices'] = \
-                        [pt.to_array() for pt in shd.upper_left_counter_clockwise_vertices]
+                        [pt.to_array() for pt in shd.upper_left_vertices]
 
     def simplify_window_constructions_in_dict(self, data):
         """Convert all window constructions in a model dictionary to SimpleGlazSys.


### PR DESCRIPTION
I am also loosening the restriction on requiring AirBoundary Faces to use Construction:AirBoundary. It seems that Construction:AirBoundary can be fragile in some cases and it's just preferable to use an opaque construction.