### PR TITLE
feat(properties) add properties that can be extended

### DIFF
--- a/honeybee_energy/hvac/_base.py
+++ b/honeybee_energy/hvac/_base.py
@@ -24,13 +24,12 @@ class _HVACSystem(object):
         * schedules
         * user_data
     """
-    __slots__ = ('_identifier', '_display_name', '_locked', '_user_data', '_properties')
+    __slots__ = ('_identifier', '_display_name', '_locked', '_user_data')
 
     def __init__(self, identifier):
         """Initialize HVACSystem."""
         self.identifier = identifier
         self._display_name = None
-        self._properties = None
         self._user_data = None
 
     @property
@@ -86,11 +85,6 @@ class _HVACSystem(object):
             assert isinstance(value, dict), 'Expected dictionary for honeybee_energy' \
                 'object user_data. Got {}.'.format(type(value))
         self._user_data = value
-
-    @property
-    def properties(self):
-        """Get properties for extensions."""
-        return self._properties
 
     def duplicate(self):
         """Get a copy of this object."""

--- a/honeybee_energy/hvac/_base.py
+++ b/honeybee_energy/hvac/_base.py
@@ -24,12 +24,13 @@ class _HVACSystem(object):
         * schedules
         * user_data
     """
-    __slots__ = ('_identifier', '_display_name', '_locked', '_user_data')
+    __slots__ = ('_identifier', '_display_name', '_locked', '_user_data', '_properties')
 
     def __init__(self, identifier):
         """Initialize HVACSystem."""
         self.identifier = identifier
         self._display_name = None
+        self._properties = None
         self._user_data = None
 
     @property
@@ -85,6 +86,11 @@ class _HVACSystem(object):
             assert isinstance(value, dict), 'Expected dictionary for honeybee_energy' \
                 'object user_data. Got {}.'.format(type(value))
         self._user_data = value
+
+    @property
+    def properties(self):
+        """Get properties for extensions."""
+        return self._properties
 
     def duplicate(self):
         """Get a copy of this object."""

--- a/honeybee_energy/hvac/idealair.py
+++ b/honeybee_energy/hvac/idealair.py
@@ -79,7 +79,7 @@ class IdealAirSystem(_HVACSystem):
                  '_sensible_heat_recovery', '_latent_heat_recovery',
                  '_heating_air_temperature', '_cooling_air_temperature',
                  '_heating_limit', '_cooling_limit', '_heating_availability',
-                 '_cooling_availability')
+                 '_cooling_availability', '_properties')
     ECONOMIZER_TYPES = ('NoEconomizer', 'DifferentialDryBulb', 'DifferentialEnthalpy')
 
     def __init__(self, identifier, economizer_type='DifferentialDryBulb',
@@ -608,6 +608,11 @@ class IdealAirSystem(_HVACSystem):
                 else data['cooling_limit']
 
         return econ, dcv, sensible, latent, heat_temp, cool_temp, heat_limit, cool_limit
+
+    @property
+    def properties(self):
+        """Get properties for extensions."""
+        return self._properties
 
     def __copy__(self):
         new_obj = IdealAirSystem(

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -160,3 +160,7 @@ class SetpointProperties(_EnergyProperties):
 
 class VentilationProperties(_EnergyProperties):
     """Ventilation properties to be extended by extensions."""
+
+
+class IdealAirSystemProperties(_EnergyProperties):
+    """IdealAirSystem properties to be extended by extensions."""


### PR DESCRIPTION
Following the same pattern from #823 ,  adding a new **.properties** to HB-E [hvac.IdealAirSystem](https://github.com/ladybug-tools/honeybee-energy/blob/4cfb86c040a4587d8bb48715db37749040e82d4c/honeybee_energy/hvac/idealair.py#L15) class in order to allow for extension by plugins.

All hvac tests pass
Note: for consistency, I can add .properties to the rest of the hvac classes if you would like? (allair, doas, heatcool)