### PR TITLE
fix(loadbalance): Tweak a few of the load balance terms

### DIFF
--- a/honeybee_energy/construction/air.py
+++ b/honeybee_energy/construction/air.py
@@ -219,6 +219,22 @@ class AirBoundaryConstruction(object):
                     'flow per floor area', 'flow per person', 'ach', 'source zone name')
         return generate_idf_string('ZoneMixing', values, comments)
 
+    def to_cross_mixing_idf(self, face, room_identifier):
+        """IDF string for the ZoneMixing of this object.
+
+        Args:
+            face: A Face object to which this construction is assigned. This
+                Face must have a parent Room.
+            room_identifier: A identifier for the Room to which the Face is adjacent.
+        """
+        flow_rate = face.area * self.air_mixing_per_area
+        values = ['{}_CrossMixing'.format(face.identifier), face.parent.identifier,
+                  self.air_mixing_schedule.identifier, 'Flow/Zone',
+                  flow_rate, '', '', '', room_identifier]
+        comments = ('name', 'zone name', 'schedule name', 'flow method', 'flow rate',
+                    'flow per floor area', 'flow per person', 'ach', 'source zone name')
+        return generate_idf_string('ZoneCrossMixing', values, comments)
+
     def to_dict(self, abridged=False):
         """Air boundary construction dictionary representation."""
         base = {'type': 'AirBoundaryConstruction'} if not \

--- a/tests/model_extend_test.py
+++ b/tests/model_extend_test.py
@@ -673,7 +673,7 @@ def test_to_dict_air_walls():
 
     model_idf_str = model.to.idf(model)
     assert model_idf_str.count('Construction:AirBoundary') == 1
-    assert model_idf_str.count('ZoneMixing') == 16
+    assert model_idf_str.count('ZoneCrossMixing') == 8
 
 
 def test_from_dict_non_abridged():


### PR DESCRIPTION
It seems that we have not been accounting for the shortwave solar reflected back out of the windows and this was causing some imbalances for buildings with very high solar loads.

The service hot water load also was not being interpreted correctly when room multipliers are used.

Lastly, I did some experiments with the air mixing across air boundaries and made some improvements that make these mixing objects more read-able in the IDF. It turns out that the actual issue with these mixing objects was that the simulation timestep was too low to model air mixing correctly. So the original code was actually fine. But I am going to leave the cleaner IDF implementation as is for now.