### PR TITLE
Add model properties transforms

### DIFF
--- a/honeybee_energy/hvac/_base.py
+++ b/honeybee_energy/hvac/_base.py
@@ -122,3 +122,57 @@ class _HVACSystem(object):
 
     def __repr__(self):
         return 'HVACSystem: {}'.format(self.display_name)
+    
+    def move(self, move_vec):
+        """Move the .properties along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the object.
+        """
+        # To be implemented by the inheriting class
+        pass
+
+    def rotate(self, angle, origin):
+        """Rotate the .properties by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        # To be implemented by the inheriting class
+        pass
+    
+    def rotate_xy(self, angle, origin):
+        """Rotate the .properties counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        # To be implemented by the inheriting class
+        pass
+
+    def reflect(self, plane):
+        """Reflect the .properties across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        # To be implemented by the inheriting class
+        pass
+
+    def scale(self, factor, origin=None):
+        """Scale the .properties by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        # To be implemented by the inheriting class
+        pass

--- a/honeybee_energy/hvac/idealair.py
+++ b/honeybee_energy/hvac/idealair.py
@@ -646,3 +646,52 @@ class IdealAirSystem(_HVACSystem):
 
     def __repr__(self):
         return 'IdealAirSystem: {}'.format(self.display_name)
+    
+    def move(self, move_vec):
+        """Move the .properties along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the object.
+        """
+        return self.properties.move(move_vec)
+
+    def rotate(self, angle, origin):
+        """Rotate the .properties by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        return self.properties.rotate(angle, origin)
+    
+    def rotate_xy(self, angle, origin):
+        """Rotate the .properties counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self.properties.rotate_xy(angle, origin)
+
+    def reflect(self, plane):
+        """Reflect the .properties across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        self.properties.reflect(plane)
+
+    def scale(self, factor, origin=None):
+        """Scale the .properties by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self.properties.scale(factor, origin)

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -126,7 +126,7 @@ class _EnergyProperties(object):
                 raise Exception("Failed to move {}: {}".format(extension, e))
 
     def rotate(self, angle, origin):
-        """Rotate the .properties by a certain angle around an axis and origin.
+        """Rotate the property's extensions by a certain angle around an axis and origin.
 
         Args:
             angle: An angle for rotation in degrees.
@@ -146,7 +146,7 @@ class _EnergyProperties(object):
                 raise Exception("Failed to rotate {}: {}".format(extension, e))
     
     def rotate_xy(self, angle, origin):
-        """Rotate the .properties counterclockwise in the world XY plane by a certain angle.
+        """Rotate the property's extensions counterclockwise in the world XY plane by a certain angle.
 
         Args:
             angle: An angle in degrees.
@@ -165,7 +165,7 @@ class _EnergyProperties(object):
                 raise Exception("Failed to rotate {}: {}".format(extension, e))
 
     def reflect(self, plane):
-        """Reflect the .properties across a plane.
+        """Reflect the property's extensions across a plane.
 
         Args:
             plane: A ladybug_geometry Plane across which the object will
@@ -183,7 +183,7 @@ class _EnergyProperties(object):
                 raise Exception("Failed to reflect {}: {}".format(extension, e))
 
     def scale(self, factor, origin=None):
-        """Scale the .properties by a factor from an origin point.
+        """Scale the property's extensions by a factor from an origin point.
 
         Args:
             factor: A number representing how much the object should be scaled.

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -15,7 +15,8 @@ class _EnergyProperties(object):
         host: A honeybee-energy object that hosts these properties
             (ie. ScheduleRuleset, OpaqueConstruction, WindowConstruction).
     """
-    _exclude = {'host', 'to_dict', 'ToString'}
+    _exclude = {'host', 'to_dict', 'ToString', 
+                'move', 'rotate', 'rotate_xy', 'reflect', 'scale',}
 
     def __init__(self, host):
         """Initialize properties."""

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -74,7 +74,6 @@ class _EnergyProperties(object):
                 continue 
             setattr(self, '_' + atr, var.__class__.from_dict(atr_prop_dict, self.host)) 
 
-
     def _duplicate_extension_attr(self, original_properties):
         """Duplicate the attributes added by extensions.
 
@@ -106,6 +105,100 @@ class _EnergyProperties(object):
     def __repr__(self):
         """Properties representation."""
         return '{}: {}'.format(self.__class__.__name__, self.host.display_name)
