### PR TITLE
feat(hvac): Add methods to convert detailed HVAC to Ideal Air equivalent

### DIFF
--- a/honeybee_energy/hvac/heatcool/_base.py
+++ b/honeybee_energy/hvac/heatcool/_base.py
@@ -6,6 +6,7 @@ import os
 from honeybee._lockable import lockable
 
 from .._template import _TemplateSystem, _EnumerationBase
+from ..idealair import IdealAirSystem
 
 
 @lockable
@@ -42,6 +43,24 @@ class _HeatCoolBase(_TemplateSystem):
         * schedules
     """
     __slots__ = ()
+    COOL_ONLY_TYPES = (
+            'EvapCoolers', 'FCU_Chiller', 'FCU_ACChiller', 'FCU_DCW',
+            'ResidentialAC', 'WindowAC'
+        )
+    HEAT_ONLY_TYPES = (
+            'ElectricBaseboard', 'BoilerBaseboard', 'ASHPBaseboard',
+            'DHWBaseboard', 'GasHeaters', 'ResidentialHPNoCool', 'ResidentialFurnace'
+        )
+
+    def to_ideal_air_equivalent(self):
+        """Get a version of this HVAC as an IdealAirSystem."""
+        i_sys = IdealAirSystem(self.identifier)
+        if self.equipment_type in self.COOL_ONLY_TYPES:
+            i_sys.heating_limit = 0
+        if self.equipment_type in self.HEAT_ONLY_TYPES:
+            i_sys.cooling_limit = 0
+        i_sys._display_name = self._display_name
+        return i_sys
 
 
 class _HeatCoolEnumeration(_EnumerationBase):

--- a/honeybee_energy/hvac/idealair.py
+++ b/honeybee_energy/hvac/idealair.py
@@ -2,13 +2,13 @@
 """Simple ideal air system object used to condition zones."""
 from __future__ import division
 
-from ._base import _HVACSystem
-from ..reader import parse_idf_string
-from ..writer import generate_idf_string
-
 from honeybee._lockable import lockable
 from honeybee.typing import valid_string, float_positive, float_in_range
 from honeybee.altnumber import autosize, no_limit
+
+from ._base import _HVACSystem
+from ..reader import parse_idf_string
+from ..writer import generate_idf_string
 
 
 @lockable

--- a/honeybee_energy/measure.py
+++ b/honeybee_energy/measure.py
@@ -340,8 +340,13 @@ class MeasureArgument(object):
         # parse any choice arguments if they exist
         self._valid_choices = None
         if self._type_text == 'Choice':
-            self._valid_choices = tuple(choice.find('value').text
-                                        for choice in xml_element.find('choices'))
+            try:
+                self._valid_choices = tuple(choice.find('value').text
+                                            for choice in xml_element.find('choices'))
+            except TypeError as e:
+                raise ValueError(
+                    'The measure is invalid. Choice argument was found without any '
+                    'available choices.\n{}'.format(e))
 
     @property
     def identifier(self):

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -373,7 +373,7 @@ def room_to_idf(room):
     return '\n\n'.join(zone_str)
 
 
-def model_to_idf(model, schedule_directory=None):
+def model_to_idf(model, schedule_directory=None, use_ideal_air_equivalent=True):
     r"""Generate an IDF string representation of a Model.
 
     The resulting string will include all geometry (Rooms, Faces, Shades, Apertures,
@@ -390,6 +390,11 @@ def model_to_idf(model, schedule_directory=None):
             schedules should be written to. If None, all ScheduleFixedIntervals
             will be translated to Schedule:Compact and written fully into the
             IDF string instead of to Schedule:File. (Default: None).
+        use_ideal_air_equivalent: Boolean to note whether any detailed HVAC system
+            templates should be converted to an equivalent IdealAirSystem upon export.
+            If False and the Model contains detailed systems, a ValueError will
+            be raised since this method does not support the translation of
+            detailed systems. (Default:True).
 
     Usage:
 
@@ -440,10 +445,11 @@ def model_to_idf(model, schedule_directory=None):
                     'Is this correct?\n{}'.format(original_model.units, e)
                 raise ValueError(error)
 
-    # check to be sure that the Airflow Network is not being used
-    assert model.properties.energy.ventilation_simulation_control.vent_control_type == \
-        'SingleZone', 'The Honeybee Airflow Network does not support direct ' \
-        'translation to IDF.\nUse the export to OpenStudio workflow instead.'
+    # convert model to simple ventilation and Ideal Air Systems
+    model.properties.energy.ventilation_simulation_control.vent_control_type ='SingleZone'
+    if use_ideal_air_equivalent:
+        for room in model.rooms:
+            room.properties.energy.assign_ideal_air_equivalent()
 
     # write the building object into the string
     model_str = ['!-   =======================================\n'
@@ -523,6 +529,10 @@ def model_to_idf(model, schedule_directory=None):
                     'Use the export to OpenStudio workflow instead.'.format(
                         room.properties.energy.hvac.__class__.__name__))
 
+    # get the default air boundary construction
+    # must be imported here to avoid circular imports
+    from .lib.constructions import air_boundary
+
     # write all of the zone geometry
     model_str.append('!-   ============ ZONE GEOMETRY ============\n')
     for room in model.rooms:
@@ -531,8 +541,16 @@ def model_to_idf(model, schedule_directory=None):
             model_str.append(face.to.idf(face))
             if isinstance(face.type, AirBoundary):  # write the air mixing objects
                 air_constr = face.properties.energy.construction
-                adj_room = face.boundary_condition.boundary_condition_objects[-1]
-                model_str.append(air_constr.to_air_mixing_idf(face, adj_room))
+                try:
+                    adj_room = face.boundary_condition.boundary_condition_objects[-1]
+                    try:
+                        model_str.append(air_constr.to_air_mixing_idf(face, adj_room))
+                    except AttributeError:  # opaque construction for air boundary
+                        model_str.append(air_boundary.to_air_mixing_idf(face, adj_room))
+                except AttributeError as e:
+                    raise ValueError(
+                        'Face "{}" is an Air Boundary but lacks a Surface boundary '
+                        'condition.\n{}'.format(face.full_id, e))
             for ap in face.apertures:
                 if len(ap.geometry) <= 4:  # ignore apertures to be triangulated
                     model_str.append(ap.to.idf(ap))

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -762,15 +762,10 @@ def test_writer_to_idf():
     idf_string = model.to.idf(model, schedule_directory='./tests/idf/')
     assert len(idf_string) != 0
 
-    model.properties.energy.ventilation_simulation_control.vent_control_type = \
-        'MultiZoneWithoutDistribution'
-    with pytest.raises(AssertionError):
-        idf_string = model.to.idf(model, schedule_directory='./tests/idf/')
-    model.properties.energy.ventilation_simulation_control.vent_control_type = \
-        'SingleZone'
     room.properties.energy.hvac = VAV('Test VAV System')
     with pytest.raises(TypeError):
-        idf_string = model.to.idf(model, schedule_directory='./tests/idf/')
+        idf_string = model.to.idf(
+            model, schedule_directory='./tests/idf/', use_ideal_air_equivalent=False)
 
 
 def test_energy_ventilation_simulation_properties():


### PR DESCRIPTION
This means that virtually all Honeybee models can now be translated through the direct-to-idf pathway.

I'm also taking the opportunity to improve some of the error messages and improve the model-to-osm command.