### PR TITLE
fix(writer): Treat no setpoint the same as unconditioned

### DIFF
--- a/honeybee_energy/properties/room.py
+++ b/honeybee_energy/properties/room.py
@@ -694,6 +694,8 @@ class RoomEnergyProperties(object):
         """
         if self.hvac is None or isinstance(self.hvac, IdealAirSystem):
             return None  # the room is already good as it is
+        if self.setpoint is None:
+            return None  # the room is not able to be conditioned
         i_sys = self.hvac.to_ideal_air_equivalent()
         i_sys.identifier = '{} Ideal Loads Air System'.format(self.host.identifier)
         if isinstance(self.hvac, _HeatCoolBase):

--- a/honeybee_energy/writer.py
+++ b/honeybee_energy/writer.py
@@ -355,7 +355,8 @@ def room_to_idf(room):
     # write the ventilation and thermostat
     if ventilation is not None:
         zone_str.append(ventilation.to_idf(room.identifier))
-    if room.properties.energy.is_conditioned:
+    if room.properties.energy.is_conditioned and \
+            room.properties.energy.setpoint is not None:
         zone_str.append(room.properties.energy.setpoint.to_idf(room.identifier))
 
     # write the daylighting control
@@ -446,7 +447,8 @@ def model_to_idf(model, schedule_directory=None, use_ideal_air_equivalent=True):
                 raise ValueError(error)
 
     # convert model to simple ventilation and Ideal Air Systems
-    model.properties.energy.ventilation_simulation_control.vent_control_type ='SingleZone'
+    model.properties.energy.ventilation_simulation_control.vent_control_type = \
+        'SingleZone'
     if use_ideal_air_equivalent:
         for room in model.rooms:
             room.properties.energy.assign_ideal_air_equivalent()
@@ -520,7 +522,8 @@ def model_to_idf(model, schedule_directory=None, use_ideal_air_equivalent=True):
     # write all of the HVAC systems
     model_str.append('!-   ============ HVAC SYSTEMS ============\n')
     for room in model.rooms:
-        if room.properties.energy.hvac is not None:
+        if room.properties.energy.hvac is not None \
+                and room.properties.energy.setpoint is not None:
             try:
                 model_str.append(room.properties.energy.hvac.to_idf(room))
             except AttributeError:


### PR DESCRIPTION
More often than not, this is what people expect so I'm just going to treat rooms without setpoints as unconditioned.