+    
+    def move(self, move_vec):
+        """Move the property's extensions along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the object.
+        """
+        for extension_name in self._extension_attributes:
+            extension = getattr(self, extension_name)
+            if not hasattr(extension, "move"):
+                continue
+            try:
+                extension.move(move_vec)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception("Failed to move {}: {}".format(extension, e))
+
+    def rotate(self, angle, origin):
+        """Rotate the .properties by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for extension_name in self._extension_attributes:
+            extension = getattr(self, extension_name)
+            if not hasattr(extension, "rotate"):
+                continue
+            try:
+                extension.rotate(angle, origin)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception("Failed to rotate {}: {}".format(extension, e))
+    
+    def rotate_xy(self, angle, origin):
+        """Rotate the .properties counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for extension_name in self._extension_attributes:
+            extension = getattr(self, extension_name)
+            if not hasattr(extension, "rotate_xy"):
+                continue
+            try:
+                extension.rotate_xy(angle, origin)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception("Failed to rotate {}: {}".format(extension, e))
+
+    def reflect(self, plane):
+        """Reflect the .properties across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        for extension_name in self._extension_attributes:
+            extension = getattr(self, extension_name)
+            if not hasattr(extension, "reflect"):
+                continue
+            try:
+                extension.reflect(plane)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception("Failed to reflect {}: {}".format(extension, e))
+
+    def scale(self, factor, origin=None):
+        """Scale the .properties by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        for extension_name in self._extension_attributes:
+            extension = getattr(self, extension_name)
+            if not hasattr(extension, "scale"):
+                continue
+            try:
+                extension.scale(factor, origin)
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                raise Exception("Failed to scale {}: {}".format(extension, e))
 
 
 class ScheduleRulesetProperties(_EnergyProperties):

--- a/honeybee_energy/properties/model.py
+++ b/honeybee_energy/properties/model.py
@@ -1983,3 +1983,67 @@ class ModelEnergyProperties(object):
 
     def __repr__(self):
         return 'Model Energy Properties: [host: {}]'.format(self.host.display_name)
+
+    def move(self, moving_vec):
+        """Move the Model's HVAC and SHW along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the object.
+        """
+        for hvac in self.hvacs:
+            hvac.move(moving_vec)
+        for shw in self.shws:
+            shw.move(moving_vec)
+
+    def rotate(self, angle, axis, origin):
+        """Rotate the Model's HVAC and SHW by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for hvac in self.hvacs:
+            hvac.rotate(angle, axis, origin)
+        for shw in self.shws:
+            shw.rotate(angle, axis, origin)
+
+    def rotate_xy(self, angle, origin):
+        """Rotate the Model's HVAC and SHW counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        for hvac in self.hvacs:
+            hvac.rotate_xy(angle, origin)
+        for shw in self.shws:
+            shw.rotate_xy(angle, origin)
+
+    def reflect(self, plane):
+        """Reflect the Model's HVAC and SHW objects across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        for hvac in self.hvacs:
+            hvac.reflect(plane)
+        for shw in self.shws:
+            shw.reflect(plane)
+
+    def scale(self, factor, origin=None):
+        """Scale the Model's HVAC and SHW by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        for hvac in self.hvacs:
+            hvac.scale(factor, origin)
+        for shw in self.shws:
+            shw.scale(factor, origin)

--- a/honeybee_energy/shw.py
+++ b/honeybee_energy/shw.py
@@ -313,3 +313,53 @@ class SHWSystem(object):
 
     def __repr__(self):
         return 'SHWSystem: {}'.format(self.display_name)
