### PR TITLE
fix(material): Remove the check for low thermal resistance

### DIFF
--- a/honeybee_energy/material/_base.py
+++ b/honeybee_energy/material/_base.py
@@ -87,7 +87,11 @@ class _EnergyMaterialBase(object):
         return self.__copy__()
 
     def _compare_thickness_conductivity(self):
-        """Compare the thickness and conductivity to avoid CTF errors from EnergyPlus."""
+        """Compare the thickness and conductivity to avoid CTF errors from EnergyPlus.
+
+        These CTF errors were common in EnergyPlus 9.5 and below but they have
+        been completely eliminated in more recent versions.
+        """
         try:
             assert self._conductivity / self._thickness <= 200000, \
                 'Material layer "{}" does not have sufficient thermal resistance.\n'\

--- a/honeybee_energy/material/glazing.py
+++ b/honeybee_energy/material/glazing.py
@@ -135,7 +135,7 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
     @thickness.setter
     def thickness(self, thick):
         self._thickness = float_positive(thick, 'glazing material thickness')
-        self._compare_thickness_conductivity()
+        assert self._thickness != 0, 'Material thickness must be greater than zero.'
 
     @property
     def solar_transmittance(self):
@@ -267,7 +267,6 @@ class EnergyWindowMaterialGlazing(_EnergyWindowMaterialGlazingBase):
     @conductivity.setter
     def conductivity(self, cond):
         self._conductivity = float_positive(cond, 'glazing material conductivity')
-        self._compare_thickness_conductivity()
 
     @property
     def dirt_correction(self):

--- a/honeybee_energy/material/opaque.py
+++ b/honeybee_energy/material/opaque.py
@@ -106,7 +106,7 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
     @thickness.setter
     def thickness(self, thick):
         self._thickness = float_positive(thick, 'material thickness')
-        self._compare_thickness_conductivity()
+        assert self._thickness != 0, 'Material thickness must be greater than zero.'
 
     @property
     def conductivity(self):
@@ -116,7 +116,6 @@ class EnergyMaterial(_EnergyMaterialOpaqueBase):
     @conductivity.setter
     def conductivity(self, cond):
         self._conductivity = float_positive(cond, 'material conductivity')
-        self._compare_thickness_conductivity()
 
     @property
     def density(self):
@@ -821,7 +820,7 @@ class EnergyMaterialVegetation(_EnergyMaterialOpaqueBase):
     @thickness.setter
     def thickness(self, thick):
         self._thickness = float_positive(thick, 'material thickness')
-        self._compare_thickness_conductivity()
+        assert self._thickness != 0, 'Material thickness must be greater than zero.'
 
     @property
     def conductivity(self):
@@ -831,7 +830,6 @@ class EnergyMaterialVegetation(_EnergyMaterialOpaqueBase):
     @conductivity.setter
     def conductivity(self, cond):
         self._conductivity = float_positive(cond, 'material conductivity')
-        self._compare_thickness_conductivity()
 
     @property
     def density(self):

--- a/tests/material_opaque_test.py
+++ b/tests/material_opaque_test.py
@@ -36,10 +36,8 @@ def test_material_init(userdatadict):
     assert concrete.conductivity == pytest.approx(0.4, rel=1e-2)
     assert concrete.user_data == userdatadict
 
-    with pytest.raises(ValueError):
-        concrete.thickness = 0
     with pytest.raises(AssertionError):
-        concrete.thickness = 0.000000001
+        concrete.thickness = 0
 
 
 def test_material_equivalency(userdatadict):


### PR DESCRIPTION
It seems that this limitation was removed in EnergyPlus 9.5 with this PR:

https://github.com/NREL/EnergyPlus/pull/7847