### PR TITLE
fix(simulate): Change default SimPar to have monthly frequency

### DIFF
--- a/honeybee_energy/cli/simulate.py
+++ b/honeybee_energy/cli/simulate.py
@@ -139,6 +139,7 @@ def simulate_model(
                 sim_par = SimulationParameter()
                 sim_par.output.add_zone_energy_use()
                 sim_par.output.add_hvac_energy_use()
+                sim_par.output.reporting_frequency = 'Monthly'
             else:
                 with open(sim_par_json) as json_file:
                     data = json.load(json_file)


### PR DESCRIPTION
This will keep the SQLite file size small when people don't connect any simulation parameters on Pollination.