+
+    def move(self, move_vec):
+        """Move the .properties along a vector.
+
+        Args:
+            moving_vec: A ladybug_geometry Vector3D with the direction and distance
+                to move the object.
+        """
+        return self.properties.move(move_vec)
+
+    def rotate(self, angle, origin):
+        """Rotate the .properties by a certain angle around an axis and origin.
+
+        Args:
+            angle: An angle for rotation in degrees.
+            axis: Rotation axis as a Vector3D.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        return self.properties.rotate(angle, origin)
+    
+    def rotate_xy(self, angle, origin):
+        """Rotate the .properties counterclockwise in the world XY plane by a certain angle.
+
+        Args:
+            angle: An angle in degrees.
+            origin: A ladybug_geometry Point3D for the origin around which the
+                object will be rotated.
+        """
+        self.properties.rotate_xy(angle, origin)
+
+    def reflect(self, plane):
+        """Reflect the .properties across a plane.
+
+        Args:
+            plane: A ladybug_geometry Plane across which the object will
+                be reflected.
+        """
+        self.properties.reflect(plane)
+
+    def scale(self, factor, origin=None):
+        """Scale the .properties by a factor from an origin point.
+
+        Args:
+            factor: A number representing how much the object should be scaled.
+            origin: A ladybug_geometry Point3D representing the origin from which
+                to scale. If None, it will be scaled from the World origin (0, 0, 0).
+        """
+        self.properties.scale(factor, origin)
+    

--- a/tests/hvac_allair_test.py
+++ b/tests/hvac_allair_test.py
@@ -8,7 +8,8 @@ from honeybee_energy.hvac.allair.furnace import ForcedAirFurnace
 from honeybee.model import Model
 from honeybee.room import Room
 
-from ladybug_geometry.geometry3d.pointvector import Point3D
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
 
 import pytest
 from .fixtures.userdata_fixtures import userdatadict
@@ -92,6 +93,35 @@ def test_vav_dict_methods(userdatadict):
     assert hvac_dict == new_hvac_sys.to_dict()
 
 
+def test_vav_transforms(userdatadict):
+    """Test the Transform methods."""
+    hvac_sys = VAV('High Efficiency HVAC System')
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'VAV_DCW_DHW'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    hvac_sys.user_data = userdatadict
+
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    hvac_sys.move(Vector3D(10, 10, 10))
+    hvac_sys.rotate(90, Point3D(0,0,0))
+    hvac_sys.rotate_xy(90, Point3D(0,0,0))
+    hvac_sys.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    hvac_sys.scale(1.0)
+
+    # Nothing should happen to the base object, only to the extensions
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'VAV_DCW_DHW'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+    assert hvac_sys.user_data == userdatadict
+
+
 def test_pvav_init(userdatadict):
     """Test the initialization of PVAV and basic properties."""
     hvac_sys = PVAV('Test System')
@@ -168,6 +198,35 @@ def test_pvav_dict_methods(userdatadict):
     new_hvac_sys = PVAV.from_dict(hvac_dict)
     assert new_hvac_sys == hvac_sys
     assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_pvav_transforms(userdatadict):
+    """Test the Transform methods."""
+    hvac_sys = PVAV('High Efficiency HVAC System')
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PVAV_DHW'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    hvac_sys.user_data = userdatadict
+
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    hvac_sys.move(Vector3D(10, 10, 10))
+    hvac_sys.rotate(90, Point3D(0,0,0))
+    hvac_sys.rotate_xy(90, Point3D(0,0,0))
+    hvac_sys.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    hvac_sys.scale(1.0)
+
+    # Nothing should happen to the base object, only to the extensions
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PVAV_DHW'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+    assert hvac_sys.user_data == userdatadict
 
 
 def test_psz_init(userdatadict):
@@ -248,6 +307,35 @@ def test_psz_dict_methods(userdatadict):
     assert hvac_dict == new_hvac_sys.to_dict()
 
 
+def test_psz_transforms(userdatadict):
+    """Test the Transform methods."""
+    hvac_sys = PSZ('High Efficiency HVAC System')
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PSZAC_DCW_DHW'
+    hvac_sys.economizer_type = 'DifferentialDryBulb'
+    hvac_sys.sensible_heat_recovery = 0.8
+    hvac_sys.latent_heat_recovery = 0.65
+    hvac_sys.user_data = userdatadict
+
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    hvac_sys.move(Vector3D(10, 10, 10))
+    hvac_sys.rotate(90, Point3D(0,0,0))
+    hvac_sys.rotate_xy(90, Point3D(0,0,0))
+    hvac_sys.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    hvac_sys.scale(1.0)
+
+    # Nothing should happen to the base object, only to the extensions
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PSZAC_DCW_DHW'
+    assert hvac_sys.economizer_type == 'DifferentialDryBulb'
+    assert hvac_sys.sensible_heat_recovery == 0.8
+    assert hvac_sys.latent_heat_recovery == 0.65
+    assert hvac_sys.user_data == userdatadict
+
+
 def test_ptac_init(userdatadict):
     """Test the initialization of PTAC and basic properties."""
     hvac_sys = PTAC('Test System')
@@ -303,6 +391,29 @@ def test_ptac_dict_methods(userdatadict):
     assert hvac_dict == new_hvac_sys.to_dict()
 
 
+def test_ptac_transforms(userdatadict):
+    """Test the Transform methods."""
+    hvac_sys = PTAC('High Efficiency HVAC System')
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.equipment_type = 'PTAC_DHW'
+    hvac_sys.user_data = userdatadict
+
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    hvac_sys.move(Vector3D(10, 10, 10))
+    hvac_sys.rotate(90, Point3D(0,0,0))
+    hvac_sys.rotate_xy(90, Point3D(0,0,0))
+    hvac_sys.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    hvac_sys.scale(1.0)
+
+    # Nothing should happen to the base object, only to the extensions
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.equipment_type == 'PTAC_DHW'
+    assert hvac_sys.user_data == userdatadict
+
+
 def test_furnace_init(userdatadict):
     """Test the initialization of ForcedAirFurnace and basic properties."""
     hvac_sys = ForcedAirFurnace('Test System')
@@ -348,3 +459,24 @@ def test_furnace_dict_methods(userdatadict):
     new_hvac_sys = ForcedAirFurnace.from_dict(hvac_dict)
     assert new_hvac_sys == hvac_sys
     assert hvac_dict == new_hvac_sys.to_dict()
+
+
+def test_furnace_transforms(userdatadict):
+    """Test the Transform methods."""
+    hvac_sys = ForcedAirFurnace('High Efficiency HVAC System')
+    hvac_sys.vintage = 'ASHRAE_2010'
+    hvac_sys.user_data = userdatadict
+
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    hvac_sys.move(Vector3D(10, 10, 10))
+    hvac_sys.rotate(90, Point3D(0,0,0))
+    hvac_sys.rotate_xy(90, Point3D(0,0,0))
+    hvac_sys.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    hvac_sys.scale(1.0)
+
+    # Nothing should happen to the base object, only to the extensions
+    assert len(list(hvac_sys.properties._extension_attributes)) == 0
+    assert hvac_sys.vintage == 'ASHRAE_2010'
+    assert hvac_sys.user_data == userdatadict

--- a/tests/shw_test.py
+++ b/tests/shw_test.py
@@ -3,6 +3,9 @@ from honeybee_energy.shw import SHWSystem
 
 from honeybee.altnumber import autocalculate
 
+from ladybug_geometry.geometry3d.pointvector import Point3D, Vector3D
+from ladybug_geometry.geometry3d.plane import Plane
+
 from .fixtures.userdata_fixtures import userdatadict
 
 
@@ -87,3 +90,28 @@ def test_default_shw_to_dict(userdatadict):
     new_default_shw = SHWSystem.from_dict(shw_dict)
     assert new_default_shw == default_shw
     assert shw_dict == new_default_shw.to_dict()
+
+
+def test_shw_transforms(userdatadict):
+    """Test the Transform methods."""
+    default_shw = SHWSystem('Passive House SHW System')
+    default_shw.equipment_type = 'Electric_WaterHeater'
+    default_shw.heater_efficiency = 0.98
+    default_shw.ambient_condition = 24
+    default_shw.ambient_loss_coefficient = 5
+
+    assert len(list(default_shw.properties._extension_attributes)) == 0
+
+    # Apply the transforms
+    default_shw.move(Vector3D(10, 10, 10))
+    default_shw.rotate(90, Point3D(0,0,0))
+    default_shw.rotate_xy(90, Point3D(0,0,0))
+    default_shw.reflect(Plane(Vector3D(0, 0, 1), Point3D(0,0,0), Vector3D(1, 0, 0)))
+    default_shw.scale(1.0)
+
+    assert len(list(default_shw.properties._extension_attributes)) == 0
+    assert default_shw.equipment_type == 'Electric_WaterHeater'
+    assert default_shw.heater_efficiency == 0.98
+    assert default_shw.ambient_condition == 24
+    assert default_shw.ambient_loss_coefficient == 5
+    


### PR DESCRIPTION
Passes transforms (move, scale, rotate, rotate_xy reflect) down to all extension properties of HVAC and Hot-Water objects.
- Add transform methods to:
    - model.Model
    - hvac.idealair.IdealAirSystem
    - hvac._base._HBACSystem
    - properties.extensions._EnergyProperties
    - shw.SHWSystem
- Add tests for all