### PR TITLE
Add new Material Properties for Extension

### DIFF
--- a/honeybee_energy/material/frame.py
+++ b/honeybee_energy/material/frame.py
@@ -77,7 +77,10 @@ class EnergyWindowFrame(_EnergyMaterialBase):
         * user_data
         * properties
     """
-
+    __slots__ = ('_identifier', '_display_name', '_width', '_conductance',
+                 '_edge_to_center_ratio', '_outside_projection', '_inside_projection',
+                 '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance')
+    
     def __init__(self, identifier, width, conductance, edge_to_center_ratio=1,
                  outside_projection=0, inside_projection=0, thermal_absorptance=0.9,
                  solar_absorptance=0.7, visible_absorptance=None):
@@ -282,6 +285,7 @@ class EnergyWindowFrame(_EnergyMaterialBase):
             new_mat.user_data = data['user_data']
         if 'properties' in data and data['properties'] is not None:
             new_mat._properties._load_extension_attr_from_dict(data['properties'])
+        
         return new_mat
 
     def to_idf(self):
@@ -312,6 +316,8 @@ class EnergyWindowFrame(_EnergyMaterialBase):
         }
         if self._display_name is not None:
             base['display_name'] = self.display_name
+        if self._user_data is not None:
+            base['user_data'] = self.user_data
         prop_dict = self._properties.to_dict()
         if prop_dict is not None:
             base['properties'] = prop_dict

--- a/honeybee_energy/material/frame.py
+++ b/honeybee_energy/material/frame.py
@@ -80,7 +80,7 @@ class EnergyWindowFrame(_EnergyMaterialBase):
     __slots__ = ('_identifier', '_display_name', '_width', '_conductance',
                  '_edge_to_center_ratio', '_outside_projection', '_inside_projection',
                  '_thermal_absorptance', '_solar_absorptance', '_visible_absorptance')
-    
+
     def __init__(self, identifier, width, conductance, edge_to_center_ratio=1,
                  outside_projection=0, inside_projection=0, thermal_absorptance=0.9,
                  solar_absorptance=0.7, visible_absorptance=None):

--- a/honeybee_energy/material/frame.py
+++ b/honeybee_energy/material/frame.py
@@ -9,7 +9,7 @@ from honeybee._lockable import lockable
 from honeybee.typing import float_in_range, float_in_range_excl_incl, float_positive
 
 from ._base import _EnergyMaterialBase
-from ..properties.extension import EnergyWindowFrameMixtureProperties
+from ..properties.extension import EnergyWindowFrameProperties
 from ..reader import parse_idf_string
 from ..writer import generate_idf_string
 
@@ -95,7 +95,7 @@ class EnergyWindowFrame(_EnergyMaterialBase):
         self.solar_absorptance = solar_absorptance
         self.visible_absorptance = visible_absorptance
         self._locked = False
-        self._properties = EnergyWindowFrameMixtureProperties(self)
+        self._properties = EnergyWindowFrameProperties(self)
 
     @property
     def width(self):

--- a/honeybee_energy/material/gas.py
+++ b/honeybee_energy/material/gas.py
@@ -10,7 +10,7 @@ from ._base import _EnergyMaterialWindowBase
 from ..properties.extension import (
     EnergyWindowMaterialGasProperties,
     EnergyWindowMaterialGasMixtureProperties,
-    EnergyWindowMaterialGasCustomMixtureProperties,
+    EnergyWindowMaterialGasCustomProperties,
 )
 from ..reader import parse_idf_string
 from ..writer import generate_idf_string
@@ -780,7 +780,7 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
         self.specific_heat_ratio = specific_heat_ratio
         self.molecular_weight = molecular_weight
         self._user_data = None
-        self._properties = EnergyWindowMaterialGasCustomMixtureProperties(self)
+        self._properties = EnergyWindowMaterialGasCustomProperties(self)
 
     @property
     def conductivity_coeff_a(self):

--- a/honeybee_energy/material/gas.py
+++ b/honeybee_energy/material/gas.py
@@ -7,6 +7,11 @@ They can only exist within window constructions bounded by glazing materials
 from __future__ import division
 
 from ._base import _EnergyMaterialWindowBase
+from ..properties.extension import (
+    EnergyWindowMaterialGasProperties,
+    EnergyWindowMaterialGasMixtureProperties,
+    EnergyWindowMaterialGasCustomMixtureProperties,
+)
 from ..reader import parse_idf_string
 from ..writer import generate_idf_string
 
@@ -333,6 +338,7 @@ class EnergyWindowMaterialGas(_EnergyWindowMaterialGasBase):
         * density
         * prandtl
         * user_data
+        * properties
     """
     __slots__ = ('_gas_type',)
 
