### PR TITLE
fix(config): Add check to be sure user standards are set up correctly

### DIFF
--- a/honeybee_energy/config.py
+++ b/honeybee_energy/config.py
@@ -650,7 +650,11 @@ class Folders(object):
             lib_folder = os.path.join(
                 lb_install, 'resources', 'standards', 'honeybee_standards')
             if os.path.isdir(lib_folder):
-                return lib_folder
+                try:
+                    Folders._check_standards_folder(lib_folder)
+                    return lib_folder
+                except AssertionError:  # the folder is not valid
+                    pass
 
         # default to the library folder that installs with this Python package
         return os.path.join(os.path.dirname(honeybee_standards.__file__))


### PR DESCRIPTION
It seems that the Pollination installer is going to intentionally delete folders that we are meant to fall back on. So I'm adding a check that will just defer everything to the final fallback folder in the Python installation if the folders have been deleted.