@@ -340,6 +346,7 @@ class EnergyWindowMaterialGas(_EnergyWindowMaterialGasBase):
         """Initialize gas energy material."""
         _EnergyWindowMaterialGasBase.__init__(self, identifier, thickness)
         self.gas_type = gas_type
+        self._properties = EnergyWindowMaterialGasProperties(self)
 
     @property
     def gas_type(self):
@@ -408,6 +415,8 @@ class EnergyWindowMaterialGas(_EnergyWindowMaterialGasBase):
             new_obj.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_obj.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_obj._properties._load_extension_attr_from_dict(data['properties'])
         return new_obj
 
     def to_idf(self):
@@ -428,6 +437,9 @@ class EnergyWindowMaterialGas(_EnergyWindowMaterialGasBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def _coeff_property(self, dictionary, t_kelvin):
@@ -457,6 +469,7 @@ class EnergyWindowMaterialGas(_EnergyWindowMaterialGasBase):
         new_obj = EnergyWindowMaterialGas(self.identifier, self.thickness, self.gas_type)
         new_obj._display_name = self._display_name
         new_obj._user_data = None if self._user_data is None else self._user_data.copy()
+        new_obj._properties._duplicate_extension_attr(self._properties)
         return new_obj
 
 
@@ -489,6 +502,8 @@ class EnergyWindowMaterialGasMixture(_EnergyWindowMaterialGasBase):
         * specific_heat
         * density
         * prandtl
+        * user_data
+        * properties
     """
     __slots__ = ('_gas_count', '_gas_types', '_gas_fractions')
 
@@ -505,6 +520,7 @@ class EnergyWindowMaterialGasMixture(_EnergyWindowMaterialGasBase):
             'between 2 anf 4. Got {}.'.format(self._gas_count)
         self.gas_types = gas_types
         self.gas_fractions = gas_fractions
+        self._properties = EnergyWindowMaterialGasMixtureProperties(self)
 
     @property
     def gas_types(self):
@@ -600,6 +616,8 @@ class EnergyWindowMaterialGasMixture(_EnergyWindowMaterialGasBase):
             new_obj.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_obj.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_obj._properties._load_extension_attr_from_dict(data['properties'])
         return new_obj
 
     def to_idf(self):
@@ -626,6 +644,9 @@ class EnergyWindowMaterialGasMixture(_EnergyWindowMaterialGasBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def _weighted_avg_coeff_property(self, dictionary, t_kelvin):
@@ -658,6 +679,7 @@ class EnergyWindowMaterialGasMixture(_EnergyWindowMaterialGasBase):
             self.identifier, self.thickness, self.gas_types, self.gas_fractions)
         new_obj._display_name = self._display_name
         new_obj._user_data = None if self._user_data is None else self._user_data.copy()
+        new_obj._properties._duplicate_extension_attr(self._properties)
         return new_obj
 
 
@@ -722,6 +744,8 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
         * specific_heat
         * density
         * prandtl
+        * user_data
+        * properties
 
     Usage:
 
@@ -756,6 +780,7 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
         self.specific_heat_ratio = specific_heat_ratio
         self.molecular_weight = molecular_weight
         self._user_data = None
+        self._properties = EnergyWindowMaterialGasCustomMixtureProperties(self)
 
     @property
     def conductivity_coeff_a(self):
@@ -942,6 +967,8 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
             new_obj.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_obj.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_obj._properties._load_extension_attr_from_dict(data['properties'])
         return new_obj
 
     def to_idf(self):
@@ -981,6 +1008,9 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def __key(self):
@@ -1015,4 +1045,5 @@ class EnergyWindowMaterialGasCustom(_EnergyWindowMaterialGasBase):
             self.specific_heat_ratio, self.molecular_weight)
         new_obj._display_name = self._display_name
         new_obj._user_data = None if self._user_data is None else self._user_data.copy()
+        new_obj._properties._duplicate_extension_attr(self._properties)
         return new_obj

--- a/honeybee_energy/material/glazing.py
+++ b/honeybee_energy/material/glazing.py
@@ -11,6 +11,10 @@ from __future__ import division
 import math
 
 from ._base import _EnergyMaterialWindowBase
+from ..properties.extension import (
+    EnergyWindowMaterialGlazingsProperties,
+    EnergyWindowMaterialSimpleGlazSysProperties,
+)
 from ..reader import parse_idf_string
 from ..writer import generate_idf_string
 
@@ -87,6 +91,7 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
         * solar_transmissivity
         * visible_transmissivity
         * user_data
+        * properties
     """
     __slots__ = ('_thickness', '_solar_transmittance', '_solar_reflectance',
                  '_solar_reflectance_back', '_visible_transmittance',
@@ -120,6 +125,7 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
         self.conductivity = conductivity
         self.dirt_correction = 1.0
         self.solar_diffusing = False
+        self._properties = EnergyWindowMaterialGlazingsProperties(self)
 
     @property
     def thickness(self):
@@ -428,6 +434,8 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
             new_mat.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_mat.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_mat._properties._load_extension_attr_from_dict(data['properties'])
         return new_mat
 
     def to_idf(self):
@@ -472,6 +480,9 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     @staticmethod
@@ -518,6 +529,7 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
         new_material._display_name = self._display_name
         new_material._user_data = None if self._user_data is None \
             else self._user_data.copy()
+        new_material._properties._duplicate_extension_attr(self._properties)
         return new_material
 
 
@@ -557,6 +569,7 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
         * visible_absorptance
         * thickness
         * user_data
+        * properties
     """
     __slots__ = ('_u_factor', '_shgc', '_vt')
 
@@ -566,6 +579,7 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
         self.u_factor = u_factor
         self.shgc = shgc
         self.vt = vt
+        self._properties = EnergyWindowMaterialSimpleGlazSysProperties(self)
 
     @property
     def u_factor(self):
@@ -755,6 +769,8 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
             new_obj.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_obj.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_obj._properties._load_extension_attr_from_dict(data['properties'])
         return new_obj
 
     def to_idf(self):
@@ -777,6 +793,9 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def __key(self):
@@ -802,4 +821,5 @@ class EnergyWindowMaterialSimpleGlazSys(_EnergyWindowMaterialGlazingBase):
         new_material._display_name = self._display_name
         new_material._user_data = None if self._user_data is None \
             else self._user_data.copy()
+        new_material._properties._duplicate_extension_attr(self._properties)
         return new_material

--- a/honeybee_energy/material/shade.py
+++ b/honeybee_energy/material/shade.py
@@ -15,6 +15,7 @@ from __future__ import division
 
 from ._base import _EnergyMaterialWindowBase
 from .gas import EnergyWindowMaterialGas
+from ..properties.extension import EnergyWindowMaterialShadeProperties, EnergyWindowMaterialBlindProperties
 from ..reader import parse_idf_string
 from ..writer import generate_idf_string
 
@@ -290,6 +291,7 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
         * u_value
         * r_value
         * user_data
+        * properties
     """
     __slots__ = ('_thickness', '_solar_transmittance', '_solar_reflectance',
                  '_visible_transmittance', '_visible_reflectance',
@@ -318,6 +320,7 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
         self.infrared_transmittance = infrared_transmittance
         self.conductivity = conductivity
         self.airflow_permeability = airflow_permeability
+        self._properties = EnergyWindowMaterialShadeProperties(self)
 
     @property
     def thickness(self):
@@ -510,6 +513,8 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
             new_mat.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_mat.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_mat._properties._load_extension_attr_from_dict(data['properties'])
         return new_mat
 
     def to_idf(self):
@@ -552,6 +557,9 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def __key(self):
@@ -591,6 +599,7 @@ class EnergyWindowMaterialShade(_EnergyWindowMaterialShadeBase):
         new_material._display_name = self._display_name
         new_material._user_data = None if self._user_data is None \
             else self._user_data.copy()
+        new_material._properties._duplicate_extension_attr(self._properties)
         return new_material
 
 
@@ -671,6 +680,7 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
         * u_value
         * r_value
         * user_data
+        * properties
     """
     ORIENTATIONS = ('Horizontal', 'Vertical')
     __slots__ = ('_slat_orientation', '_slat_width', '_slat_separation',
@@ -716,6 +726,7 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
         self.set_all_visible_reflectance(visible_reflectance)
         self.infrared_transmittance = infrared_transmittance
         self.emissivity_back = None
+        self._properties = EnergyWindowMaterialBlindProperties(self)
 
     @property
     def slat_orientation(self):
@@ -1165,6 +1176,8 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
             new_mat.display_name = data['display_name']
         if 'user_data' in data and data['user_data'] is not None:
             new_mat.user_data = data['user_data']
+        if 'properties' in data and data['properties'] is not None:
+            new_mat._properties._load_extension_attr_from_dict(data['properties'])
         return new_mat
 
     def to_idf(self):
@@ -1233,6 +1246,9 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
             base['display_name'] = self.display_name
         if self._user_data is not None:
             base['user_data'] = self.user_data
+        prop_dict = self._properties.to_dict()
+        if prop_dict is not None:
+            base['properties'] = prop_dict
         return base
 
     def __key(self):
@@ -1286,4 +1302,5 @@ class EnergyWindowMaterialBlind(_EnergyWindowMaterialShadeBase):
         new_m._right_opening_multiplier = self._right_opening_multiplier
         new_m._display_name = self._display_name
         new_m._user_data = None if self._user_data is None else self._user_data.copy()
+        new_m._properties._duplicate_extension_attr(self._properties)
         return new_m

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -198,3 +198,35 @@ class EnergyMaterialNoMassProperties(_EnergyProperties):
 
 class EnergyMaterialVegetationProperties(_EnergyProperties):
     """EnergyMaterialVegetation properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialGlazingsProperties(_EnergyProperties):
+    """EnergyWindowMaterialGlazing properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialSimpleGlazSysProperties(_EnergyProperties):
+    """EnergyWindowMaterialSimpleGlazSys properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialGasProperties(_EnergyProperties):
+    """EnergyWindowMaterialGas properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialGasMixtureProperties(_EnergyProperties):
+    """EnergyWindowMaterialGasMixture properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialGasCustomMixtureProperties(_EnergyProperties):
+    """EnergyWindowMaterialGasCustom properties to be extended by extensions."""
+
+
+class EnergyWindowFrameMixtureProperties(_EnergyProperties):
+    """EnergyWindowFrameMixture properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialShadeProperties(_EnergyProperties):
+    """EnergyWindowMaterialShade properties to be extended by extensions."""
+
+
+class EnergyWindowMaterialBlindProperties(_EnergyProperties):
+    """EnergyWindowMaterialBlind properties to be extended by extensions."""

--- a/honeybee_energy/properties/extension.py
+++ b/honeybee_energy/properties/extension.py
@@ -216,12 +216,12 @@ class EnergyWindowMaterialGasMixtureProperties(_EnergyProperties):
     """EnergyWindowMaterialGasMixture properties to be extended by extensions."""
 
 
-class EnergyWindowMaterialGasCustomMixtureProperties(_EnergyProperties):
+class EnergyWindowMaterialGasCustomProperties(_EnergyProperties):
     """EnergyWindowMaterialGasCustom properties to be extended by extensions."""
 
 
-class EnergyWindowFrameMixtureProperties(_EnergyProperties):
-    """EnergyWindowFrameMixture properties to be extended by extensions."""
+class EnergyWindowFrameProperties(_EnergyProperties):
+    """EnergyWindowFrame properties to be extended by extensions."""
 
 
 class EnergyWindowMaterialShadeProperties(_EnergyProperties):


### PR DESCRIPTION
As discussed in [Issue #1038](https://github.com/ladybug-tools/honeybee-energy/issues/1038), this PR updates some Honeybee-Energy materials with a `.properties` to allow for extension. The affected classes have had their `to_dict`, `from_dict`, and `__copy__` methods modified as well to support these properties extensions, following the pattern from [PR#861](https://github.com/ladybug-tools/honeybee-energy/pull/861)

Honeybee-Energy Materials updated include:
- [EnergyWindowMaterialGlazing](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/glazing.py#L34)
- [EnergyWindowMaterialSimpleGlazSys](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/glazing.py#L525C7-L525C40)
- [EnergyWindowMaterialGas](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/gas.py#L312)
- [EnergyWindowMaterialGasMixture](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/gas.py#L464)
- [EnergyWindowMaterialGasCustom](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/gas.py#L665C7-L665C36)
- [EnergyWindowFrame](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/frame.py#L17C7-L17C24)
- [EnergyWindowMaterialShade](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/shade.py#L233)
- [EnergyWindowMaterialBlind](https://github.com/ladybug-tools/honeybee-energy/blob/8a896d6b4d687118782f3be4a06132a0251c82b0/honeybee_energy/material/shade.py#L598C7-L598C32)

- - - 
- All tests pass